### PR TITLE
Remove sidebar hiding logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ A modern, feature-rich desktop application built with Python and CustomTkinter.
   menu bar now includes recent files, a Quick Settings dialog and a fullscreen
   toggle. Quick Settings can also be launched from the toolbar or with the
   `Ctrl+Q` shortcut.
-- **Collapsible Sidebar**: Quickly hide the sidebar using the toolbar button,
-  arrow icon or `Ctrl+B`. CoolBox remembers your preference across sessions.
 - **Cross-Platform**: Works on Windows, macOS, and Linux
 - **Expanded Utilities**: File and directory copy/move helpers, an enhanced file manager, a threaded port scanner, a flexible hash calculator with optional disk caching, a multi-threaded duplicate finder that persists file hashes for lightning fast rescans, a screenshot capture tool, and a built-in process manager that auto-refreshes and sorts by CPU usage. The system info viewer now reports CPU cores and memory usage.
 - **Network Scanner CLI**: Scan multiple hosts asynchronously with IPv4/IPv6

--- a/scripts/run_debug.sh
+++ b/scripts/run_debug.sh
@@ -6,8 +6,9 @@ if [ -d ".venv" ]; then
     source .venv/bin/activate
 fi
 
-# Ensure debugpy is installed
+# Ensure debugpy and runtime deps are installed
 python -m pip install --quiet debugpy
+python -m pip install --quiet -r requirements.txt
 
 # Choose debug port
 DEBUG_PORT=${DEBUG_PORT:-5678}

--- a/src/app.py
+++ b/src/app.py
@@ -97,10 +97,6 @@ class CoolBoxApp:
         # Create sidebar
         self.sidebar = Sidebar(self.content_area, self)
         self.sidebar.grid(row=0, column=0, sticky="nsew", padx=0, pady=0)
-        self.sidebar.set_collapsed(self.config.get("sidebar_collapsed", False))
-        # Ensure geometry is realized before responsive check
-        self.window.update_idletasks()
-        self.sidebar.auto_adjust(self.window.winfo_width())
 
         # Create view container
         self.view_container = ctk.CTkFrame(self.content_area, corner_radius=0)
@@ -171,8 +167,6 @@ class CoolBoxApp:
         self.window.bind("<Control-s>", lambda e: self.switch_view("settings"))
         self.window.bind("<Control-q>", lambda e: self.open_quick_settings())
         self.window.bind("<F11>", lambda e: self.toggle_fullscreen())
-        self.window.bind("<Control-b>", lambda e: self.toggle_sidebar())
-        self.window.bind("<Configure>", self._on_resize)
 
     def switch_view(self, view_name: str):
         """Switch to a different view"""
@@ -227,29 +221,6 @@ class CoolBoxApp:
         if self.quick_settings_window is not None and self.quick_settings_window.winfo_exists():
             self.quick_settings_window.destroy()
         self.quick_settings_window = None
-
-    def toggle_sidebar(self) -> None:
-        """Collapse or expand the sidebar."""
-        self.sidebar.toggle()
-        self.config.set("sidebar_collapsed", self.sidebar.collapsed)
-        if self.status_bar is not None:
-            state = "collapsed" if self.sidebar.collapsed else "expanded"
-            self.status_bar.set_message(f"Sidebar {state}", "info")
-        if self.menu_bar is not None:
-            self.menu_bar.refresh_toggles()
-
-    def _on_resize(self, event) -> None:
-        """Handle window resize events for responsive UI."""
-        previous = self.sidebar.collapsed
-        self.sidebar.auto_adjust(event.width)
-        if previous != self.sidebar.collapsed:
-            if not self.sidebar._auto_collapsed:
-                self.config.set("sidebar_collapsed", self.sidebar.collapsed)
-            if self.status_bar is not None:
-                state = "collapsed" if self.sidebar.collapsed else "expanded"
-                self.status_bar.set_message(f"Sidebar {state}", "info")
-            if self.menu_bar is not None:
-                self.menu_bar.refresh_toggles()
 
     def _on_closing(self):
         """Handle window closing event"""

