### PR TITLE
Optimize force quit watcher

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -47,6 +47,11 @@ class Config:
             "force_quit_sort": "CPU",
             "force_quit_sort_reverse": True,
             "force_quit_on_top": False,
+            "force_quit_conn_interval": 2.0,
+            "force_quit_file_interval": 2.0,
+            "force_quit_cache_ttl": 30.0,
+            "force_quit_conn_global": 50,
+            "force_quit_file_global": 50,
             "theme": {
                 "primary_color": "#1f538d",
                 "secondary_color": "#212121",

--- a/src/utils/cache.py
+++ b/src/utils/cache.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Generic, TypeVar
+from typing import Dict, Generic, TypeVar, Iterable
 import json
 import time
+import threading
 
 T = TypeVar("T")
 
@@ -19,10 +20,12 @@ class CacheItem(Generic[T]):
 
 
 class CacheManager(Generic[T]):
-    """Simple disk-backed cache with TTL support.
+    """Thread-safe disk-backed cache with TTL support.
 
     The manager tracks the modification time of the backing file so
-    updates written by other processes are picked up automatically.
+    updates written by other processes are picked up automatically. A
+    lock guards internal state so the cache can be safely used from
+    multiple threads.
     """
 
     def __init__(self, file: Path) -> None:
@@ -31,6 +34,7 @@ class CacheManager(Generic[T]):
         self._mtime: float = self.file.stat().st_mtime if self.file.exists() else 0.0
         self.hits = 0
         self.misses = 0
+        self._lock = threading.RLock()
 
     # -- persistence helpers -------------------------------------------------
     def _load(self) -> Dict[str, CacheItem[T]]:
@@ -50,17 +54,18 @@ class CacheManager(Generic[T]):
 
     def _check_reload(self) -> None:
         """Reload the cache from disk if the file changed."""
-        try:
-            mtime = self.file.stat().st_mtime
-        except FileNotFoundError:
-            if self._cache:
-                self._cache.clear()
-            self._mtime = 0.0
-            return
+        with self._lock:
+            try:
+                mtime = self.file.stat().st_mtime
+            except FileNotFoundError:
+                if self._cache:
+                    self._cache.clear()
+                self._mtime = 0.0
+                return
 
-        if mtime > self._mtime:
-            self._cache = self._load()
-            self._mtime = mtime
+            if mtime > self._mtime:
+                self._cache = self._load()
+                self._mtime = mtime
 
     def refresh(self) -> None:
         """Public method to reload the cache if the file changed."""
@@ -81,53 +86,88 @@ class CacheManager(Generic[T]):
     def get(self, key: str, ttl: float | None = None) -> T | None:
         """Return cached value for *key* or ``None`` if expired/missing."""
         self._check_reload()
-        item = self._cache.get(key)
-        if not item:
+        with self._lock:
+            item = self._cache.get(key)
+            if not item:
+                self.misses += 1
+                return None
+
+            effective_ttl = item.ttl if ttl is None else min(item.ttl, ttl)
+            if effective_ttl <= 0:
+                return None
+
+            if time.time() - item.timestamp < effective_ttl:
+                self.hits += 1
+                return item.value
+
+            self._cache.pop(key, None)
+            self._save()
             self.misses += 1
             return None
 
-        effective_ttl = item.ttl if ttl is None else min(item.ttl, ttl)
-        if effective_ttl <= 0:
-            return None
-
-        if time.time() - item.timestamp < effective_ttl:
-            self.hits += 1
-            return item.value
-
-        self._cache.pop(key, None)
-        self._save()
-        self.misses += 1
-        return None
-
     def set(self, key: str, value: T, ttl: float) -> None:
         self._check_reload()
-        self._cache[key] = CacheItem(time.time(), ttl, value)
-        self._save()
+        with self._lock:
+            self._cache[key] = CacheItem(time.time(), ttl, value)
+            self._save()
 
     def clear(self) -> None:
         self._check_reload()
-        self._cache.clear()
-        try:
-            self.file.unlink()
-        except FileNotFoundError:
-            pass
-        self._mtime = 0.0
-        self.hits = 0
-        self.misses = 0
+        with self._lock:
+            self._cache.clear()
+            try:
+                self.file.unlink()
+            except FileNotFoundError:
+                pass
+            self._mtime = 0.0
+            self.hits = 0
+            self.misses = 0
 
     def prune(self) -> None:
         self._check_reload()
-        now = time.time()
-        to_delete = [k for k, c in self._cache.items() if c.ttl > 0 and now - c.timestamp >= c.ttl]
-        for k in to_delete:
-            self._cache.pop(k, None)
-        if to_delete:
-            self._save()
+        with self._lock:
+            now = time.time()
+            to_delete = [
+                k
+                for k, c in self._cache.items()
+                if c.ttl > 0 and now - c.timestamp >= c.ttl
+            ]
+            for k in to_delete:
+                self._cache.pop(k, None)
+            if to_delete:
+                self._save()
 
     def __len__(self) -> int:  # pragma: no cover - trivial
         self._check_reload()
-        return len(self._cache)
+        with self._lock:
+            return len(self._cache)
 
     def stats(self) -> Dict[str, int]:  # pragma: no cover - simple
         """Return cache hit/miss statistics."""
-        return {"hits": self.hits, "misses": self.misses}
+        with self._lock:
+            return {"hits": self.hits, "misses": self.misses}
+
+    def get_many(self, keys: Iterable[str], ttl: float | None = None) -> Dict[str, T]:
+        """Return mapping of keys to cached values, dropping expired ones."""
+        self._check_reload()
+        now = time.time()
+        results: Dict[str, T] = {}
+        expired: list[str] = []
+        with self._lock:
+            for key in keys:
+                item = self._cache.get(key)
+                if not item:
+                    self.misses += 1
+                    continue
+                effective_ttl = item.ttl if ttl is None else min(item.ttl, ttl)
+                if effective_ttl > 0 and now - item.timestamp < effective_ttl:
+                    results[key] = item.value
+                    self.hits += 1
+                else:
+                    expired.append(key)
+                    self.misses += 1
+            for key in expired:
+                self._cache.pop(key, None)
+            if expired:
+                self._save()
+        return results

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -37,3 +37,14 @@ def test_cache_stats(tmp_path):
     assert cache.get("b") is None
     stats = cache.stats()
     assert stats["hits"] == 1 and stats["misses"] == 1
+
+
+def test_cache_get_many(tmp_path):
+    file = tmp_path / "cache.json"
+    cache = CacheManager[int](file)
+    cache.set("a", 1, ttl=1)
+    cache.set("b", 2, ttl=1)
+    result = cache.get_many(["a", "b", "c"])
+    assert result == {"a": 1, "b": 2}
+    stats = cache.stats()
+    assert stats["hits"] >= 2 and stats["misses"] >= 1

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -80,6 +80,11 @@ def test_force_quit_defaults(monkeypatch):
     assert cfg.get("force_quit_on_top") is False
     assert cfg.get("force_quit_adaptive") is True
     assert cfg.get("force_quit_adaptive_detail") is True
+    assert cfg.get("force_quit_conn_interval") == 2.0
+    assert cfg.get("force_quit_file_interval") == 2.0
+    assert cfg.get("force_quit_cache_ttl") == 30.0
+    assert cfg.get("force_quit_conn_global") == 50
+    assert cfg.get("force_quit_file_global") == 50
 
 
 def test_force_quit_persist(monkeypatch):


### PR DESCRIPTION
## Summary
- add tuning options in config for connection/file intervals and cache TTL
- pass new settings to the watcher, sourced from env or config
- avoid restarting background scans unnecessarily by clearing futures
- test default config values for the new parameters
- prefetch connection and file scans when many processes are detected
- reuse global file scan results for detail updates
- fix ProcessWatcher change detection so updates are emitted correctly
- store global connection and file counts with TTL so future cycles reuse them
- **prefetch global scans only when needed**

## Testing
- `python -m flake8 src setup.py tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d841cc220832ba022312ed5ccdf2a