### PR TITLE
Fix ProcessWatcher alert attributes

### DIFF
--- a/src/utils/process_monitor.py
+++ b/src/utils/process_monitor.py
@@ -34,6 +34,10 @@ WARN_CPU_THRESHOLD = float(os.getenv("FORCE_QUIT_WARN_CPU", "40.0"))
 WARN_MEM_THRESHOLD = float(os.getenv("FORCE_QUIT_WARN_MEM", "200.0"))
 WARN_IO_THRESHOLD = float(os.getenv("FORCE_QUIT_WARN_IO", "1.0"))
 
+# Critical thresholds for process classification
+CPU_ALERT_THRESHOLD = float(os.getenv("FORCE_QUIT_CPU_ALERT", "80.0"))
+MEM_ALERT_THRESHOLD = float(os.getenv("FORCE_QUIT_MEM_ALERT", "500.0"))
+
 
 # Trending thresholds and sample window
 TREND_WINDOW = int(os.getenv("FORCE_QUIT_TREND_WINDOW", "5"))
@@ -353,6 +357,16 @@ class ProcessWatcher(threading.Thread):
     ``ratio_window`` controls how many recent change ratios are averaged when
     tuning refresh intervals, smoothing out brief spikes. Processes owned by
     any usernames in ``exclude_users`` are skipped entirely.
+
+    Parameters
+    ----------
+    cpu_alert:
+        CPU usage threshold at which a process is classified as ``critical``.
+        This complements ``warn_cpu`` and allows callers to distinguish between
+        warning and critical states.
+    mem_alert:
+        Memory usage threshold for the ``critical`` level. Processes exceeding
+        this value will be highlighted even if their CPU usage is low.
     """
 
     def __init__(
@@ -393,6 +407,8 @@ class ProcessWatcher(threading.Thread):
         warn_cpu: float = WARN_CPU_THRESHOLD,
         warn_mem: float = WARN_MEM_THRESHOLD,
         warn_io: float = WARN_IO_THRESHOLD,
+        cpu_alert: float = CPU_ALERT_THRESHOLD,
+        mem_alert: float = MEM_ALERT_THRESHOLD,
         ignore_age: float = 1.0,
         change_alpha: float = CHANGE_ALPHA,
         change_ratio: float = CHANGE_RATIO,
@@ -458,6 +474,8 @@ class ProcessWatcher(threading.Thread):
         self.warn_cpu = float(warn_cpu)
         self.warn_mem = float(warn_mem)
         self.warn_io = float(warn_io)
+        self.cpu_alert = float(cpu_alert)
+        self.mem_alert = float(mem_alert)
         self.ignore_age = float(ignore_age)
         self.change_alpha = float(change_alpha)
         self.change_ratio = float(change_ratio)

--- a/src/views/force_quit_dialog.py
+++ b/src/views/force_quit_dialog.py
@@ -446,6 +446,8 @@ class ForceQuitDialog(ctk.CTkToplevel):
             warn_cpu=self.warn_cpu,
             warn_mem=self.warn_mem,
             warn_io=self.warn_io,
+            cpu_alert=self.cpu_alert,
+            mem_alert=self.mem_alert,
             ignore_age=self.ignore_age,
             change_alpha=self.change_alpha,
             change_ratio=self.change_ratio,
@@ -1041,7 +1043,9 @@ class ForceQuitDialog(ctk.CTkToplevel):
         pids: list[int] = []
         for proc in psutil.process_iter(["pid"]):
             try:
-                if len(proc.net_connections(kind="inet")) > threshold:
+                # ``Process.connections`` replaces the deprecated
+                # ``net_connections`` method in recent psutil versions.
+                if len(proc.connections(kind="inet")) > threshold:
                     pids.append(proc.pid)
             except (psutil.NoSuchProcess, psutil.AccessDenied):
                 continue

--- a/tests/test_process_monitor_alert.py
+++ b/tests/test_process_monitor_alert.py
@@ -1,0 +1,18 @@
+from queue import Queue
+from src.utils.process_monitor import ProcessWatcher
+
+
+def test_process_watcher_alert_defaults():
+    q: Queue[tuple[dict[int, object], set[int]]] = Queue()
+    watcher = ProcessWatcher(q)
+    assert watcher.cpu_alert == 80.0
+    assert watcher.mem_alert == 500.0
+    watcher.stop()
+
+
+def test_process_watcher_alert_custom():
+    q: Queue[tuple[dict[int, object], set[int]]] = Queue()
+    watcher = ProcessWatcher(q, cpu_alert=70.0, mem_alert=400.0)
+    assert watcher.cpu_alert == 70.0
+    assert watcher.mem_alert == 400.0
+    watcher.stop()


### PR DESCRIPTION
## Summary
- initialize `cpu_alert` and `mem_alert` in `ProcessWatcher`
- pass alert thresholds from `ForceQuitDialog`
- add unit tests for alert threshold handling
- use environment variables as defaults for critical thresholds
- fix ForceQuitDialog connection check

## Testing
- `pytest -q`
- `python scripts/run_vm_debug.py --list`
- `timeout 5 python scripts/run_vm_debug.py --port 5678`


------
https://chatgpt.com/codex/tasks/task_e_685eb5b8df8c832bb45ad3917f107941