### PR TITLE
Improve sidebar collapse UI

### DIFF
--- a/src/components/__init__.py
+++ b/src/components/__init__.py
@@ -4,5 +4,6 @@ from .sidebar import Sidebar
 from .toolbar import Toolbar
 from .status_bar import StatusBar
 from .widgets import info_label
+from .tooltip import Tooltip
 
-__all__ = ["Sidebar", "Toolbar", "StatusBar", "info_label"]
+__all__ = ["Sidebar", "Toolbar", "StatusBar", "info_label", "Tooltip"]

--- a/src/components/sidebar.py
+++ b/src/components/sidebar.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 import customtkinter as ctk
 from typing import Dict
 
+from .tooltip import Tooltip
+
 COLLAPSED_WIDTH = 60
 EXPANDED_WIDTH = 200
+AUTO_COLLAPSE_WIDTH = 700
 
 
 class Sidebar(ctk.CTkFrame):
@@ -19,7 +22,13 @@ class Sidebar(ctk.CTkFrame):
         self.buttons: Dict[str, ctk.CTkButton] = {}
         self.icons: Dict[str, str] = {}
         self.labels: Dict[str, str] = {}
+        self._tooltips: Dict[str, Tooltip] = {}
         self.collapsed: bool = False
+        self._auto_collapsed = False
+        self._animating = False
+        # Prevent grid geometry from overriding the specified width so
+        # collapsing the sidebar actually changes its visible size.
+        self.grid_propagate(False)
 
         # Configure grid
         self.grid_rowconfigure(4, weight=1)  # Make row 4 expandable
@@ -65,9 +74,11 @@ class Sidebar(ctk.CTkFrame):
 
     def set_collapsed(self, collapsed: bool) -> None:
         """Collapse or expand the sidebar."""
+        if collapsed == self.collapsed and not self._animating:
+            return
         self.collapsed = collapsed
         width = COLLAPSED_WIDTH if collapsed else EXPANDED_WIDTH
-        self.configure(width=width)
+        self._animate_width(width)
         self.title.configure(text="🧊" if collapsed else "CoolBox")
         for name, button in self.buttons.items():
             icon = self.icons[name]
@@ -80,10 +91,50 @@ class Sidebar(ctk.CTkFrame):
             dark_text = "☀️" if collapsed else "☀️ Light Mode"
         self.theme_toggle.configure(text=dark_text)
         self.collapse_btn.configure(text="▶" if collapsed else "◀")
+        if not collapsed:
+            for tooltip in self._tooltips.values():
+                tooltip.hide()
 
     def toggle(self) -> None:
         """Toggle collapsed state."""
+        self._auto_collapsed = False
         self.set_collapsed(not self.collapsed)
+
+    def _on_hover(self, tooltip: Tooltip, event) -> None:
+        """Show tooltip for a button when sidebar is collapsed."""
+        if not self.collapsed:
+            return
+        x = self.winfo_rootx() + self.winfo_width() + 10
+        y = event.widget.winfo_rooty() + event.widget.winfo_height() // 2
+        tooltip.show(x, y)
+
+    def _animate_width(self, target: int) -> None:
+        """Animate sidebar width change to *target* pixels."""
+        start = self.winfo_width()
+        steps = 8
+        delta = (target - start) / steps
+
+        def step(i: int = 1) -> None:
+            if i > steps:
+                self.configure(width=target)
+                self._animating = False
+                return
+            self.configure(width=int(start + delta * i))
+            self.after(15, lambda: step(i + 1))
+
+        self._animating = True
+        step()
+
+    def auto_adjust(self, window_width: int) -> None:
+        """Collapse or expand based on *window_width* for responsive layout."""
+        if self._animating:
+            return
+        if window_width <= AUTO_COLLAPSE_WIDTH and not self.collapsed:
+            self._auto_collapsed = True
+            self.set_collapsed(True)
+        elif window_width > AUTO_COLLAPSE_WIDTH and self.collapsed and self._auto_collapsed:
+            self._auto_collapsed = False
+            self.set_collapsed(False)
 
     def _create_nav_button(self, name: str, text: str, row: int):
         """Create a navigation button"""
@@ -100,6 +151,10 @@ class Sidebar(ctk.CTkFrame):
         self.buttons[name] = button
         self.icons[name] = icon
         self.labels[name] = label
