### PR TITLE
Optimize Force Quit CPU monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,50 @@ A modern, feature-rich desktop application built with Python and CustomTkinter.
   that should be ignored entirely by the Force Quit monitor.
   ``FORCE_QUIT_IGNORE_AGE`` skips processes younger than this many seconds so
   short-lived helpers do not clutter the list.
+  ``FORCE_QUIT_IDLE_CPU`` sets the CPU percentage considered idle for adaptive
+  sampling. After a process stays below this for ``FORCE_QUIT_IDLE_CYCLES``
+  refreshes, CPU usage collection is skipped for up to ``FORCE_QUIT_MAX_SKIP``
+  cycles with exponential backoff. Idle processes no longer trigger expensive
+  ``cpu_times`` calls, dramatically reducing monitor overhead.
+  When activity resumes, idle counters reset automatically so metrics remain
+  responsive without manual intervention.
+  ``FORCE_QUIT_IDLE_BASELINE`` controls how quickly per-process idle baselines
+  adapt to recent CPU usage. ``FORCE_QUIT_IDLE_RATIO`` specifies the fraction of
+  the baseline considered idle. Together they let the monitor learn typical
+  process activity and dynamically tune skip thresholds for even lower impact.
+  ``FORCE_QUIT_IDLE_DECAY`` sets the fraction of the skip interval retained when
+  a process becomes active again. Values below ``1`` slowly reduce skipping
+  instead of resetting immediately, smoothing out CPU spikes.
+  ``FORCE_QUIT_IDLE_GLOBAL_ALPHA`` controls how quickly a global idle baseline
+  adapts to observed CPU usage. New processes use this baseline to determine
+  skip thresholds before they accumulate history of their own, improving
+  accuracy when many short-lived helpers appear.
+  ``FORCE_QUIT_IDLE_JITTER`` introduces random jitter when skip intervals
+  increase so multiple processes do not resample in lockstep. Set to ``1`` to
+  disable.
+  ``FORCE_QUIT_IDLE_WINDOW`` controls how many recent CPU samples are averaged
+  when computing idle baselines for each process, smoothing out spikes and
+  improving skip accuracy.
+  ``FORCE_QUIT_IDLE_HYSTERESIS`` adds a margin around the idle threshold so
+  processes must fall below ``(1-h)`` or exceed ``(1+h)`` times the threshold
+  before switching states, preventing rapid flapping.
+  ``FORCE_QUIT_IDLE_REFRESH`` forces a CPU sample if a process hasn't been
+  measured for this many seconds, ensuring long-idle processes still update
+  their baselines.
+  ``FORCE_QUIT_IDLE_SKIP_ALPHA`` controls how strongly idle baselines are
+  updated when CPU sampling is skipped. Higher values adapt faster to long
+  periods of inactivity.
+  ``FORCE_QUIT_IDLE_GRACE`` sets how many initial refresh cycles a new process
+  is always sampled before idle skipping can activate, allowing more accurate
+  baselines.
+  ``FORCE_QUIT_BULK_CPU`` sets how many sampled processes trigger a bulk
+  ``/proc`` scan for CPU times. When the number of active processes exceeds this
+  threshold, the monitor reads all CPU times in one pass to further reduce
+  overhead.
+  ``FORCE_QUIT_BULK_WORKERS`` controls how many threads are used for the bulk
+  scan so large systems can prefetch CPU times in parallel.
+  ``FORCE_QUIT_LOAD_THRESHOLD`` sets the system CPU usage percentage that triggers a temporary pause in monitoring. When exceeded, the watcher skips ``FORCE_QUIT_LOAD_CYCLES`` refreshes to reduce contention.
+  ``FORCE_QUIT_LOAD_CYCLES`` configures how many cycles are skipped each time the threshold is hit. Set the threshold to ``0`` to disable this behaviour.
   ``FORCE_QUIT_TREND_SLOW_RATIO`` and ``FORCE_QUIT_TREND_FAST_RATIO`` adjust how
   aggressively refresh intervals respond to the number of trending processes.
   Set ``FORCE_QUIT_AUTO_KILL`` to ``cpu``, ``mem`` or ``both`` to automatically

