### PR TITLE
Remove collapsible sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,8 @@ A modern, feature-rich desktop application built with Python and CustomTkinter.
 - **Modular Architecture**: Clean, maintainable code structure
 - **Rich Toolset**: File tools, system utilities, text processing, and more
 - **Customizable**: Extensive settings and preferences
-- **Configurable UI**: Toggle the menu bar, toolbar and status bar on demand. The
-  menu bar now includes recent files, a Quick Settings dialog and a fullscreen
-  toggle. Quick Settings can also be launched from the toolbar or with the
-  `Ctrl+Q` shortcut.
-- **Collapsible Sidebar**: Quickly hide the sidebar using the toolbar button,
-  arrow icon or `Ctrl+B`. CoolBox remembers your preference across sessions.
+- **Configurable UI**: Toggle the menu bar, toolbar and status bar on demand. The menu bar now includes recent files, a Quick Settings dialog and a fullscreen toggle. Quick Settings can also be launched from the toolbar or with the `Ctrl+Q` shortcut.
+- **Fixed Sidebar**: Persistent navigation panel with quick theme switching.
 - **Cross-Platform**: Works on Windows, macOS, and Linux
 - **Expanded Utilities**: File and directory copy/move helpers, an enhanced file manager, a threaded port scanner, a flexible hash calculator with optional disk caching, a multi-threaded duplicate finder that persists file hashes for lightning fast rescans, a screenshot capture tool, and a built-in process manager that auto-refreshes and sorts by CPU usage. The system info viewer now reports CPU cores and memory usage.
 - **Network Scanner CLI**: Scan multiple hosts asynchronously with IPv4/IPv6

--- a/src/app.py
+++ b/src/app.py
@@ -97,10 +97,6 @@ class CoolBoxApp:
         # Create sidebar
         self.sidebar = Sidebar(self.content_area, self)
         self.sidebar.grid(row=0, column=0, sticky="nsew", padx=0, pady=0)
-        self.sidebar.set_collapsed(self.config.get("sidebar_collapsed", False))
-        # Ensure geometry is realized before responsive check
-        self.window.update_idletasks()
-        self.sidebar.auto_adjust(self.window.winfo_width())
 
         # Create view container
         self.view_container = ctk.CTkFrame(self.content_area, corner_radius=0)
@@ -171,8 +167,6 @@ class CoolBoxApp:
         self.window.bind("<Control-s>", lambda e: self.switch_view("settings"))
         self.window.bind("<Control-q>", lambda e: self.open_quick_settings())
         self.window.bind("<F11>", lambda e: self.toggle_fullscreen())
-        self.window.bind("<Control-b>", lambda e: self.toggle_sidebar())
-        self.window.bind("<Configure>", self._on_resize)
 
     def switch_view(self, view_name: str):
         """Switch to a different view"""
@@ -227,29 +221,6 @@ class CoolBoxApp:
         if self.quick_settings_window is not None and self.quick_settings_window.winfo_exists():
             self.quick_settings_window.destroy()
         self.quick_settings_window = None
-
-    def toggle_sidebar(self) -> None:
-        """Collapse or expand the sidebar."""
-        self.sidebar.toggle()
-        self.config.set("sidebar_collapsed", self.sidebar.collapsed)
-        if self.status_bar is not None:
-            state = "collapsed" if self.sidebar.collapsed else "expanded"
-            self.status_bar.set_message(f"Sidebar {state}", "info")
-        if self.menu_bar is not None:
-            self.menu_bar.refresh_toggles()
-
-    def _on_resize(self, event) -> None:
-        """Handle window resize events for responsive UI."""
-        previous = self.sidebar.collapsed
-        self.sidebar.auto_adjust(event.width)
-        if previous != self.sidebar.collapsed:
-            if not self.sidebar._auto_collapsed:
-                self.config.set("sidebar_collapsed", self.sidebar.collapsed)
-            if self.status_bar is not None:
-                state = "collapsed" if self.sidebar.collapsed else "expanded"
-                self.status_bar.set_message(f"Sidebar {state}", "info")
-            if self.menu_bar is not None:
-                self.menu_bar.refresh_toggles()
 
     def _on_closing(self):
         """Handle window closing event"""