+        tooltip = Tooltip(self, label)
+        self._tooltips[name] = tooltip
+        button.bind("<Enter>", lambda e, t=tooltip: self._on_hover(t, e))
+        button.bind("<Leave>", lambda e, t=tooltip: t.hide())
 
     def set_active(self, view_name: str):
         """Set the active button"""

--- a/src/components/toolbar.py
+++ b/src/components/toolbar.py
@@ -1,12 +1,14 @@
 """
 Toolbar component with common actions
 """
+
 import customtkinter as ctk
 from tkinter import filedialog
 from pathlib import Path
 
 from ..utils import file_manager, open_path
 import pyperclip
+from .tooltip import Tooltip
 
 
 class Toolbar(ctk.CTkFrame):
@@ -16,6 +18,7 @@ class Toolbar(ctk.CTkFrame):
         """Initialize toolbar"""
         super().__init__(parent, height=50, corner_radius=0)
         self.app = app
+        self._tooltips: list[Tooltip] = []
 
         # Prevent frame from shrinking
         self.pack_propagate(False)
@@ -31,12 +34,22 @@ class Toolbar(ctk.CTkFrame):
         left_frame.pack(side="left", padx=10)
 
         # File operations
-        self._create_button(left_frame, "📁", "Open File", self._open_file).pack(side="left", padx=5)
-        self._create_button(left_frame, "💾", "Save", self._save_file).pack(side="left", padx=5)
-        self._create_button(left_frame, "📋", "Copy", self._copy).pack(side="left", padx=5)
+        self._create_button(left_frame, "📁", "Open File", self._open_file).pack(
+            side="left", padx=5
+        )
+        self._create_button(left_frame, "💾", "Save", self._save_file).pack(
+            side="left", padx=5
+        )
+        self._create_button(left_frame, "📋", "Copy", self._copy).pack(
+            side="left", padx=5
+        )
         self._create_button(left_frame, "✂️", "Cut", self._cut).pack(side="left", padx=5)
-        self._create_button(left_frame, "📌", "Paste", self._paste).pack(side="left", padx=5)
-        self._create_button(left_frame, "☰", "Toggle Sidebar", self.app.toggle_sidebar).pack(side="left", padx=5)
+        self._create_button(left_frame, "📌", "Paste", self._paste).pack(
+            side="left", padx=5
+        )
+        self._create_button(
+            left_frame, "☰", "Toggle Sidebar", self.app.toggle_sidebar
+        ).pack(side="left", padx=5)
 
         # Separator
         separator = ctk.CTkFrame(self, width=2, fg_color="gray50")
@@ -68,7 +81,9 @@ class Toolbar(ctk.CTkFrame):
         self.search_entry.pack(side="right", padx=5)
 
         # Search button
-        self._create_button(right_frame, "🔍", "Search", self._search).pack(side="right", padx=5)
+        self._create_button(right_frame, "🔍", "Search", self._search).pack(
+            side="right", padx=5
+        )
 
     def _create_button(self, parent, icon: str, tooltip: str, command) -> ctk.CTkButton:
         """Create a toolbar button"""
@@ -80,8 +95,17 @@ class Toolbar(ctk.CTkFrame):
             command=command,
             font=ctk.CTkFont(size=16),
         )
-        # Could add tooltip functionality here
+        tip = Tooltip(self, tooltip)
+        btn.bind("<Enter>", lambda e, t=tip: self._on_hover(t, e))
+        btn.bind("<Leave>", lambda e, t=tip: t.hide())
+        self._tooltips.append(tip)
         return btn
+
+    def _on_hover(self, tooltip: Tooltip, event) -> None:
+        """Show tooltip below a toolbar button."""
+        x = event.widget.winfo_rootx() + event.widget.winfo_width() // 2
+        y = event.widget.winfo_rooty() + event.widget.winfo_height() + 10
+        tooltip.show(x, y)
 
     def _open_file(self):
         """Open file dialog"""
@@ -143,7 +167,9 @@ class Toolbar(ctk.CTkFrame):
         if self.app.status_bar is not None:
             self.app.status_bar.set_message(f"Searching for: {query}", "info")
 
-        directory = filedialog.askdirectory(title="Select folder to search", parent=self)
+        directory = filedialog.askdirectory(
+            title="Select folder to search", parent=self
+        )
         if not directory:
             return
 

