### PR TITLE
Fix system info option menu and gauge colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A modern, feature-rich desktop application built with Python and CustomTkinter.
   `Ctrl+Q` shortcut.
 - **Cross-Platform**: Works on Windows, macOS, and Linux
 - **Expanded Utilities**: File and directory copy/move helpers, an enhanced file manager, a threaded port scanner, a flexible hash calculator with optional disk caching, a multi-threaded duplicate finder that persists file hashes for lightning fast rescans, a screenshot capture tool, and a built-in process manager that auto-refreshes and sorts by CPU usage. The system info viewer now reports CPU cores and memory usage.
+- **Dynamic Gauges**: Resource gauges automatically change color from green to yellow to red as usage increases for quick visual feedback.
   It also includes an advanced Force Quit utility with a searchable process
   list, automatic refresh, sort options, and multi-select termination. It can
   kill processes by name, command line pattern, port, host, open file, executable path
@@ -267,10 +268,13 @@ To automatically spin up a Docker/Podman or Vagrant environment and attach a
 debugger, run:
 
 ```bash
-python main.py --vm-debug
+python main.py --vm-debug --vm-prefer docker --open-code --debug-port 5679
 ```
-This calls ``launch_vm_debug`` which tries Docker or Podman first, then Vagrant,
-falling back to ``run_debug.sh`` if neither is available.
+This calls ``launch_vm_debug`` which tries Docker, Podman or Vagrant depending
+on ``--vm-prefer`` (or auto-detection when omitted). ``--open-code`` opens
+Visual Studio Code once the environment starts and ``--debug-port`` sets the
+debug server port. If no backend is available the app runs locally under
+``debugpy``.
 
 ### Network Scanner CLI
 

--- a/main.py
+++ b/main.py
@@ -27,17 +27,32 @@ def main() -> None:
         "--debug-port",
         type=int,
         default=5678,
-        help="Port for debugpy to listen on (default: 5678)",
+        help="Port for debugpy or --vm-debug listener (default: 5678)",
     )
     parser.add_argument(
         "--vm-debug",
         action="store_true",
         help="Launch inside a VM or container and wait for debugger",
     )
+    parser.add_argument(
+        "--vm-prefer",
+        choices=["docker", "vagrant", "podman", "auto"],
+        default="auto",
+        help="Preferred VM backend for --vm-debug",
+    )
+    parser.add_argument(
+        "--open-code",
+        action="store_true",
+        help="Open VS Code when launching --vm-debug",
+    )
     args = parser.parse_args()
 
     if args.vm_debug:
-        launch_vm_debug()
+        launch_vm_debug(
+            prefer=None if args.vm_prefer == "auto" else args.vm_prefer,
+            open_code=args.open_code,
+            port=args.debug_port,
+        )
         return
 
     if args.debug:

--- a/src/components/bar_chart.py
+++ b/src/components/bar_chart.py
@@ -25,4 +25,3 @@ class BarChart(ctk.CTkFrame):
         self._bars = self._ax.bar(range(len(values)), values, color="#3B8ED0")
         self._ax.grid(True, axis="y", linestyle="--", alpha=0.5)
         self._canvas.draw_idle()
-

--- a/src/components/gauge.py
+++ b/src/components/gauge.py
@@ -5,14 +5,30 @@ import customtkinter as ctk
 class Gauge(ctk.CTkFrame):
     """Circular gauge widget displaying a percentage value."""
 
-    def __init__(self, master, title: str, *, size: int = 120, thickness: int = 12, color: str = "#3B8ED0") -> None:
+    def __init__(
+        self,
+        master,
+        title: str,
+        *,
+        size: int = 120,
+        thickness: int = 12,
+        color: str = "#3B8ED0",
+        auto_color: bool = False,
+    ) -> None:
         super().__init__(master, width=size, height=size)
         self._size = size
         self._thickness = thickness
         self._color = color
+        self._auto_color = auto_color
         self._value = 0.0
 