--- a/src/components/menubar.py
+++ b/src/components/menubar.py
@@ -40,9 +40,6 @@ class MenuBar:
         self.status_var = tk.BooleanVar(
             value=self.app.config.get("show_statusbar", True)
         )
-        self.sidebar_var = tk.BooleanVar(
-            value=not self.app.config.get("sidebar_collapsed", False)
-        )
         self.fullscreen_var = tk.BooleanVar(
             value=self.app.window.attributes("-fullscreen")
         )
@@ -52,9 +49,6 @@ class MenuBar:
         )
         view_menu.add_checkbutton(
             label="Status Bar", variable=self.status_var, command=self._toggle_statusbar
-        )
-        view_menu.add_checkbutton(
-            label="Sidebar", variable=self.sidebar_var, command=self._toggle_sidebar
         )
         view_menu.add_checkbutton(
             label="Full Screen", variable=self.fullscreen_var, command=self._toggle_fullscreen
@@ -75,7 +69,6 @@ class MenuBar:
         """Sync toggle states with current config."""
         self.toolbar_var.set(self.app.config.get("show_toolbar", True))
         self.status_var.set(self.app.config.get("show_statusbar", True))
-        self.sidebar_var.set(not self.app.config.get("sidebar_collapsed", False))
         self.fullscreen_var.set(self.app.window.attributes("-fullscreen"))
 
     # ------------------------------------------------------------------
@@ -98,15 +91,6 @@ class MenuBar:
         self.app.config.set("show_statusbar", self.status_var.get())
         self.app.update_ui_visibility()
 
-    def _toggle_sidebar(self) -> None:
-        collapsed = not self.sidebar_var.get()
-        self.app.sidebar.set_collapsed(collapsed)
-        self.app.config.set("sidebar_collapsed", collapsed)
-        if self.app.status_bar is not None:
-            state = "collapsed" if collapsed else "expanded"
-            self.app.status_bar.set_message(f"Sidebar {state}", "info")
-
-    # ------------------------------------------------------------------
     def update_recent_files(self) -> None:
         """Refresh the recent files submenu."""
         self.recent_menu.delete(0, "end")

--- a/src/components/sidebar.py
+++ b/src/components/sidebar.py
@@ -1,5 +1,4 @@
 """Sidebar component for navigation."""
-
 from __future__ import annotations
 
 import customtkinter as ctk
@@ -7,35 +6,24 @@ from typing import Dict
 
 from .tooltip import Tooltip
 
-COLLAPSED_WIDTH = 60
-EXPANDED_WIDTH = 200
-AUTO_COLLAPSE_WIDTH = 700
+WIDTH = 200
 
 
 class Sidebar(ctk.CTkFrame):
     """Application sidebar for navigation"""
 
     def __init__(self, parent, app):
-        """Initialize sidebar"""
-        super().__init__(parent, corner_radius=0, width=EXPANDED_WIDTH)
+        super().__init__(parent, corner_radius=0, width=WIDTH)
         self.app = app
         self.buttons: Dict[str, ctk.CTkButton] = {}
         self.icons: Dict[str, str] = {}
         self.labels: Dict[str, str] = {}
         self._tooltips: Dict[str, Tooltip] = {}
-        self.collapsed: bool = False
-        self._auto_collapsed = False
-        self._user_override = False
-        self._animating = False
-        self._anim_job: str | None = None
-        # Prevent grid geometry from overriding the specified width so
-        # collapsing the sidebar actually changes its visible size.
+
+        # Prevent geometry from shrinking
         self.grid_propagate(False)
+        self.grid_rowconfigure(4, weight=1)
 
-        # Configure grid
-        self.grid_rowconfigure(4, weight=1)  # Make row 4 expandable
-
-        # Title
         self.title = ctk.CTkLabel(
             self,
             text="CoolBox",
@@ -48,14 +36,11 @@ class Sidebar(ctk.CTkFrame):
         self._create_nav_button("tools", "🛠️ Tools", 2)
         self._create_nav_button("settings", "⚙️ Settings", 3)
 
-        # Spacer frame (this will expand)
         spacer = ctk.CTkFrame(self, fg_color="transparent")
         spacer.grid(row=4, column=0, sticky="nsew")
 
-        # About button at bottom
         self._create_nav_button("about", "ℹ️ About", 5)
 
-        # Theme toggle
         self.theme_toggle = ctk.CTkButton(
             self,
             text="🌙 Dark Mode",
@@ -64,92 +49,14 @@ class Sidebar(ctk.CTkFrame):
         )
         self.theme_toggle.grid(row=6, column=0, padx=20, pady=(10, 5), sticky="ew")
 
-        # Collapse/expand button
-        self.collapse_btn = ctk.CTkButton(
-            self,
-            text="◀",
-            command=self.toggle,
-            width=32,
-            height=32,
-        )
-        self.collapse_btn.grid(row=7, column=0, pady=(0, 20))
-
-    def set_collapsed(self, collapsed: bool) -> None:
-        """Collapse or expand the sidebar."""
-        if collapsed == self.collapsed and not self._animating:
-            return
-        self.collapsed = collapsed
-        width = COLLAPSED_WIDTH if collapsed else EXPANDED_WIDTH
-        self._animate_width(width)
-        self.title.configure(text="🧊" if collapsed else "CoolBox")
-        for name, button in self.buttons.items():
-            icon = self.icons[name]
-            label = self.labels[name]
-            button.configure(text=icon if collapsed else f"{icon} {label}")
-        current = ctk.get_appearance_mode()
-        if current == "Dark":
-            dark_text = "🌙" if collapsed else "🌙 Dark Mode"
-        else:
-            dark_text = "☀️" if collapsed else "☀️ Light Mode"
-        self.theme_toggle.configure(text=dark_text)
-        self.collapse_btn.configure(text="▶" if collapsed else "◀")
-        if not collapsed:
-            for tooltip in self._tooltips.values():
-                tooltip.hide()
-
-    def toggle(self) -> None:
-        """Toggle collapsed state."""
-        self._auto_collapsed = False
-        self._user_override = True
-        self.set_collapsed(not self.collapsed)
-
+    # ------------------------------------------------------------------
     def _on_hover(self, tooltip: Tooltip, event) -> None:
-        """Show tooltip for a button when sidebar is collapsed."""
-        if not self.collapsed:
-            return
         x = self.winfo_rootx() + self.winfo_width() + 10
         y = event.widget.winfo_rooty() + event.widget.winfo_height() // 2
         tooltip.show(x, y)
 
-    def _animate_width(self, target: int) -> None:
-        """Animate sidebar width change to *target* pixels."""
-        start = self.winfo_width()
-        steps = 8
-        delta = (target - start) / steps
-
-        def step(i: int = 1) -> None:
-            if i > steps:
-                self.configure(width=target)
-                self._animating = False
-                self._anim_job = None
-                return
-            self.configure(width=int(start + delta * i))
-            self._anim_job = self.after(15, lambda: step(i + 1))
-
-        if self._anim_job is not None:
-            self.after_cancel(self._anim_job)
-
-        self._animating = True
-        step()
-
-    def auto_adjust(self, window_width: int) -> None:
-        """Collapse or expand based on *window_width* for responsive layout."""
-        if self._animating:
-            return
-        if window_width > AUTO_COLLAPSE_WIDTH:
-            # Reset manual override when window is sufficiently wide
-            self._user_override = False
-        if self._user_override:
-            return
-        if window_width <= AUTO_COLLAPSE_WIDTH and not self.collapsed:
-            self._auto_collapsed = True
-            self.set_collapsed(True)
-        elif window_width > AUTO_COLLAPSE_WIDTH and self.collapsed and self._auto_collapsed:
-            self._auto_collapsed = False
-            self.set_collapsed(False)
-
-    def _create_nav_button(self, name: str, text: str, row: int):
-        """Create a navigation button"""
+    # ------------------------------------------------------------------
+    def _create_nav_button(self, name: str, text: str, row: int) -> None:
         icon, label = text.split(" ", 1)
         button = ctk.CTkButton(
             self,
@@ -168,30 +75,22 @@ class Sidebar(ctk.CTkFrame):
         button.bind("<Enter>", lambda e, t=tooltip: self._on_hover(t, e))
         button.bind("<Leave>", lambda e, t=tooltip: t.hide())
 
-    def set_active(self, view_name: str):
-        """Set the active button"""
-        # Reset all buttons
+    # ------------------------------------------------------------------
+    def set_active(self, view_name: str) -> None:
         for button in self.buttons.values():
             button.configure(fg_color=["#3B8ED0", "#1F6AA5"])
-
-        # Highlight active button
         if view_name in self.buttons:
             self.buttons[view_name].configure(fg_color=["#1F6AA5", "#144870"])
 
-    def _toggle_theme(self):
-        """Toggle between light and dark theme"""
+    # ------------------------------------------------------------------
+    def _toggle_theme(self) -> None:
         current = ctk.get_appearance_mode()
         new_mode = "light" if current == "Dark" else "dark"
         ctk.set_appearance_mode(new_mode)
 
-        # Update button text
         if new_mode == "dark":
             self.theme_toggle.configure(text="🌙 Dark Mode")
         else:
             self.theme_toggle.configure(text="☀️ Light Mode")
 
-        # Save preference
         self.app.config.set("appearance_mode", new_mode)
-        # Refresh collapsed state label
-        if self.collapsed:
-            self.set_collapsed(True)

--- a/src/components/toolbar.py
+++ b/src/components/toolbar.py
@@ -47,9 +47,6 @@ class Toolbar(ctk.CTkFrame):
         self._create_button(left_frame, "📌", "Paste", self._paste).pack(
             side="left", padx=5
         )
-        self._create_button(
-            left_frame, "☰", "Toggle Sidebar", self.app.toggle_sidebar
-        ).pack(side="left", padx=5)
 
         self._create_button(
             left_frame,

--- a/src/config.py
+++ b/src/config.py
@@ -33,7 +33,6 @@ class Config:
             "show_toolbar": True,
             "show_statusbar": True,
             "show_menu": True,
-            "sidebar_collapsed": False,
             "theme": {
                 "primary_color": "#1f538d",
                 "secondary_color": "#212121",

--- a/src/views/quick_settings.py
+++ b/src/views/quick_settings.py
@@ -21,14 +21,12 @@ class QuickSettingsDialog(ctk.CTkToplevel):
         self.menu_var = ctk.BooleanVar(value=app.config.get("show_menu", True))
         self.toolbar_var = ctk.BooleanVar(value=app.config.get("show_toolbar", True))
         self.status_var = ctk.BooleanVar(value=app.config.get("show_statusbar", True))
-        self.sidebar_var = ctk.BooleanVar(value=not app.config.get("sidebar_collapsed", False))
         self.theme_var = ctk.StringVar(value=app.config.get("appearance_mode", "dark").title())
         self.color_var = ctk.StringVar(value=app.config.get("color_theme", "blue"))
 
         ctk.CTkCheckBox(self, text="Show Menu Bar", variable=self.menu_var).pack(anchor="w", padx=20, pady=5)
         ctk.CTkCheckBox(self, text="Show Toolbar", variable=self.toolbar_var).pack(anchor="w", padx=20, pady=5)
         ctk.CTkCheckBox(self, text="Show Status Bar", variable=self.status_var).pack(anchor="w", padx=20, pady=5)
-        ctk.CTkCheckBox(self, text="Show Sidebar", variable=self.sidebar_var).pack(anchor="w", padx=20, pady=5)
 
         ctk.CTkLabel(self, text="Appearance:").pack(anchor="w", padx=20, pady=(10, 0))
         ctk.CTkOptionMenu(
@@ -58,7 +56,6 @@ class QuickSettingsDialog(ctk.CTkToplevel):
         cfg.set("show_menu", self.menu_var.get())
         cfg.set("show_toolbar", self.toolbar_var.get())
         cfg.set("show_statusbar", self.status_var.get())
-        cfg.set("sidebar_collapsed", not self.sidebar_var.get())
         cfg.set("appearance_mode", self.theme_var.get().lower())
         cfg.set("color_theme", self.color_var.get())
         cfg.save()
@@ -66,7 +63,6 @@ class QuickSettingsDialog(ctk.CTkToplevel):
         ctk.set_appearance_mode(cfg.get("appearance_mode", "dark"))
         ctk.set_default_color_theme(cfg.get("color_theme", "blue"))
         self.app.theme.apply_theme(cfg.get("theme", {}))
-        self.app.sidebar.set_collapsed(cfg.get("sidebar_collapsed", False))
         self.app.update_ui_visibility()
         self.destroy()
 

--- a/src/views/settings_view.py
+++ b/src/views/settings_view.py
@@ -165,7 +165,6 @@ class SettingsView(ctk.CTkFrame):
         # Auto-save
         self.auto_save_var = ctk.BooleanVar(value=self.app.config.get("auto_save", True))
         auto_save_check = ctk.CTkCheckBox(
-            section,
             text="Enable auto-save",
             variable=self.auto_save_var,
         )
@@ -174,7 +173,6 @@ class SettingsView(ctk.CTkFrame):
         # Show toolbar
         self.show_toolbar_var = ctk.BooleanVar(value=self.app.config.get("show_toolbar", True))
         toolbar_check = ctk.CTkCheckBox(
-            section,
             text="Show toolbar",
             variable=self.show_toolbar_var,
         )
@@ -183,7 +181,6 @@ class SettingsView(ctk.CTkFrame):
         # Show status bar
         self.show_statusbar_var = ctk.BooleanVar(value=self.app.config.get("show_statusbar", True))
         statusbar_check = ctk.CTkCheckBox(
-            section,
             text="Show status bar",
             variable=self.show_statusbar_var,
         )
@@ -192,25 +189,13 @@ class SettingsView(ctk.CTkFrame):
         # Show menu bar
         self.show_menu_var = ctk.BooleanVar(value=self.app.config.get("show_menu", True))
         menu_check = ctk.CTkCheckBox(
-            section,
             text="Show menu bar",
             variable=self.show_menu_var,
         )
         menu_check.pack(anchor="w", padx=20, pady=5)
 
-        # Collapse sidebar
-        self.collapse_sidebar_var = ctk.BooleanVar(
-            value=self.app.config.get("sidebar_collapsed", False)
-        )
-        sidebar_check = ctk.CTkCheckBox(
-            section,
-            text="Collapse sidebar",
-            variable=self.collapse_sidebar_var,
-        )
-        sidebar_check.pack(anchor="w", padx=20, pady=5)
-
-        # Recent files limit
         recent_frame = ctk.CTkFrame(section)
+        # Recent files limit
         recent_frame.pack(fill="x", padx=20, pady=10)
 
         ctk.CTkLabel(
@@ -234,7 +219,6 @@ class SettingsView(ctk.CTkFrame):
 
         # Clear cache button
         clear_cache_btn = ctk.CTkButton(
-            section,
             text="🗑️ Clear Cache",
             command=self._clear_cache,
             width=200,
@@ -298,7 +282,6 @@ class SettingsView(ctk.CTkFrame):
         ).pack(side="left", padx=10)
 
         clear_scan_cache_btn = ctk.CTkButton(
-            section,
             text="🗑️ Clear Scan Cache",
             command=self._clear_scan_cache,
             width=200,
@@ -306,7 +289,6 @@ class SettingsView(ctk.CTkFrame):
         clear_scan_cache_btn.pack(pady=10)
 
         clear_host_cache_btn = ctk.CTkButton(
-            section,
             text="🗑️ Clear Host Cache",
             command=self._clear_host_cache,
             width=200,
@@ -314,7 +296,6 @@ class SettingsView(ctk.CTkFrame):
         clear_host_cache_btn.pack(pady=10)
 
         open_cache_btn = ctk.CTkButton(
-            section,
             text="📂 Open Cache Folder",
             command=self._open_cache_folder,
             width=200,
@@ -322,7 +303,6 @@ class SettingsView(ctk.CTkFrame):
         open_cache_btn.pack(pady=10)
 
         open_config_btn = ctk.CTkButton(
-            section,
             text="📂 Open Config Folder",
             command=self._open_config_folder,
             width=200,
@@ -330,7 +310,6 @@ class SettingsView(ctk.CTkFrame):
         open_config_btn.pack(pady=10)
 
         open_config_file_btn = ctk.CTkButton(
-            section,
             text="📄 Open Config File",
             command=self._open_config_file_external,
             width=200,
@@ -338,7 +317,6 @@ class SettingsView(ctk.CTkFrame):
         open_config_file_btn.pack(pady=10)
 
         edit_config_btn = ctk.CTkButton(
-            section,
             text="📝 Edit Config File",
             command=self._edit_config_file,
             width=200,
@@ -347,7 +325,6 @@ class SettingsView(ctk.CTkFrame):
 
         # Reset settings button
         reset_btn = ctk.CTkButton(
-            section,
             text="🔄 Reset to Defaults",
             command=self._reset_settings,
             width=200,
@@ -358,7 +335,6 @@ class SettingsView(ctk.CTkFrame):
 
         # Export settings
         export_btn = ctk.CTkButton(
-            section,
             text="📤 Export Settings",
             command=self._export_settings,
             width=200,
@@ -367,7 +343,6 @@ class SettingsView(ctk.CTkFrame):
 
         # Import settings
         import_btn = ctk.CTkButton(
-            section,
             text="📥 Import Settings",
             command=self._import_settings,
             width=200,
@@ -381,7 +356,6 @@ class SettingsView(ctk.CTkFrame):
 
         # Section title
         title_label = ctk.CTkLabel(
-            section,
             text=title,
             font=ctk.CTkFont(size=18, weight="bold"),
         )
@@ -412,7 +386,6 @@ class SettingsView(ctk.CTkFrame):
         self.app.config.set("show_toolbar", self.show_toolbar_var.get())
         self.app.config.set("show_statusbar", self.show_statusbar_var.get())
         self.app.config.set("show_menu", self.show_menu_var.get())
-        self.app.config.set("sidebar_collapsed", self.collapse_sidebar_var.get())
         self.app.config.set("max_recent_files", self.recent_limit_var.get())
         self.app.config.set("scan_cache_ttl", int(self.scan_ttl_var.get()))
         self.app.config.set("scan_concurrency", int(self.scan_concurrency_var.get()))
@@ -422,7 +395,6 @@ class SettingsView(ctk.CTkFrame):
         theme = self.app.theme.get_theme()
         theme["accent_color"] = self.accent_color_var.get()
         self.app.theme.apply_theme(theme)
-        self.app.sidebar.set_collapsed(self.collapse_sidebar_var.get())
 
         # Save to file
         self.app.config.save()
@@ -452,8 +424,6 @@ class SettingsView(ctk.CTkFrame):
                 self.app.status_bar.set_message("Settings reset to defaults!", "success")
             self.app.switch_view("settings")
             self.app.update_ui_visibility()
-            self.collapse_sidebar_var.set(self.app.config.get("sidebar_collapsed", False))
-            self.app.sidebar.set_collapsed(self.collapse_sidebar_var.get())
             self.show_menu_var.set(self.app.config.get("show_menu", True))
             self.scan_ttl_var.set(self.app.config.get("scan_cache_ttl", 300))
             self.scan_concurrency_var.set(self.app.config.get("scan_concurrency", 100))

--- a/src/views/tools_view.py
+++ b/src/views/tools_view.py
@@ -983,7 +983,7 @@ class ToolsView(ctk.CTkFrame):
                     family=fam,
                 )
             )
-            
+
             def show_result() -> None:
                 lines = []
                 for host, ports in results.items():

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -6,7 +6,6 @@ import customtkinter as ctk
 from unittest.mock import patch
 
 from src.app import CoolBoxApp
-from src.components.sidebar import COLLAPSED_WIDTH, EXPANDED_WIDTH
 
 
 class TestCoolBoxApp(unittest.TestCase):
@@ -17,69 +16,8 @@ class TestCoolBoxApp(unittest.TestCase):
         app.destroy()
 
     @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
-    def test_toggle_sidebar_updates_config(self) -> None:
-        app = CoolBoxApp()
-        initial = app.sidebar.collapsed
-        app.toggle_sidebar()
-        # process pending animation events
-        for _ in range(10):
-            app.window.update()
-        self.assertNotEqual(app.sidebar.collapsed, initial)
-        # sidebar width should match the expected collapsed/expanded size
-        expected_width = COLLAPSED_WIDTH if app.sidebar.collapsed else EXPANDED_WIDTH
-        self.assertEqual(int(app.sidebar.cget("width")), expected_width)
-        self.assertEqual(app.config.get("sidebar_collapsed"), app.sidebar.collapsed)
-        expected = "▶" if app.sidebar.collapsed else "◀"
-        self.assertEqual(app.sidebar.collapse_btn.cget("text"), expected)
-        app.destroy()
-
-    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
-    def test_sidebar_auto_resize(self) -> None:
-        app = CoolBoxApp()
-        app.window.geometry("500x600")
-        app.window.update()
-        self.assertTrue(app.sidebar.collapsed)
-        # config should not persist auto-collapsed state
-        self.assertFalse(app.config.get("sidebar_collapsed"))
-        app.window.geometry("1200x800")
-        app.window.update()
-        self.assertFalse(app.sidebar.collapsed)
-        self.assertFalse(app.config.get("sidebar_collapsed"))
-        app.destroy()
-
-    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
-    def test_sidebar_manual_override_persists(self) -> None:
-        app = CoolBoxApp()
-        app.window.update()
-        self.assertFalse(app.sidebar.collapsed)
-
-        app.toggle_sidebar()
-        for _ in range(10):
-            app.window.update()
-        self.assertTrue(app.sidebar.collapsed)
-
-        app.window.geometry("500x600")
-        app.window.update()
-        self.assertTrue(app.sidebar.collapsed)
-
-        app.window.geometry("1200x800")
-        app.window.update()
-        self.assertTrue(app.sidebar.collapsed)
-
-        app.destroy()
-
-    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
-    def test_sidebar_initial_state_large_window(self) -> None:
-        app = CoolBoxApp()
-        app.window.update()
-        self.assertFalse(app.sidebar.collapsed)
-        self.assertEqual(int(app.sidebar.cget("width")), EXPANDED_WIDTH)
-        app.destroy()
-
-    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
     def test_sidebar_tooltips_show_and_hide(self) -> None:
         app = CoolBoxApp()
-        app.sidebar.set_collapsed(True)
         tooltip = app.sidebar._tooltips["home"]
         tooltip.show(100, 100)
         app.window.update()
@@ -124,8 +62,7 @@ class TestCoolBoxApp(unittest.TestCase):
     @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
     def test_menubar_sync(self) -> None:
         app = CoolBoxApp()
-        app.toggle_sidebar()
-        self.assertEqual(app.menu_bar.sidebar_var.get(), not app.sidebar.collapsed)
+        self.assertIsNotNone(app.menu_bar)
         app.toggle_fullscreen()
         self.assertEqual(app.menu_bar.fullscreen_var.get(), app.window.attributes("-fullscreen"))
         app.destroy()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -49,13 +49,6 @@ def test_add_recent_file_persists(monkeypatch, tmp_path):
     assert "x.txt" in json.loads(cfg.config_file.read_text())["recent_files"]
 
 
-def test_sidebar_collapsed_default(monkeypatch):
-    tmp = Path(tempfile.mkdtemp())
-    monkeypatch.setattr(Path, "home", lambda: tmp)
-    cfg = Config()
-    assert cfg.get("sidebar_collapsed") is False
-
-
 def test_menu_default(monkeypatch):
     tmp = Path(tempfile.mkdtemp())
     monkeypatch.setattr(Path, "home", lambda: tmp)


### PR DESCRIPTION
## Summary
- strip all logic related to collapsing the sidebar
- simplify `Sidebar` component
- drop sidebar options from settings, quick settings and menubar
- clean up README description
- update tests
- add bullet highlighting the fixed sidebar

## Testing
- `pip install -q -r requirements.txt`
- `python setup.py --dev`
- `flake8 src setup.py tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c6d18c474832bab845deec4bd0831