### PR TITLE
Optimize ForceQuit dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,18 @@ A modern, feature-rich desktop application built with Python and CustomTkinter.
   pool so updates remain fast even with hundreds of processes. Expensive metrics
   like open files and network connections are refreshed only every few cycles to
   further reduce overhead without losing accuracy.
+  The dialog now skips UI updates when nothing has changed and supports several
+  environment variables to tune performance. ``FORCE_QUIT_INTERVAL`` sets the
+  refresh delay, ``FORCE_QUIT_DETAIL_INTERVAL`` controls how often expensive
+  metrics are gathered, ``FORCE_QUIT_MAX`` limits displayed rows and
+  ``FORCE_QUIT_WORKERS`` defines the worker thread count. ``FORCE_QUIT_CPU_ALERT``
+  and ``FORCE_QUIT_MEM_ALERT`` change the CPU and memory thresholds that trigger
+  row highlighting. ``FORCE_QUIT_SAMPLES`` controls how many samples are kept for
+  average CPU/IO calculations. Row data is cached so only changed entries are
+  redrawn for smoother updates. Pausing the dialog now halts the background
+  watcher thread so no resources are wasted while inspecting a snapshot.
+  Set ``FORCE_QUIT_AUTO_KILL`` to ``cpu``, ``mem`` or ``both`` to automatically
+  terminate processes exceeding the configured thresholds.
 - **Network Scanner CLI**: Scan multiple hosts asynchronously with IPv4/IPv6
   support, host lookup caching, and configurable timeouts.
 - **Auto Network Scan**: Detects local networks, pings for active hosts and

--- a/tests/test_force_quit.py
+++ b/tests/test_force_quit.py
@@ -7,7 +7,7 @@ import re
 
 import psutil
 
-from src.views.force_quit_dialog import ForceQuitDialog
+from src.views.force_quit_dialog import ForceQuitDialog, ProcessEntry
 
 
 class TestForceQuit(unittest.TestCase):
@@ -321,6 +321,47 @@ class TestForceQuit(unittest.TestCase):
         time.sleep(0.1)
         self.assertGreaterEqual(count, 1)
         self.assertFalse(psutil.pid_exists(proc.pid))
+
+    def test_find_over_threshold(self) -> None:
+        e1 = ProcessEntry(
+            pid=1,
+            name="p1",
+            cpu=90.0,
+            mem=100.0,
+            user="u",
+            start=0.0,
+            status="",
+            cpu_time=0.0,
+            threads=1,
+            read_bytes=0,
+            write_bytes=0,
+            files=0,
+            conns=0,
+        )
+        e2 = ProcessEntry(
+            pid=2,
+            name="p2",
+            cpu=10.0,
+            mem=600.0,
+            user="u",
+            start=0.0,
+            status="",
+            cpu_time=0.0,
+            threads=1,
+            read_bytes=0,
+            write_bytes=0,
+            files=0,
+            conns=0,
+        )
+        snapshot = {1: e1, 2: e2}
+        pids = ForceQuitDialog._find_over_threshold(
+            snapshot,
+            kill_cpu=True,
+            kill_mem=True,
+            cpu_alert=80.0,
+            mem_alert=500.0,
+        )
+        assert set(pids) == {1, 2}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- refine ProcessEntry sample handling with deque
- allow ProcessWatcher to pause while dialog is paused
- process watcher uses ThreadPoolExecutor.map for less overhead
- pause button now stops the watcher thread
- document watcher pausing in README
- add automatic killing for high CPU/memory processes
- provide `FORCE_QUIT_AUTO_KILL` env var
- unit test for threshold helper

## Testing
- `python -m flake8 src setup.py tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d310689dc832b80513352ec711a68