### PR TITLE
Improve sidebar manual collapse handling

### DIFF
--- a/src/components/sidebar.py
+++ b/src/components/sidebar.py
@@ -25,6 +25,7 @@ class Sidebar(ctk.CTkFrame):
         self._tooltips: Dict[str, Tooltip] = {}
         self.collapsed: bool = False
         self._auto_collapsed = False
+        self._user_override = False
         self._animating = False
         self._anim_job: str | None = None
         # Prevent grid geometry from overriding the specified width so
@@ -99,6 +100,7 @@ class Sidebar(ctk.CTkFrame):
     def toggle(self) -> None:
         """Toggle collapsed state."""
         self._auto_collapsed = False
+        self._user_override = True
         self.set_collapsed(not self.collapsed)
 
     def _on_hover(self, tooltip: Tooltip, event) -> None:
@@ -133,6 +135,11 @@ class Sidebar(ctk.CTkFrame):
     def auto_adjust(self, window_width: int) -> None:
         """Collapse or expand based on *window_width* for responsive layout."""
         if self._animating:
+            return
+        if window_width > AUTO_COLLAPSE_WIDTH:
+            # Reset manual override when window is sufficiently wide
+            self._user_override = False
+        if self._user_override:
             return
         if window_width <= AUTO_COLLAPSE_WIDTH and not self.collapsed:
             self._auto_collapsed = True

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -48,6 +48,27 @@ class TestCoolBoxApp(unittest.TestCase):
         app.destroy()
 
     @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_sidebar_manual_override_persists(self) -> None:
+        app = CoolBoxApp()
+        app.window.update()
+        self.assertFalse(app.sidebar.collapsed)
+
+        app.toggle_sidebar()
+        for _ in range(10):
+            app.window.update()
+        self.assertTrue(app.sidebar.collapsed)
+
+        app.window.geometry("500x600")
+        app.window.update()
+        self.assertTrue(app.sidebar.collapsed)
+
+        app.window.geometry("1200x800")
+        app.window.update()
+        self.assertTrue(app.sidebar.collapsed)
+
+        app.destroy()
+
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
     def test_sidebar_initial_state_large_window(self) -> None:
         app = CoolBoxApp()
         app.window.update()


### PR DESCRIPTION
## Summary
- ensure sidebar keeps manual state
- prevent auto-collapse from immediately overriding user toggle
- add regression test for manual override persistence

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c65d6a4cc832ba3f0c0501113bf8a