--- a/src/components/menubar.py
+++ b/src/components/menubar.py
@@ -40,9 +40,6 @@ class MenuBar:
         self.status_var = tk.BooleanVar(
             value=self.app.config.get("show_statusbar", True)
         )
-        self.sidebar_var = tk.BooleanVar(
-            value=not self.app.config.get("sidebar_collapsed", False)
-        )
         self.fullscreen_var = tk.BooleanVar(
             value=self.app.window.attributes("-fullscreen")
         )
@@ -52,9 +49,6 @@ class MenuBar:
         )
         view_menu.add_checkbutton(
             label="Status Bar", variable=self.status_var, command=self._toggle_statusbar
-        )
-        view_menu.add_checkbutton(
-            label="Sidebar", variable=self.sidebar_var, command=self._toggle_sidebar
         )
         view_menu.add_checkbutton(
             label="Full Screen", variable=self.fullscreen_var, command=self._toggle_fullscreen
@@ -75,7 +69,6 @@ class MenuBar:
         """Sync toggle states with current config."""
         self.toolbar_var.set(self.app.config.get("show_toolbar", True))
         self.status_var.set(self.app.config.get("show_statusbar", True))
-        self.sidebar_var.set(not self.app.config.get("sidebar_collapsed", False))
         self.fullscreen_var.set(self.app.window.attributes("-fullscreen"))
 
     # ------------------------------------------------------------------
@@ -97,14 +90,6 @@ class MenuBar:
     def _toggle_statusbar(self) -> None:
         self.app.config.set("show_statusbar", self.status_var.get())
         self.app.update_ui_visibility()
-
-    def _toggle_sidebar(self) -> None:
-        collapsed = not self.sidebar_var.get()
-        self.app.sidebar.set_collapsed(collapsed)
-        self.app.config.set("sidebar_collapsed", collapsed)
-        if self.app.status_bar is not None:
-            state = "collapsed" if collapsed else "expanded"
-            self.app.status_bar.set_message(f"Sidebar {state}", "info")
 
     # ------------------------------------------------------------------
     def update_recent_files(self) -> None:

--- a/src/components/toolbar.py
+++ b/src/components/toolbar.py
@@ -47,9 +47,6 @@ class Toolbar(ctk.CTkFrame):
         self._create_button(left_frame, "📌", "Paste", self._paste).pack(
             side="left", padx=5
         )
-        self._create_button(
-            left_frame, "☰", "Toggle Sidebar", self.app.toggle_sidebar
-        ).pack(side="left", padx=5)
 
         self._create_button(
             left_frame,

--- a/src/config.py
+++ b/src/config.py
@@ -33,7 +33,6 @@ class Config:
             "show_toolbar": True,
             "show_statusbar": True,
             "show_menu": True,
-            "sidebar_collapsed": False,
             "theme": {
                 "primary_color": "#1f538d",
                 "secondary_color": "#212121",

--- a/src/views/quick_settings.py
+++ b/src/views/quick_settings.py
@@ -21,14 +21,12 @@ class QuickSettingsDialog(ctk.CTkToplevel):
         self.menu_var = ctk.BooleanVar(value=app.config.get("show_menu", True))
         self.toolbar_var = ctk.BooleanVar(value=app.config.get("show_toolbar", True))
         self.status_var = ctk.BooleanVar(value=app.config.get("show_statusbar", True))
-        self.sidebar_var = ctk.BooleanVar(value=not app.config.get("sidebar_collapsed", False))
         self.theme_var = ctk.StringVar(value=app.config.get("appearance_mode", "dark").title())
         self.color_var = ctk.StringVar(value=app.config.get("color_theme", "blue"))
 
         ctk.CTkCheckBox(self, text="Show Menu Bar", variable=self.menu_var).pack(anchor="w", padx=20, pady=5)
         ctk.CTkCheckBox(self, text="Show Toolbar", variable=self.toolbar_var).pack(anchor="w", padx=20, pady=5)
         ctk.CTkCheckBox(self, text="Show Status Bar", variable=self.status_var).pack(anchor="w", padx=20, pady=5)
-        ctk.CTkCheckBox(self, text="Show Sidebar", variable=self.sidebar_var).pack(anchor="w", padx=20, pady=5)
 
         ctk.CTkLabel(self, text="Appearance:").pack(anchor="w", padx=20, pady=(10, 0))
         ctk.CTkOptionMenu(
@@ -58,7 +56,6 @@ class QuickSettingsDialog(ctk.CTkToplevel):
         cfg.set("show_menu", self.menu_var.get())
         cfg.set("show_toolbar", self.toolbar_var.get())
         cfg.set("show_statusbar", self.status_var.get())
-        cfg.set("sidebar_collapsed", not self.sidebar_var.get())
         cfg.set("appearance_mode", self.theme_var.get().lower())
         cfg.set("color_theme", self.color_var.get())
         cfg.save()
@@ -66,7 +63,6 @@ class QuickSettingsDialog(ctk.CTkToplevel):
         ctk.set_appearance_mode(cfg.get("appearance_mode", "dark"))
         ctk.set_default_color_theme(cfg.get("color_theme", "blue"))
         self.app.theme.apply_theme(cfg.get("theme", {}))
-        self.app.sidebar.set_collapsed(cfg.get("sidebar_collapsed", False))
         self.app.update_ui_visibility()
         self.destroy()
 

--- a/src/views/settings_view.py
+++ b/src/views/settings_view.py
@@ -198,17 +198,6 @@ class SettingsView(ctk.CTkFrame):
         )
         menu_check.pack(anchor="w", padx=20, pady=5)
 
-        # Collapse sidebar
-        self.collapse_sidebar_var = ctk.BooleanVar(
-            value=self.app.config.get("sidebar_collapsed", False)
-        )
-        sidebar_check = ctk.CTkCheckBox(
-            section,
-            text="Collapse sidebar",
-            variable=self.collapse_sidebar_var,
-        )
-        sidebar_check.pack(anchor="w", padx=20, pady=5)
-
         # Recent files limit
         recent_frame = ctk.CTkFrame(section)
         recent_frame.pack(fill="x", padx=20, pady=10)
@@ -412,7 +401,6 @@ class SettingsView(ctk.CTkFrame):
         self.app.config.set("show_toolbar", self.show_toolbar_var.get())
         self.app.config.set("show_statusbar", self.show_statusbar_var.get())
         self.app.config.set("show_menu", self.show_menu_var.get())
-        self.app.config.set("sidebar_collapsed", self.collapse_sidebar_var.get())
         self.app.config.set("max_recent_files", self.recent_limit_var.get())
         self.app.config.set("scan_cache_ttl", int(self.scan_ttl_var.get()))
         self.app.config.set("scan_concurrency", int(self.scan_concurrency_var.get()))
@@ -422,7 +410,6 @@ class SettingsView(ctk.CTkFrame):
         theme = self.app.theme.get_theme()
         theme["accent_color"] = self.accent_color_var.get()
         self.app.theme.apply_theme(theme)
-        self.app.sidebar.set_collapsed(self.collapse_sidebar_var.get())
 
         # Save to file
         self.app.config.save()
@@ -452,8 +439,6 @@ class SettingsView(ctk.CTkFrame):
                 self.app.status_bar.set_message("Settings reset to defaults!", "success")
             self.app.switch_view("settings")
             self.app.update_ui_visibility()
-            self.collapse_sidebar_var.set(self.app.config.get("sidebar_collapsed", False))
-            self.app.sidebar.set_collapsed(self.collapse_sidebar_var.get())
             self.show_menu_var.set(self.app.config.get("show_menu", True))
             self.scan_ttl_var.set(self.app.config.get("scan_cache_ttl", 300))
             self.scan_concurrency_var.set(self.app.config.get("scan_concurrency", 100))

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -6,7 +6,6 @@ import customtkinter as ctk
 from unittest.mock import patch
 
 from src.app import CoolBoxApp
-from src.components.sidebar import COLLAPSED_WIDTH, EXPANDED_WIDTH
 
 
 class TestCoolBoxApp(unittest.TestCase):
@@ -17,69 +16,8 @@ class TestCoolBoxApp(unittest.TestCase):
         app.destroy()
 
     @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
-    def test_toggle_sidebar_updates_config(self) -> None:
-        app = CoolBoxApp()
-        initial = app.sidebar.collapsed
-        app.toggle_sidebar()
-        # process pending animation events
-        for _ in range(10):
-            app.window.update()
-        self.assertNotEqual(app.sidebar.collapsed, initial)
-        # sidebar width should match the expected collapsed/expanded size
-        expected_width = COLLAPSED_WIDTH if app.sidebar.collapsed else EXPANDED_WIDTH
-        self.assertEqual(int(app.sidebar.cget("width")), expected_width)
-        self.assertEqual(app.config.get("sidebar_collapsed"), app.sidebar.collapsed)
-        expected = "▶" if app.sidebar.collapsed else "◀"
-        self.assertEqual(app.sidebar.collapse_btn.cget("text"), expected)
-        app.destroy()
-
-    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
-    def test_sidebar_auto_resize(self) -> None:
-        app = CoolBoxApp()
-        app.window.geometry("500x600")
-        app.window.update()
-        self.assertTrue(app.sidebar.collapsed)
-        # config should not persist auto-collapsed state
-        self.assertFalse(app.config.get("sidebar_collapsed"))
-        app.window.geometry("1200x800")
-        app.window.update()
-        self.assertFalse(app.sidebar.collapsed)
-        self.assertFalse(app.config.get("sidebar_collapsed"))
-        app.destroy()
-
-    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
-    def test_sidebar_manual_override_persists(self) -> None:
-        app = CoolBoxApp()
-        app.window.update()
-        self.assertFalse(app.sidebar.collapsed)
-
-        app.toggle_sidebar()
-        for _ in range(10):
-            app.window.update()
-        self.assertTrue(app.sidebar.collapsed)
-
-        app.window.geometry("500x600")
-        app.window.update()
-        self.assertTrue(app.sidebar.collapsed)
-
-        app.window.geometry("1200x800")
-        app.window.update()
-        self.assertTrue(app.sidebar.collapsed)
-
-        app.destroy()
-
-    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
-    def test_sidebar_initial_state_large_window(self) -> None:
-        app = CoolBoxApp()
-        app.window.update()
-        self.assertFalse(app.sidebar.collapsed)
-        self.assertEqual(int(app.sidebar.cget("width")), EXPANDED_WIDTH)
-        app.destroy()
-
-    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
     def test_sidebar_tooltips_show_and_hide(self) -> None:
         app = CoolBoxApp()
-        app.sidebar.set_collapsed(True)
         tooltip = app.sidebar._tooltips["home"]
         tooltip.show(100, 100)
         app.window.update()
@@ -124,8 +62,6 @@ class TestCoolBoxApp(unittest.TestCase):
     @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
     def test_menubar_sync(self) -> None:
         app = CoolBoxApp()
-        app.toggle_sidebar()
-        self.assertEqual(app.menu_bar.sidebar_var.get(), not app.sidebar.collapsed)
         app.toggle_fullscreen()
         self.assertEqual(app.menu_bar.fullscreen_var.get(), app.window.attributes("-fullscreen"))
         app.destroy()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -49,13 +49,6 @@ def test_add_recent_file_persists(monkeypatch, tmp_path):
     assert "x.txt" in json.loads(cfg.config_file.read_text())["recent_files"]
 
 
-def test_sidebar_collapsed_default(monkeypatch):
-    tmp = Path(tempfile.mkdtemp())
-    monkeypatch.setattr(Path, "home", lambda: tmp)
-    cfg = Config()
-    assert cfg.get("sidebar_collapsed") is False
-
-
 def test_menu_default(monkeypatch):
     tmp = Path(tempfile.mkdtemp())
     monkeypatch.setattr(Path, "home", lambda: tmp)


### PR DESCRIPTION
## Summary
- remove collapsible sidebar feature and cleanup UI
- drop sidebar toggle from toolbar and menubar
- update settings and quick settings dialogs
- simplify tests now that sidebar is always visible
- ensure debug launcher installs runtime dependencies

## Testing
- `pytest -q`
- `flake8 src setup.py tests`
- `./scripts/run_vm_debug.sh` *(terminates once started)*

------
https://chatgpt.com/codex/tasks/task_e_685c73612ed4832b99c19d9b696a0928