### PR TITLE
Fix UI settings and process manager

### DIFF
--- a/src/views/quick_settings.py
+++ b/src/views/quick_settings.py
@@ -23,6 +23,7 @@ class QuickSettingsDialog(ctk.CTkToplevel):
         self.status_var = ctk.BooleanVar(value=app.config.get("show_statusbar", True))
         self.sidebar_var = ctk.BooleanVar(value=not app.config.get("sidebar_collapsed", False))
         self.theme_var = ctk.StringVar(value=app.config.get("appearance_mode", "dark").title())
+        self.color_var = ctk.StringVar(value=app.config.get("color_theme", "blue"))
 
         ctk.CTkCheckBox(self, text="Show Menu Bar", variable=self.menu_var).pack(anchor="w", padx=20, pady=5)
         ctk.CTkCheckBox(self, text="Show Toolbar", variable=self.toolbar_var).pack(anchor="w", padx=20, pady=5)
@@ -34,6 +35,16 @@ class QuickSettingsDialog(ctk.CTkToplevel):
             self,
             values=["Light", "Dark", "System"],
             variable=self.theme_var,
+            command=self._change_theme,
+            width=120,
+        ).pack(anchor="w", padx=20, pady=5)
+
+        ctk.CTkLabel(self, text="Color Theme:").pack(anchor="w", padx=20, pady=(10, 0))
+        ctk.CTkOptionMenu(
+            self,
+            values=["blue", "green", "dark-blue"],
+            variable=self.color_var,
+            command=self._change_color_theme,
             width=120,
         ).pack(anchor="w", padx=20, pady=5)
 
@@ -49,9 +60,20 @@ class QuickSettingsDialog(ctk.CTkToplevel):
         cfg.set("show_statusbar", self.status_var.get())
         cfg.set("sidebar_collapsed", not self.sidebar_var.get())
         cfg.set("appearance_mode", self.theme_var.get().lower())
+        cfg.set("color_theme", self.color_var.get())
         cfg.save()
 
+        ctk.set_appearance_mode(cfg.get("appearance_mode", "dark"))
+        ctk.set_default_color_theme(cfg.get("color_theme", "blue"))
         self.app.theme.apply_theme(cfg.get("theme", {}))
         self.app.sidebar.set_collapsed(cfg.get("sidebar_collapsed", False))
         self.app.update_ui_visibility()
         self.destroy()
+
+    def _change_theme(self, value: str) -> None:
+        """Preview the selected appearance mode immediately."""
+        ctk.set_appearance_mode(value.lower())
+
+    def _change_color_theme(self, value: str) -> None:
+        """Preview the selected color theme immediately."""
+        ctk.set_default_color_theme(value)

--- a/src/views/tools_view.py
+++ b/src/views/tools_view.py
@@ -462,9 +462,21 @@ class ToolsView(ctk.CTkFrame):
                 line = f"{pid:6} {name:<25} {cpu:6.1f} {mem:10.1f}\n"
                 text.insert("end", line)
 
+        refresh_job: str | None = None
+
         def schedule_refresh() -> None:
+            nonlocal refresh_job
+            if not window.winfo_exists():
+                return
             refresh()
-            window.after(5000, schedule_refresh)
+            refresh_job = window.after(5000, schedule_refresh)
+
+        def on_close() -> None:
+            if refresh_job is not None:
+                window.after_cancel(refresh_job)
+            window.destroy()
+
+        window.protocol("WM_DELETE_WINDOW", on_close)
 
         def kill_selected() -> None:
             """Prompt for a PID and attempt to terminate that process."""

--- a/tests/test_quick_settings.py
+++ b/tests/test_quick_settings.py
@@ -1,0 +1,21 @@
+import os
+import unittest
+from src.app import CoolBoxApp
+from src.views.quick_settings import QuickSettingsDialog
+
+
+@unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+class TestQuickSettings(unittest.TestCase):
+    def test_apply_updates_config(self) -> None:
+        app = CoolBoxApp()
+        dialog = QuickSettingsDialog(app)
+        dialog.theme_var.set("Light")
+        dialog.color_var.set("green")
+        dialog._apply()
+        self.assertEqual(app.config.get("appearance_mode"), "light")
+        self.assertEqual(app.config.get("color_theme"), "green")
+        app.destroy()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- apply appearance mode and theme immediately when using Quick Settings
- stop process manager refresh when closed to avoid errors
- add color theme selection to Quick Settings for immediate preview
- add test verifying Quick Settings saves selections

## Testing
- `pytest -q`
- `flake8 src setup.py tests`
- `xvfb-run -a python main.py` *(terminated manually)*
- `python scripts/run_vm_debug.py` *(terminated manually while waiting for debugger)*


------
https://chatgpt.com/codex/tasks/task_e_685c5eea1ddc832ba9a97ac4ed900b84