--- a/src/components/tooltip.py
+++ b/src/components/tooltip.py
@@ -1,0 +1,24 @@
+"""Simple tooltip implementation for CTk widgets."""
+from __future__ import annotations
+
+import customtkinter as ctk
+
+
+class Tooltip(ctk.CTkToplevel):
+    """Popup tooltip window bound to a widget."""
+
+    def __init__(self, parent: ctk.CTkBaseClass, text: str) -> None:
+        super().__init__(parent)
+        self.overrideredirect(True)
+        self.withdraw()
+        self.label = ctk.CTkLabel(self, text=text, font=ctk.CTkFont(size=12))
+        self.label.pack(padx=6, pady=3)
+
+    def show(self, x: int, y: int) -> None:
+        """Display the tooltip at screen coordinates (x, y)."""
+        self.geometry(f"+{x}+{y}")
+        self.deiconify()
+
+    def hide(self) -> None:
+        """Hide the tooltip."""
+        self.withdraw()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -4,6 +4,7 @@ import os
 import unittest
 
 from src.app import CoolBoxApp
+from src.components.sidebar import COLLAPSED_WIDTH, EXPANDED_WIDTH
 
 
 class TestCoolBoxApp(unittest.TestCase):
@@ -18,10 +19,64 @@ class TestCoolBoxApp(unittest.TestCase):
         app = CoolBoxApp()
         initial = app.sidebar.collapsed
         app.toggle_sidebar()
+        # process pending animation events
+        for _ in range(10):
+            app.window.update()
         self.assertNotEqual(app.sidebar.collapsed, initial)
+        # sidebar width should match the expected collapsed/expanded size
+        expected_width = COLLAPSED_WIDTH if app.sidebar.collapsed else EXPANDED_WIDTH
+        self.assertEqual(int(app.sidebar.cget("width")), expected_width)
         self.assertEqual(app.config.get("sidebar_collapsed"), app.sidebar.collapsed)
         expected = "▶" if app.sidebar.collapsed else "◀"
         self.assertEqual(app.sidebar.collapse_btn.cget("text"), expected)
+        app.destroy()
+
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_sidebar_auto_resize(self) -> None:
+        app = CoolBoxApp()
+        app.window.geometry("500x600")
+        app.window.update()
+        self.assertTrue(app.sidebar.collapsed)
+        # config should not persist auto-collapsed state
+        self.assertFalse(app.config.get("sidebar_collapsed"))
+        app.window.geometry("1200x800")
+        app.window.update()
+        self.assertFalse(app.sidebar.collapsed)
+        self.assertFalse(app.config.get("sidebar_collapsed"))
+        app.destroy()
+
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_sidebar_initial_state_large_window(self) -> None:
+        app = CoolBoxApp()
+        app.window.update()
+        self.assertFalse(app.sidebar.collapsed)
+        self.assertEqual(int(app.sidebar.cget("width")), EXPANDED_WIDTH)
+        app.destroy()
+
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_sidebar_tooltips_show_and_hide(self) -> None:
+        app = CoolBoxApp()
+        app.sidebar.set_collapsed(True)
+        tooltip = app.sidebar._tooltips["home"]
+        tooltip.show(100, 100)
+        app.window.update()
+        self.assertTrue(tooltip.winfo_viewable())
+        tooltip.hide()
+        app.window.update()
+        self.assertFalse(tooltip.winfo_viewable())
+        app.destroy()
+
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_toolbar_tooltips_show_and_hide(self) -> None:
+        app = CoolBoxApp()
+        # Use the first created tooltip
+        tooltip = app.toolbar._tooltips[0]
+        tooltip.show(50, 50)
+        app.window.update()
+        self.assertTrue(tooltip.winfo_viewable())
+        tooltip.hide()
+        app.window.update()
+        self.assertFalse(tooltip.winfo_viewable())
         app.destroy()
 
 


### PR DESCRIPTION
## Summary
- refine sidebar to prevent grid resize
- animate sidebar collapse for smoother UX
- update tests to validate sidebar width after toggle
- auto-collapse sidebar when window width is small
- fix initial sidebar state and save responsive collapse state
- add tooltips on collapsed sidebar buttons for easier navigation
- add tooltips to toolbar buttons
- avoid persisting auto-collapsed state on window resize

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q flake8`
- `flake8 src setup.py tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685bd3fa1ee8832bb092baad479f6cc6