-        self.canvas = tk.Canvas(self, width=size, height=size, highlightthickness=0, bg=self.cget("fg_color"))
+        self.canvas = tk.Canvas(
+            self,
+            width=size,
+            height=size,
+            highlightthickness=0,
+            bg=self._apply_appearance_mode(self.cget("fg_color")),
+        )
         self.canvas.pack()
         pad = thickness // 2 + 2
         self.arc = self.canvas.create_arc(
@@ -35,12 +51,19 @@ class Gauge(ctk.CTkFrame):
         """Set gauge value between 0 and 100 or display N/A."""
         if value is None:
             self._value = 0.0
-            self.canvas.itemconfig(self.arc, extent=0)
+            self.canvas.itemconfig(self.arc, extent=0, outline=self._color)
             self.label.configure(text="N/A")
             return
         value = max(0.0, min(100.0, float(value)))
         self._value = value
         extent = -value / 100.0 * 360.0
-        self.canvas.itemconfig(self.arc, extent=extent)
+        color = self._color
+        if self._auto_color:
+            if value >= 90:
+                color = "#d9534f"  # red
+            elif value >= 70:
+                color = "#f0ad4e"  # orange
+            else:
+                color = "#5cb85c"  # green
+        self.canvas.itemconfig(self.arc, extent=extent, outline=color)
         self.label.configure(text=f"{value:.0f}%")
-

--- a/src/utils/network.py
+++ b/src/utils/network.py
@@ -30,6 +30,12 @@ _CACHE_FILE = Path(
 # Cache manager instance used by both sync and async scanners
 PORT_CACHE: CacheManager[List[int]] = CacheManager[List[int]](_CACHE_FILE)
 
+
+def _flags_key(*, with_services: bool, with_banner: bool, with_latency: bool) -> str:
+    """Return a short string representing option flags for cache keys."""
+    return f"{int(with_services)}{int(with_banner)}{int(with_latency)}"
+
+
 # In-memory cache for host resolution results
 _HOST_CACHE: Dict[tuple[str, int | None], tuple[str, int, float]] = {}
 _HOST_CACHE_TTL = float(os.environ.get("HOST_CACHE_TTL", 300))
@@ -485,7 +491,7 @@ def scan_ports(
     force IPv4 or IPv6 scanning. ``timeout`` controls the connection timeout
     in seconds.
     """
-    cache_key = f"{host}|{start}|{end}"
+    cache_key = f"{host}|{start}|{end}|{_flags_key(with_services=with_services, with_banner=with_banner, with_latency=with_latency)}"
     if cache_ttl > 0:
         PORT_CACHE.prune()
         cached = PORT_CACHE.get(cache_key, cache_ttl)
@@ -559,7 +565,7 @@ async def async_scan_ports(
     ``socket.AF_INET6``. ``timeout`` sets the connection timeout in seconds.
     """
 
-    cache_key = f"{host}|{start}|{end}"
+    cache_key = f"{host}|{start}|{end}|{_flags_key(with_services=with_services, with_banner=with_banner, with_latency=with_latency)}"
     if cache_ttl > 0:
         PORT_CACHE.prune()
         cached = PORT_CACHE.get(cache_key, cache_ttl)
@@ -742,7 +748,7 @@ def scan_port_list(
             progress(None)
         return {}
 
-    key = f"{host}|{','.join(map(str, port_list))}"
+    key = f"{host}|{','.join(map(str, port_list))}|{_flags_key(with_services=with_services, with_banner=with_banner, with_latency=with_latency)}"
     if cache_ttl > 0:
         PORT_CACHE.prune()
         cached = PORT_CACHE.get(key, cache_ttl)
@@ -814,7 +820,7 @@ async def async_scan_port_list(
             progress(None)
         return {}
 
-    key = f"{host}|{','.join(map(str, port_list))}"
+    key = f"{host}|{','.join(map(str, port_list))}|{_flags_key(with_services=with_services, with_banner=with_banner, with_latency=with_latency)}"
     if cache_ttl > 0:
         PORT_CACHE.prune()
         cached = PORT_CACHE.get(key, cache_ttl)

--- a/src/views/system_info_dialog.py
+++ b/src/views/system_info_dialog.py
@@ -43,7 +43,7 @@ class SystemInfoDialog(ctk.CTkToplevel):
         ctk.CTkOptionMenu(
             toolbar,
             variable=self.interval_var,
-            values=[1, 2, 5, 10],
+            values=["1", "2", "5", "10"],
             command=lambda _: self._restart_loop(),
             width=80,
         ).pack(side="right", padx=5)
@@ -66,12 +66,12 @@ class SystemInfoDialog(ctk.CTkToplevel):
         # Gauges and charts
         gauge_frame = ctk.CTkFrame(self.perf_tab, fg_color="transparent")
         gauge_frame.pack(fill="x")
-        self.cpu_gauge = Gauge(gauge_frame, "CPU")
-        self.mem_gauge = Gauge(gauge_frame, "Memory", color="#2386c8")
-        self.disk_gauge = Gauge(gauge_frame, "Disk", color="#dbb73a")
-        self.temp_gauge = Gauge(gauge_frame, "Temp", color="#d9534f")
-        self.batt_gauge = Gauge(gauge_frame, "Battery", color="#5cb85c")
-        self.net_gauge = Gauge(gauge_frame, "Network", color="#8e44ad")
+        self.cpu_gauge = Gauge(gauge_frame, "CPU", auto_color=True)
+        self.mem_gauge = Gauge(gauge_frame, "Memory", color="#2386c8", auto_color=True)
+        self.disk_gauge = Gauge(gauge_frame, "Disk", color="#dbb73a", auto_color=True)
+        self.temp_gauge = Gauge(gauge_frame, "Temp", color="#d9534f", auto_color=True)
+        self.batt_gauge = Gauge(gauge_frame, "Battery", color="#5cb85c", auto_color=True)
+        self.net_gauge = Gauge(gauge_frame, "Network", color="#8e44ad", auto_color=True)
         self.cpu_gauge.grid(row=0, column=0, padx=10, pady=10)
         self.mem_gauge.grid(row=0, column=1, padx=10, pady=10)
         self.disk_gauge.grid(row=0, column=2, padx=10, pady=10)


### PR DESCRIPTION
## Summary
- fix CTkOptionMenu values to avoid integer string issue
- include option flags in network scan cache keys to prevent stale results
- add helper for cache key flags
- set gauge background using appearance mode color
- add automatic gauge color changes and CLI flags for VM debug

## Testing
- `pytest -q`
- `python main.py --vm-debug --vm-prefer auto --debug-port 5679 --open-code` *(fails waiting for debugger; script runs)*

------
https://chatgpt.com/codex/tasks/task_e_685f4252be40832b8490c39bbb778baf