### PR TITLE
Enhance sidebar UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ A modern, feature-rich desktop application built with Python and CustomTkinter.
 - **Rich Toolset**: File tools, system utilities, text processing, and more
 - **Customizable**: Extensive settings and preferences
 - **Configurable UI**: Show or hide the toolbar and status bar on demand
+- **Collapsible Sidebar**: Quickly hide the sidebar using the toolbar button,
+  arrow icon or `Ctrl+B`. CoolBox remembers your preference across sessions.
 - **Cross-Platform**: Works on Windows, macOS, and Linux
 - **Expanded Utilities**: File and directory copy/move helpers, an enhanced file manager, a threaded port scanner, a flexible hash calculator with optional disk caching, a multi-threaded duplicate finder that persists file hashes for lightning fast rescans, a screenshot capture tool, and a built-in process manager that auto-refreshes and sorts by CPU usage. The system info viewer now reports CPU cores and memory usage.
 - **Network Scanner CLI**: Scan multiple hosts asynchronously with IPv4/IPv6
@@ -31,6 +33,10 @@ cd CoolBox
 2. Install dependencies:
 ```bash
 python setup.py
+```
+Alternatively you can run:
+```bash
+pip install -r requirements.txt
 ```
 
 For a development environment with additional tools, use:

--- a/src/app.py
+++ b/src/app.py
@@ -86,6 +86,7 @@ class CoolBoxApp:
         # Create sidebar
         self.sidebar = Sidebar(self.content_area, self)
         self.sidebar.grid(row=0, column=0, sticky="nsew", padx=0, pady=0)
+        self.sidebar.set_collapsed(self.config.get("sidebar_collapsed", False))
 
         # Create view container
         self.view_container = ctk.CTkFrame(self.content_area, corner_radius=0)
@@ -135,6 +136,7 @@ class CoolBoxApp:
         self.window.bind("<Control-t>", lambda e: self.switch_view("tools"))
         self.window.bind("<Control-s>", lambda e: self.switch_view("settings"))
         self.window.bind("<F11>", lambda e: self.toggle_fullscreen())
+        self.window.bind("<Control-b>", lambda e: self.toggle_sidebar())
 
     def switch_view(self, view_name: str):
         """Switch to a different view"""
@@ -169,6 +171,14 @@ class CoolBoxApp:
         """Toggle fullscreen mode"""
         current_state = self.window.attributes("-fullscreen")
         self.window.attributes("-fullscreen", not current_state)
+
+    def toggle_sidebar(self) -> None:
+        """Collapse or expand the sidebar."""
+        self.sidebar.toggle()
+        self.config.set("sidebar_collapsed", self.sidebar.collapsed)
+        if self.status_bar is not None:
+            state = "collapsed" if self.sidebar.collapsed else "expanded"
+            self.status_bar.set_message(f"Sidebar {state}", "info")
 
     def _on_closing(self):
         """Handle window closing event"""

--- a/src/components/sidebar.py
+++ b/src/components/sidebar.py
@@ -1,8 +1,12 @@
-"""
-Sidebar component for navigation
-"""
+"""Sidebar component for navigation."""
+
+from __future__ import annotations
+
 import customtkinter as ctk
 from typing import Dict
+
+COLLAPSED_WIDTH = 60
+EXPANDED_WIDTH = 200
 
 
 class Sidebar(ctk.CTkFrame):
@@ -10,9 +14,12 @@ class Sidebar(ctk.CTkFrame):
 
     def __init__(self, parent, app):
         """Initialize sidebar"""
-        super().__init__(parent, corner_radius=0, width=200)
+        super().__init__(parent, corner_radius=0, width=EXPANDED_WIDTH)
         self.app = app
         self.buttons: Dict[str, ctk.CTkButton] = {}
+        self.icons: Dict[str, str] = {}
+        self.labels: Dict[str, str] = {}
+        self.collapsed: bool = False
 
         # Configure grid
         self.grid_rowconfigure(4, weight=1)  # Make row 4 expandable
@@ -44,10 +51,43 @@ class Sidebar(ctk.CTkFrame):
             command=self._toggle_theme,
             height=32,
         )
-        self.theme_toggle.grid(row=6, column=0, padx=20, pady=(10, 20), sticky="ew")
+        self.theme_toggle.grid(row=6, column=0, padx=20, pady=(10, 5), sticky="ew")
+
+        # Collapse/expand button
+        self.collapse_btn = ctk.CTkButton(
+            self,
+            text="◀",
+            command=self.toggle,
+            width=32,
+            height=32,
+        )
+        self.collapse_btn.grid(row=7, column=0, pady=(0, 20))
+
+    def set_collapsed(self, collapsed: bool) -> None:
+        """Collapse or expand the sidebar."""
+        self.collapsed = collapsed
+        width = COLLAPSED_WIDTH if collapsed else EXPANDED_WIDTH
+        self.configure(width=width)
+        self.title.configure(text="🧊" if collapsed else "CoolBox")
+        for name, button in self.buttons.items():
+            icon = self.icons[name]
+            label = self.labels[name]
+            button.configure(text=icon if collapsed else f"{icon} {label}")
+        current = ctk.get_appearance_mode()
+        if current == "Dark":
+            dark_text = "🌙" if collapsed else "🌙 Dark Mode"
+        else:
+            dark_text = "☀️" if collapsed else "☀️ Light Mode"
+        self.theme_toggle.configure(text=dark_text)
+        self.collapse_btn.configure(text="▶" if collapsed else "◀")
+
+    def toggle(self) -> None:
+        """Toggle collapsed state."""
+        self.set_collapsed(not self.collapsed)
 
     def _create_nav_button(self, name: str, text: str, row: int):
         """Create a navigation button"""