--- a/scripts/network_scan.py
+++ b/scripts/network_scan.py
@@ -9,12 +9,10 @@ import sys
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-from src.utils import (
-    PortInfo,
+from src.utils import (  # noqa: E402
     TOP_PORTS,
     async_scan_targets,
     async_scan_targets_list,
-    async_scan_port_list,
     async_filter_active_hosts,
     ports_as_range,
     parse_ports,

--- a/src/utils/vm.py
+++ b/src/utils/vm.py
@@ -47,19 +47,18 @@ def launch_vm_debug(
     backend = prefer or os.environ.get("PREFER_VM", "auto").lower()
     for name in _pick_backend(backend):
         if shutil.which(name):
+            print(f"Launching CoolBox in {name} for debugging...")
+            env = os.environ.copy()
+            env["DEBUG_PORT"] = str(port)
             if name in {"docker", "podman"}:
                 script = root / "scripts" / "run_devcontainer.sh"
-                env = os.environ.copy()
-                env["DEBUG_PORT"] = str(port)
                 subprocess.check_call([str(script), name], env=env)
             else:
                 script = root / "scripts" / "run_vagrant.sh"
-                env = os.environ.copy()
-                env["DEBUG_PORT"] = str(port)
                 subprocess.check_call([str(script)], env=env)
-            break
+            return
     else:
-        # Neither docker nor vagrant available; run locally under debugpy
+        print("No VM backend available; launching locally under debugpy...")
         env = os.environ.copy()
         env["DEBUG_PORT"] = str(port)
         subprocess.check_call([str(root / "scripts" / "run_debug.sh")], env=env)

--- a/tests/test_bulk_cpu_scan.py
+++ b/tests/test_bulk_cpu_scan.py
@@ -1,0 +1,27 @@
+from queue import Queue
+import os
+
+from src.utils.process_monitor import ProcessEntry, ProcessWatcher
+
+
+def test_scan_proc_stat_self() -> None:
+    q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+    watcher = ProcessWatcher(q)
+    try:
+        if not os.path.isdir("/proc"):
+            return
+        res = watcher._scan_proc_stat({os.getpid()})
+        assert os.getpid() in res
+        assert res[os.getpid()] > 0.0
+    finally:
+        watcher.stop()
+
+
+def test_bulk_cpu_threshold_param() -> None:
+    q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+    watcher = ProcessWatcher(q, bulk_cpu_threshold=5, bulk_cpu_workers=2)
+    try:
+        assert watcher.bulk_cpu_threshold == 5
+        assert watcher.bulk_cpu_workers == 2
+    finally:
+        watcher.stop()

--- a/tests/test_idle_cpu_skip.py
+++ b/tests/test_idle_cpu_skip.py
@@ -1,0 +1,503 @@
+from queue import Queue
+import random
+
+from src.utils.process_monitor import ProcessEntry, ProcessWatcher
+
+
+class _FakeProc:
+    def __init__(self, pid: int = 1, step: float = 0.001) -> None:
+        self.pid = pid
+        self._t = 0.0
+        self._step = step
+
+    def cpu_times(self):
+        self._t += self._step
+        return (self._t, 0.0)
+
+
+def test_proc_cpu_time_override() -> None:
+    q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+    watcher = ProcessWatcher(q)
+    watcher._system_time_delta = 1.0
+
+    called: list[int] = []
+
+    def fake_cpu_time(pid: int, proc: _FakeProc, bulk=None) -> float:  # type: ignore[unused-argument]
+        called.append(pid)
+        return 42.0
+
+    watcher._proc_cpu_time = fake_cpu_time  # type: ignore[assignment]
+    proc = _FakeProc()
+    cpu_time, cpu, _ = watcher._maybe_sample_cpu(proc, None, 1.0, 0, 0)
+    assert cpu_time == 42.0
+    assert called == [proc.pid]
+
+
+def test_idle_global_alpha_param() -> None:
+    q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+    watcher = ProcessWatcher(q, idle_global_alpha=0.7)
+    watcher._system_time_delta = 1.0
+    try:
+        assert watcher.idle_global_alpha == 0.7
+    finally:
+        watcher.stop()
+
+
+def test_idle_cpu_skip_logic() -> None:
+    q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+    watcher = ProcessWatcher(q, idle_cpu=1.0, idle_cycles=2, max_skip=4)
+    watcher._cpu_count = 1
+    watcher._system_time_delta = 1.0
+
+    proc = _FakeProc()
+    prev = None
+    ts = 1.0
+
+    cpu_time, cpu, _ = watcher._maybe_sample_cpu(proc, prev, ts, 0, 0)
+    prev = ProcessEntry(
+        pid=proc.pid,
+        name="p",
+        cpu=cpu,
+        mem=0.0,
+        user="u",
+        start=0.0,
+        status="",
+        cpu_time=cpu_time,
+        threads=1,
+        read_bytes=0,
+        write_bytes=0,
+        files=0,
+        conns=0,
+    )
+
+    ts += 1.0
+    cpu_time, cpu, _ = watcher._maybe_sample_cpu(proc, prev, ts, 0, 0)
+    assert watcher._idle_counts[proc.pid] == 1
+    prev.cpu_time = cpu_time
+    prev.cpu = cpu
+
+    ts += 1.0
+    cpu_time, cpu, _ = watcher._maybe_sample_cpu(proc, prev, ts, 0, 0)
+    assert watcher._idle_counts[proc.pid] == 2
+    assert watcher._cpu_skip_intervals[proc.pid] == 2
+    prev.cpu_time = cpu_time
+    prev.cpu = cpu
+
+    # Next call should skip
+    ts += 1.0
+    cpu_time2, cpu2, _ = watcher._maybe_sample_cpu(proc, prev, ts, 0, 0)
+    assert cpu_time2 == prev.cpu_time
+    assert cpu2 == prev.cpu
+    assert watcher._cpu_skip_counts[proc.pid] == 1
+
+    watcher.stop()
+
+
+def test_idle_skip_reset_on_activity() -> None:
+    q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+    watcher = ProcessWatcher(q, idle_cpu=1.0, idle_cycles=2, max_skip=4)
+    watcher._cpu_count = 1
+    watcher._system_time_delta = 1.0
+
+    proc = _FakeProc()
+    prev = None
+    ts = 1.0
+
+    cpu_time, cpu, _ = watcher._maybe_sample_cpu(proc, prev, ts, 0, 0)
+    prev = ProcessEntry(
+        pid=proc.pid,
+        name="p",
+        cpu=cpu,
+        mem=0.0,
+        user="u",
+        start=0.0,
+        status="",
+        cpu_time=cpu_time,
+        threads=1,
+        read_bytes=0,
+        write_bytes=0,
+        files=0,
+        conns=0,
+    )
+
+    # Two idle samples to trigger skipping
+    for _ in range(2):
+        ts += 1.0
+        cpu_time, cpu, _ = watcher._maybe_sample_cpu(proc, prev, ts, 0, 0)
+        prev.cpu_time = cpu_time
+        prev.cpu = cpu
+
+    assert watcher._cpu_skip_intervals[proc.pid] == 2
+
+    # Simulate activity after skip cycle completes
+    proc._step = 0.02
+    for _ in range(watcher._cpu_skip_intervals[proc.pid] + 1):
+        ts += 1.0
+        cpu_time, cpu, _ = watcher._maybe_sample_cpu(proc, prev, ts, 0, 0)
+        proc.cpu_times()
+    assert cpu > 0.5
+    assert watcher._cpu_skip_intervals[proc.pid] == 1
+    assert watcher._idle_counts[proc.pid] == 0
+
+    watcher.stop()
+
+
+def test_skip_interval_decay() -> None:
+    q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+    watcher = ProcessWatcher(
+        q,
+        idle_cpu=1.0,
+        idle_cycles=2,
+        max_skip=4,
+        idle_decay=0.5,
+    )
+    watcher._cpu_count = 1
+    watcher._system_time_delta = 1.0
+
+    proc = _FakeProc()
+    prev = None
+    ts = 1.0
+
+    cpu_time, cpu, _ = watcher._maybe_sample_cpu(proc, prev, ts, 0, 0)
+    prev = ProcessEntry(
+        pid=proc.pid,
+        name="p",
+        cpu=cpu,
+        mem=0.0,
+        user="u",
+        start=0.0,
+        status="",
+        cpu_time=cpu_time,
+        threads=1,
+        read_bytes=0,
+        write_bytes=0,
+        files=0,
+        conns=0,
+    )
+
+    for _ in range(2):
+        ts += 1.0
+        cpu_time, cpu, _ = watcher._maybe_sample_cpu(proc, prev, ts, 0, 0)
+        prev.cpu_time = cpu_time
+        prev.cpu = cpu
+
+    assert watcher._cpu_skip_intervals[proc.pid] == 2
+
+    proc._step = 0.02
+    for _ in range(watcher._cpu_skip_intervals[proc.pid] + 1):
+        ts += 1.0
+        cpu_time, cpu, _ = watcher._maybe_sample_cpu(proc, prev, ts, 0, 0)
+        proc.cpu_times()
+    assert cpu > 0.5
+    assert watcher._cpu_skip_intervals[proc.pid] == 1
+
+    watcher.stop()
+
+
+def test_global_baseline_used_for_new_process() -> None:
+    q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+    watcher = ProcessWatcher(q, idle_cpu=1.0, idle_cycles=1, max_skip=3)
+    watcher._cpu_count = 1
+    watcher._system_time_delta = 1.0
+
+    proc_a = _FakeProc(pid=1, step=0.02)
+    proc_b = _FakeProc(pid=2, step=0.02)
+
+    ts = 1.0
+    cpu_time, cpu, _ = watcher._maybe_sample_cpu(proc_a, None, ts, 0, 0)
+    # Second process should get baseline close to first sample
+    ts += 1.0
+    cpu_time_b, cpu_b, _ = watcher._maybe_sample_cpu(proc_b, None, ts, 0, 0)
+    assert abs(watcher._idle_baseline[proc_b.pid] - watcher._global_idle_baseline) < 1e-6
+    watcher.stop()
+
+
+def test_exponential_backoff() -> None:
+    q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+    watcher = ProcessWatcher(q, idle_cpu=1.0, idle_cycles=1, max_skip=8)
+    watcher._cpu_count = 1
+    watcher._system_time_delta = 1.0
+
+    proc = _FakeProc()
+    prev = None
+    ts = 1.0
+
+    cpu_time, cpu, _ = watcher._maybe_sample_cpu(proc, prev, ts, 0, 0)
+    prev = ProcessEntry(
+        pid=proc.pid,
+        name="p",
+        cpu=cpu,
+        mem=0.0,
+        user="u",
+        start=0.0,
+        status="",
+        cpu_time=cpu_time,
+        threads=1,
+        read_bytes=0,
+        write_bytes=0,
+        files=0,
+        conns=0,
+    )
+
+    # first idle cycle triggers skip interval 2
+    ts += 1.0
+    cpu_time, cpu, _ = watcher._maybe_sample_cpu(proc, prev, ts, 0, 0)
+    prev.cpu_time = cpu_time
+    prev.cpu = cpu
+    assert watcher._cpu_skip_intervals[proc.pid] == 2
+
+    # run through skip interval then sample again to double to 4
+    for _ in range(watcher._cpu_skip_intervals[proc.pid] + 1):
+        ts += 1.0
+        cpu_time, cpu, _ = watcher._maybe_sample_cpu(proc, prev, ts, 0, 0)
+        prev.cpu_time = cpu_time
+        prev.cpu = cpu
+    assert watcher._cpu_skip_intervals[proc.pid] == 4
+
+    # run through next interval to reach 8 (max_skip)
+    for _ in range(watcher._cpu_skip_intervals[proc.pid] + 1):
+        ts += 1.0
+        cpu_time, cpu, _ = watcher._maybe_sample_cpu(proc, prev, ts, 0, 0)
+        prev.cpu_time = cpu_time
+        prev.cpu = cpu
+    assert watcher._cpu_skip_intervals[proc.pid] == 8
+
+    watcher.stop()
+
+
+def test_idle_skip_jitter(monkeypatch) -> None:
+    q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+    watcher = ProcessWatcher(
+        q,
+        idle_cpu=1.0,
+        idle_cycles=1,
+        max_skip=8,
+        idle_jitter=2.0,
+    )
+    watcher._cpu_count = 1
+    watcher._system_time_delta = 1.0
+
+    monkeypatch.setattr(random, "uniform", lambda a, b: 1.5)
+
+    proc = _FakeProc()
+    prev = None
+    ts = 1.0
+
+    cpu_time, cpu, _ = watcher._maybe_sample_cpu(proc, prev, ts, 0, 0)
+    prev = ProcessEntry(
+        pid=proc.pid,
+        name="p",
+        cpu=cpu,
+        mem=0.0,
+        user="u",
+        start=0.0,
+        status="",
+        cpu_time=cpu_time,
+        threads=1,
+        read_bytes=0,
+        write_bytes=0,
+        files=0,
+        conns=0,
+    )
+
+    ts += 1.0
+    cpu_time, cpu, _ = watcher._maybe_sample_cpu(proc, prev, ts, 0, 0)
+    assert watcher._cpu_skip_intervals[proc.pid] == int(1 * 2 * 1.5)
+
+    watcher.stop()
+
+
+def test_idle_window_baseline() -> None:
+    q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+    watcher = ProcessWatcher(
+        q,
+        idle_window=3,
+        idle_baseline=1.0,
+        idle_global_alpha=1.0,
+    )
+    watcher._cpu_count = 1
+    watcher._system_time_delta = 1.0
+
+    proc = _FakeProc(step=0.02)
+    prev = None
+    ts = 1.0
+
+    cpu_time, cpu, _ = watcher._maybe_sample_cpu(proc, prev, ts, 0, 0)
+    prev = ProcessEntry(
+        pid=proc.pid,
+        name="p",
+        cpu=cpu,
+        mem=0.0,
+        user="u",
+        start=0.0,
+        status="",
+        cpu_time=cpu_time,
+        threads=1,
+        read_bytes=0,
+        write_bytes=0,
+        files=0,
+        conns=0,
+    )
+    assert abs(watcher._idle_baseline[proc.pid] - cpu) < 0.01
+
+    proc._step = 0.06
+    ts += 1.0
+    cpu_time, cpu2, _ = watcher._maybe_sample_cpu(proc, prev, ts, 0, 0)
+    prev.cpu_time = cpu_time
+    prev.cpu = cpu2
+
+    proc._step = 0.04
+    ts += 1.0
+    cpu_time, cpu3, _ = watcher._maybe_sample_cpu(proc, prev, ts, 0, 0)
+
+    avg = (cpu + cpu2 + cpu3) / 3
+    assert abs(watcher._idle_baseline[proc.pid] - avg) < 0.01
+
+    watcher.stop()
+
+
+def test_idle_refresh_forces_sample() -> None:
+    q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+    watcher = ProcessWatcher(
+        q,
+        idle_cpu=1.0,
+        idle_cycles=1,
+        max_skip=8,
+        idle_refresh=2.5,
+        idle_jitter=1.0,
+    )
+    watcher._cpu_count = 1
+    watcher._system_time_delta = 1.0
+
+    proc = _FakeProc()
+    prev = None
+    ts = 1.0
+
+    cpu_time, cpu, _ = watcher._maybe_sample_cpu(proc, prev, ts, 0, 0)
+    prev = ProcessEntry(
+        pid=proc.pid,
+        name="p",
+        cpu=cpu,
+        mem=0.0,
+        user="u",
+        start=0.0,
+        status="",
+        cpu_time=cpu_time,
+        threads=1,
+        read_bytes=0,
+        write_bytes=0,
+        files=0,
+        conns=0,
+    )
+
+    ts += 1.0
+    cpu_time, cpu, _ = watcher._maybe_sample_cpu(proc, prev, ts, 0, 0)
+    prev.cpu_time = cpu_time
+    prev.cpu = cpu
+
+    # skip twice while within idle_refresh
+    for _ in range(2):
+        ts += 1.0
+        cpu_time2, cpu2, _ = watcher._maybe_sample_cpu(proc, prev, ts, 0, 0)
+        assert cpu_time2 == prev.cpu_time
+        assert cpu2 == prev.cpu
+
+    # exceeded idle_refresh, sampling should resume even though skip interval
+    ts += 1.0
+    cpu_time3, cpu3, _ = watcher._maybe_sample_cpu(proc, prev, ts, 0, 0)
+    assert cpu_time3 != prev.cpu_time
+    assert watcher._cpu_skip_counts[proc.pid] == 0
+
+    watcher.stop()
+
+
+def test_idle_baseline_updates_during_skip() -> None:
+    q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+    watcher = ProcessWatcher(
+        q,
+        idle_cpu=1.0,
+        idle_cycles=1,
+        max_skip=4,
+        idle_skip_alpha=1.0,
+        idle_window=3,
+    )
+    watcher._cpu_count = 1
+    watcher._system_time_delta = 1.0
+
+    proc = _FakeProc()
+    ts = 1.0
+    cpu_time, cpu, _ = watcher._maybe_sample_cpu(proc, None, ts, 0, 0)
+    prev = ProcessEntry(
+        pid=proc.pid,
+        name="p",
+        cpu=cpu,
+        mem=0.0,
+        user="u",
+        start=0.0,
+        status="",
+        cpu_time=cpu_time,
+        threads=1,
+        read_bytes=0,
+        write_bytes=0,
+        files=0,
+        conns=0,
+    )
+
+    ts += 1.0
+    cpu_time, cpu, _ = watcher._maybe_sample_cpu(proc, prev, ts, 0, 0)
+    prev.cpu_time = cpu_time
+    prev.cpu = cpu
+    hist_len = len(watcher._idle_history[proc.pid])
+
+    ts += 1.0
+    cpu_time2, cpu2, _ = watcher._maybe_sample_cpu(proc, prev, ts, 0, 0)
+    assert cpu_time2 == prev.cpu_time
+    assert len(watcher._idle_history[proc.pid]) == hist_len + 1
+
+    watcher.stop()
+
+
+def test_idle_grace_delay() -> None:
+    q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+    watcher = ProcessWatcher(q, idle_cpu=1.0, idle_cycles=1, idle_grace=2, max_skip=4)
+    watcher._cpu_count = 1
+    watcher._system_time_delta = 1.0
+
+    proc = _FakeProc()
+    prev = None
+    ts = 1.0
+
+    cpu_time, cpu, _ = watcher._maybe_sample_cpu(proc, prev, ts, 0, 0)
+    prev = ProcessEntry(
+        pid=proc.pid,
+        name="p",
+        cpu=cpu,
+        mem=0.0,
+        user="u",
+        start=0.0,
+        status="",
+        cpu_time=cpu_time,
+        threads=1,
+        read_bytes=0,
+        write_bytes=0,
+        files=0,
+        conns=0,
+    )
+
+    ts += 1.0
+    cpu_time, cpu, _ = watcher._maybe_sample_cpu(proc, prev, ts, 0, 0)
+    prev.cpu_time = cpu_time
+    prev.cpu = cpu
+
+    # still within grace period, skip interval should remain 1
+    assert watcher._cpu_skip_intervals.get(proc.pid, 1) == 1
+
+    ts += 1.0
+    cpu_time, cpu, _ = watcher._maybe_sample_cpu(proc, prev, ts, 0, 0)
+    prev.cpu_time = cpu_time
+    prev.cpu = cpu
+
+    assert watcher._idle_counts[proc.pid] == 1
+    assert watcher._cpu_skip_intervals[proc.pid] == 2
+
+    watcher.stop()

--- a/tests/test_load_skip.py
+++ b/tests/test_load_skip.py
@@ -1,0 +1,37 @@
+from queue import Queue
+import psutil
+
+from src.utils.process_monitor import ProcessWatcher
+
+
+def test_load_skip_params() -> None:
+    q: Queue[tuple[dict[int, object], set[int]]] = Queue()
+    watcher = ProcessWatcher(q, load_threshold=50.0, load_cycles=3)
+    try:
+        assert watcher.load_threshold == 50.0
+        assert watcher.load_cycles == 3
+    finally:
+        watcher.stop()
+
+
+def test_should_pause_for_load(monkeypatch) -> None:
+    q: Queue[tuple[dict[int, object], set[int]]] = Queue()
+    watcher = ProcessWatcher(q, load_threshold=10.0, load_cycles=2)
+    called = []
+
+    def fake_cpu_percent(interval=None):
+        called.append(True)
+        return 20.0
+
+    monkeypatch.setattr(psutil, "cpu_percent", fake_cpu_percent)
+    try:
+        assert watcher._should_pause_for_load() is True
+        # next call should use remaining skip cycle without calling cpu_percent
+        called.clear()
+        assert watcher._should_pause_for_load() is True
+        assert not called
+        # load below threshold ends skipping
+        monkeypatch.setattr(psutil, "cpu_percent", lambda interval=None: 1.0)
+        assert watcher._should_pause_for_load() is False
+    finally:
+        watcher.stop()


### PR DESCRIPTION
## Summary
- add incremental MovingAverage to speed idle history updates
- use MovingAverage when computing idle baselines for processes and globally
- keep idle baseline state when activity resumes
- compute CPU usage relative to system time for consistency
- show which VM backend launches during debug startup

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ec3b29720832b9f3614f04ad5c20a