### PR TITLE
Fix env var initialization in ForceQuitDialog

### DIFF
--- a/scripts/run_debug.sh
+++ b/scripts/run_debug.sh
@@ -6,9 +6,11 @@ if [ -d ".venv" ]; then
     source .venv/bin/activate
 fi
 
-# Ensure debugpy and runtime deps are installed
-python -m pip install --quiet debugpy
-python -m pip install --quiet -r requirements.txt
+# Ensure debugpy and runtime deps are installed unless SKIP_DEPS=1
+if [ "$SKIP_DEPS" != "1" ]; then
+    python -m pip install --quiet debugpy
+    python -m pip install --quiet -r requirements.txt
+fi
 
 # Choose debug port
 DEBUG_PORT=${DEBUG_PORT:-5678}

--- a/src/views/force_quit_dialog.py
+++ b/src/views/force_quit_dialog.py
@@ -270,6 +270,9 @@ class ForceQuitDialog(ctk.CTkToplevel):
         self.title("Force Quit")
         width_env = os.getenv("FORCE_QUIT_WIDTH")
         height_env = os.getenv("FORCE_QUIT_HEIGHT")
+        sort_env = os.getenv("FORCE_QUIT_SORT")
+        reverse_env = os.getenv("FORCE_QUIT_SORT_REVERSE")
+        on_top_env = os.getenv("FORCE_QUIT_ON_TOP")
         cfg = app.config
         width = (
             int(width_env)
@@ -309,9 +312,6 @@ class ForceQuitDialog(ctk.CTkToplevel):
         mem_alert_env = os.getenv("FORCE_QUIT_MEM_ALERT")
         sample_env = os.getenv("FORCE_QUIT_SAMPLES")
         auto_env = os.getenv("FORCE_QUIT_AUTO_KILL", "").lower()
-        sort_env = os.getenv("FORCE_QUIT_SORT")
-        reverse_env = os.getenv("FORCE_QUIT_SORT_REVERSE")
-        on_top_env = os.getenv("FORCE_QUIT_ON_TOP")
 
         workers = int(worker_env) if worker_env and worker_env.isdigit() else None
         interval = (


### PR DESCRIPTION
## Summary
- fix ForceQuitDialog to read environment variables before usage
- allow skipping package install in run_debug via `SKIP_DEPS`

## Testing
- `flake8 src setup.py tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d4af6598c832b8aa190c444d76030