+        icon, label = text.split(" ", 1)
         button = ctk.CTkButton(
             self,
             text=text,
@@ -58,6 +98,8 @@ class Sidebar(ctk.CTkFrame):
         )
         button.grid(row=row, column=0, padx=20, pady=5, sticky="ew")
         self.buttons[name] = button
+        self.icons[name] = icon
+        self.labels[name] = label
 
     def set_active(self, view_name: str):
         """Set the active button"""
@@ -83,3 +125,6 @@ class Sidebar(ctk.CTkFrame):
 
         # Save preference
         self.app.config.set("appearance_mode", new_mode)
+        # Refresh collapsed state label
+        if self.collapsed:
+            self.set_collapsed(True)

--- a/src/components/toolbar.py
+++ b/src/components/toolbar.py
@@ -36,6 +36,7 @@ class Toolbar(ctk.CTkFrame):
         self._create_button(left_frame, "📋", "Copy", self._copy).pack(side="left", padx=5)
         self._create_button(left_frame, "✂️", "Cut", self._cut).pack(side="left", padx=5)
         self._create_button(left_frame, "📌", "Paste", self._paste).pack(side="left", padx=5)
+        self._create_button(left_frame, "☰", "Toggle Sidebar", self.app.toggle_sidebar).pack(side="left", padx=5)
 
         # Separator
         separator = ctk.CTkFrame(self, width=2, fg_color="gray50")

--- a/src/config.py
+++ b/src/config.py
@@ -32,6 +32,7 @@ class Config:
             "font_size": 14,
             "show_toolbar": True,
             "show_statusbar": True,
+            "sidebar_collapsed": False,
             "theme": {
                 "primary_color": "#1f538d",
                 "secondary_color": "#212121",

--- a/src/views/settings_view.py
+++ b/src/views/settings_view.py
@@ -189,6 +189,17 @@ class SettingsView(ctk.CTkFrame):
         )
         statusbar_check.pack(anchor="w", padx=20, pady=5)
 
+        # Collapse sidebar
+        self.collapse_sidebar_var = ctk.BooleanVar(
+            value=self.app.config.get("sidebar_collapsed", False)
+        )
+        sidebar_check = ctk.CTkCheckBox(
+            section,
+            text="Collapse sidebar",
+            variable=self.collapse_sidebar_var,
+        )
+        sidebar_check.pack(anchor="w", padx=20, pady=5)
+
         # Recent files limit
         recent_frame = ctk.CTkFrame(section)
         recent_frame.pack(fill="x", padx=20, pady=10)
@@ -391,6 +402,7 @@ class SettingsView(ctk.CTkFrame):
         self.app.config.set("auto_save", self.auto_save_var.get())
         self.app.config.set("show_toolbar", self.show_toolbar_var.get())
         self.app.config.set("show_statusbar", self.show_statusbar_var.get())
+        self.app.config.set("sidebar_collapsed", self.collapse_sidebar_var.get())
         self.app.config.set("max_recent_files", self.recent_limit_var.get())
         self.app.config.set("scan_cache_ttl", int(self.scan_ttl_var.get()))
         self.app.config.set("scan_concurrency", int(self.scan_concurrency_var.get()))
@@ -400,6 +412,7 @@ class SettingsView(ctk.CTkFrame):
         theme = self.app.theme.get_theme()
         theme["accent_color"] = self.accent_color_var.get()
         self.app.theme.apply_theme(theme)
+        self.app.sidebar.set_collapsed(self.collapse_sidebar_var.get())
 
         # Save to file
         self.app.config.save()
@@ -429,6 +442,8 @@ class SettingsView(ctk.CTkFrame):
                 self.app.status_bar.set_message("Settings reset to defaults!", "success")
             self.app.switch_view("settings")
             self.app.update_ui_visibility()
+            self.collapse_sidebar_var.set(self.app.config.get("sidebar_collapsed", False))
+            self.app.sidebar.set_collapsed(self.collapse_sidebar_var.get())
             self.scan_ttl_var.set(self.app.config.get("scan_cache_ttl", 300))
             self.scan_concurrency_var.set(self.app.config.get("scan_concurrency", 100))
             self.scan_timeout_var.set(self.app.config.get("scan_timeout", 0.5))

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -13,6 +13,17 @@ class TestCoolBoxApp(unittest.TestCase):
         self.assertEqual(app.state.current_view, "home")
         app.destroy()
 
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_toggle_sidebar_updates_config(self) -> None:
+        app = CoolBoxApp()
+        initial = app.sidebar.collapsed
+        app.toggle_sidebar()
+        self.assertNotEqual(app.sidebar.collapsed, initial)
+        self.assertEqual(app.config.get("sidebar_collapsed"), app.sidebar.collapsed)
+        expected = "▶" if app.sidebar.collapsed else "◀"
+        self.assertEqual(app.sidebar.collapse_btn.cget("text"), expected)
+        app.destroy()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -47,3 +47,10 @@ def test_add_recent_file_persists(monkeypatch, tmp_path):
     cfg = Config()
     cfg.add_recent_file("x.txt")
     assert "x.txt" in json.loads(cfg.config_file.read_text())["recent_files"]
+
+
+def test_sidebar_collapsed_default(monkeypatch):
+    tmp = Path(tempfile.mkdtemp())
+    monkeypatch.setattr(Path, "home", lambda: tmp)
+    cfg = Config()
+    assert cfg.get("sidebar_collapsed") is False


### PR DESCRIPTION
## Summary
- add collapse button to sidebar and update toggle logic
- bind `Ctrl+B` to toggle the sidebar
- document new toggle methods in README
- expand sidebar tests for button text

## Testing
- `pip install -r requirements.txt`
- `flake8 src setup.py tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b1277e1d0832b82adbb3174c082f4