### PR TITLE
Optimize force quit watcher

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -39,6 +39,8 @@ class Config:
             "force_quit_interval": 2.0,
             "force_quit_detail_interval": 5,
             "force_quit_samples": 5,
+            "force_quit_adaptive": True,
+            "force_quit_adaptive_detail": True,
             "force_quit_max": 300,
             "force_quit_width": 1000,
             "force_quit_height": 650,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -78,6 +78,8 @@ def test_force_quit_defaults(monkeypatch):
     assert cfg.get("force_quit_sort") == "CPU"
     assert cfg.get("force_quit_sort_reverse") is True
     assert cfg.get("force_quit_on_top") is False
+    assert cfg.get("force_quit_adaptive") is True
+    assert cfg.get("force_quit_adaptive_detail") is True
 
 
 def test_force_quit_persist(monkeypatch):


### PR DESCRIPTION
## Summary
- add `force_quit_adaptive_detail` config default
- expose detail adaptivity and interval controls in Force Quit
- allow ProcessWatcher to adapt detail refresh frequency
- persist adaptive detail settings in config
- implement per-process detail refresh scheduling for ProcessWatcher

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d5cb22098832bb7f68efa9edb41f3