### PR TITLE
Handle missing customtkinter at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ This requires Docker to be installed on your system. Like
 ``xvfb`` if no display is detected so the GUI works even in headless
 Docker environments.  You may also use ``./scripts/run_vm_debug.sh`` or
 ``python scripts/run_vm_debug.py`` which choose Docker or Vagrant
-depending on what is installed, launching the app under debugpy in
-whichever environment is available.
+depending on what is installed. If neither is present, it falls back to
+``run_debug.sh`` so you can still debug locally.
 
 ### Debugging in a Vagrant VM
 
@@ -112,7 +112,9 @@ to `localhost:5678`:
 
 As a shortcut you can use ``./scripts/run_vm_debug.sh`` or
 ``python scripts/run_vm_debug.py`` which will start ``run_vagrant.sh`` or
-``run_devcontainer.sh`` depending on what tools are available.
+``run_devcontainer.sh`` depending on what tools are available. When
+neither is found the script falls back to running ``run_debug.sh`` in the
+current environment.
 
 The first run may take a while while Vagrant downloads the base box and
 installs packages. Once finished, Visual Studio Code can attach to the

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,5 +1,6 @@
 """Public package interface for CoolBox."""
 
 from .app import CoolBoxApp
+from .ensure_deps import ensure_customtkinter
 
-__all__ = ["CoolBoxApp"]
+__all__ = ["CoolBoxApp", "ensure_customtkinter"]

--- a/src/app.py
+++ b/src/app.py
@@ -2,7 +2,12 @@
 CoolBox Application Class
 Manages the main application window and navigation
 """
-import customtkinter as ctk
+try:
+    import customtkinter as ctk
+except ImportError:  # pragma: no cover - runtime dependency check
+    from .ensure_deps import ensure_customtkinter
+
+    ctk = ensure_customtkinter()
 from typing import Dict, Optional
 import sys
 

--- a/src/ensure_deps.py
+++ b/src/ensure_deps.py
@@ -1,0 +1,43 @@
+"""Utilities to ensure required packages are available at runtime."""
+
+from __future__ import annotations
+
+import importlib
+import subprocess
+import sys
+from types import ModuleType
+from typing import Optional
+
+from .utils.helpers import log
+
+
+_DEF_VERSION = "5.2.2"
+
+
+def require_package(name: str, version: Optional[str] = None) -> ModuleType:
+    """Import and return *name*, installing it first if missing."""
+
+    try:
+        return importlib.import_module(name)
+    except ImportError:
+        pkg = f"{name}=={version}" if version else name
+        log(f"Package '{name}' missing, attempting install of {pkg}...")
+        try:
+            subprocess.check_call([
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                pkg,
+            ])
+        except Exception as exc:  # pragma: no cover - install step may fail
+            raise ImportError(
+                f"{name} is required. Install dependencies with 'python setup.py' or 'pip install -r requirements.txt'."
+            ) from exc
+        return importlib.import_module(name)
+
+
+def ensure_customtkinter(version: str = _DEF_VERSION) -> ModuleType:
+    """Return the ``customtkinter`` module, installing it if needed."""
+
+    return require_package("customtkinter", version)

--- a/src/utils/vm.py
+++ b/src/utils/vm.py
@@ -4,11 +4,13 @@ from pathlib import Path
 
 
 def launch_vm_debug() -> None:
-    """Launch CoolBox inside Docker or Vagrant for debugging."""
-    root = Path(__file__).resolve().parents[1]
+    """Launch CoolBox in a VM or fall back to local debugging."""
+
+    root = Path(__file__).resolve().parents[2]
     if shutil.which("vagrant"):
         subprocess.check_call([str(root / "scripts" / "run_vagrant.sh")])
     elif shutil.which("docker"):
         subprocess.check_call([str(root / "scripts" / "run_devcontainer.sh")])
     else:
-        raise RuntimeError("Neither vagrant nor docker is available")
+        # Neither docker nor vagrant available; run locally under debugpy
+        subprocess.check_call([str(root / "scripts" / "run_debug.sh")])

--- a/tests/test_ensure_deps.py
+++ b/tests/test_ensure_deps.py
@@ -1,0 +1,37 @@
+import importlib
+from types import ModuleType
+
+from src.ensure_deps import require_package, ensure_customtkinter
+
+
+def test_require_package_installs(monkeypatch):
+    calls = []
+
+    def fake_import(name):
+        if name == "missing" and not calls:
+            raise ImportError
+        return ModuleType("missing")
+
+    def fake_check_call(args):
+        calls.append(args)
+
+    monkeypatch.setattr(importlib, "import_module", fake_import)
+    monkeypatch.setattr("subprocess.check_call", fake_check_call)
+
+    mod = require_package("missing")
+    assert isinstance(mod, ModuleType)
+    assert calls
+
+
+def test_ensure_customtkinter_calls_require(monkeypatch):
+    called = {}
+
+    def fake_require(name, version=None):
+        called["name"] = name
+        called["version"] = version
+        return ModuleType(name)
+
+    monkeypatch.setattr("src.ensure_deps.require_package", fake_require)
+    mod = ensure_customtkinter("5.0")
+    assert mod.__name__ == "customtkinter"
+    assert called == {"name": "customtkinter", "version": "5.0"}

--- a/tests/test_vm.py
+++ b/tests/test_vm.py
@@ -2,8 +2,6 @@ import subprocess
 import shutil
 from pathlib import Path
 
-import pytest
-
 from src.utils.vm import launch_vm_debug
 
 
@@ -28,6 +26,8 @@ def test_launch_vm_debug_docker(monkeypatch):
 
 
 def test_launch_vm_debug_missing(monkeypatch):
+    called = []
     monkeypatch.setattr(shutil, "which", lambda x: None)
-    with pytest.raises(RuntimeError):
-        launch_vm_debug()
+    monkeypatch.setattr(subprocess, "check_call", lambda args: called.append(args))
+    launch_vm_debug()
+    assert Path(called[0][0]).name == "run_debug.sh"


### PR DESCRIPTION
## Summary
- add helper to ensure customtkinter is available and install it if missing
- use the helper in `CoolBoxApp` to avoid startup errors when customtkinter is absent
- add a general `require_package` helper and export dependency helpers
- cover dependency helpers with unit tests
- fall back to running `run_debug.sh` when no VM provider is found
- document the new fallback behavior

## Testing
- `flake8 src setup.py tests`
- `pytest -q`
- `python scripts/run_vm_debug.py` *(runs and waits for debugger using local fallback)*

------
https://chatgpt.com/codex/tasks/task_e_685ad8fb2600832b85e89548fb0cf452