### PR TITLE
Fix CTkFrame canvas conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,9 @@ Docker environments.  You may also use ``./scripts/run_vm_debug.sh`` or
 ``python scripts/run_vm_debug.py`` (``.\scripts\run_vm_debug.ps1`` on Windows) which choose Docker/Podman or Vagrant
 depending on what is installed. If neither is present, it falls back to
 ``run_debug.sh`` so you can still debug locally.
+When this fallback occurs the application waits for a debugger to attach on
+``DEBUG_PORT`` (default ``5678``). Run ``python scripts/run_vm_debug.py --list``
+to verify whether Docker, Podman or Vagrant are available on your system.
 
 ### Debugging in a Vagrant VM
 

--- a/src/components/bar_chart.py
+++ b/src/components/bar_chart.py
@@ -6,9 +6,29 @@ from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 class BarChart(ctk.CTkFrame):
     """Simple vertical bar chart for displaying lists of values."""
 
-    def __init__(self, master, title: str, *, bar_color: str = "#3B8ED0") -> None:
+    def __init__(
+        self,
+        master,
+        title: str,
+        *,
+        bar_color: str = "#3B8ED0",
+        size: tuple[float, float] = (4, 2),
+    ) -> None:
+        """Create a new bar chart widget.
+
+        Parameters
+        ----------
+        master:
+            Parent tkinter widget.
+        title:
+            Title displayed above the chart.
+        bar_color:
+            Initial color for the bars.
+        size:
+            Matplotlib figure size as ``(width, height)`` in inches.
+        """
         super().__init__(master)
-        self._fig = Figure(figsize=(4, 2), dpi=100)
+        self._fig = Figure(figsize=size, dpi=100)
         self._ax = self._fig.add_subplot(111)
         self._ax.set_title(title)
         self._ax.set_ylim(0, 100)
@@ -17,11 +37,27 @@ class BarChart(ctk.CTkFrame):
         canvas = FigureCanvasTkAgg(self._fig, master=self)
         canvas.draw()
         canvas.get_tk_widget().pack(fill="both", expand=True)
-        self._canvas = canvas
+        # store the matplotlib canvas separately to avoid clashing with
+        # CTkFrame's internal canvas attribute
+        self._mpl_canvas = canvas
 
     def set_values(self, values: list[float]) -> None:
         self._ax.cla()
         self._ax.set_ylim(0, 100)
         self._bars = self._ax.bar(range(len(values)), values, color="#3B8ED0")
         self._ax.grid(True, axis="y", linestyle="--", alpha=0.5)
-        self._canvas.draw_idle()
+        self._mpl_canvas.draw_idle()
+
+    def set_bar_color(self, color: str) -> None:
+        """Change the bar color."""
+        for bar in self._bars:
+            bar.set_color(color)
+        self._mpl_canvas.draw_idle()
+
+    def clear(self) -> None:
+        """Remove all bars from the chart."""
+        self._ax.cla()
+        self._ax.set_ylim(0, 100)
+        self._bars = self._ax.bar([], [], color="#3B8ED0")
+        self._ax.grid(True, axis="y", linestyle="--", alpha=0.5)
+        self._mpl_canvas.draw_idle()

--- a/src/components/charts.py
+++ b/src/components/charts.py
@@ -6,9 +6,23 @@ from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 class LineChart(ctk.CTkFrame):
     """Simple line chart widget with matplotlib."""
 
-    def __init__(self, master, title: str, color: str = "#1f6aa5") -> None:
+    def __init__(self, master, title: str, color: str = "#1f6aa5", *,
+                 size: tuple[float, float] = (4, 2)) -> None:
+        """Create a new line chart widget.
+
+        Parameters
+        ----------
+        master:
+            Parent tkinter widget.
+        title:
+            Chart title displayed above the plot.
+        color:
+            Initial line color.
+        size:
+            Matplotlib figure size as ``(width, height)`` in inches.
+        """
         super().__init__(master)
-        self._fig = Figure(figsize=(4, 2), dpi=100)
+        self._fig = Figure(figsize=size, dpi=100)
         self._ax = self._fig.add_subplot(111)
         self._ax.set_title(title)
         self._ax.set_ylim(0, 100)
@@ -20,7 +34,9 @@ class LineChart(ctk.CTkFrame):
         canvas = FigureCanvasTkAgg(self._fig, master=self)
         canvas.draw()
         canvas.get_tk_widget().pack(fill="both", expand=True)
-        self._canvas = canvas
+        # keep a reference to the matplotlib canvas without interfering with
+        # CTkFrame's internal `_canvas` attribute
+        self._mpl_canvas = canvas
 
     def add_point(self, value: float) -> None:
         self._data.append(value)
@@ -28,4 +44,16 @@ class LineChart(ctk.CTkFrame):
             self._data.pop(0)
         self._line.set_data(range(len(self._data)), self._data)
         self._ax.set_xlim(0, max(60, len(self._data)))
-        self._canvas.draw_idle()
+        self._mpl_canvas.draw_idle()
+
+    def set_color(self, color: str) -> None:
+        """Update the line color."""
+        self._line.set_color(color)
+        self._mpl_canvas.draw_idle()
+
+    def clear(self) -> None:
+        """Remove all data points from the chart."""
+        self._data.clear()
+        self._line.set_data([], [])
+        self._ax.set_xlim(0, 60)
+        self._mpl_canvas.draw_idle()

--- a/src/views/system_info_dialog.py
+++ b/src/views/system_info_dialog.py
@@ -106,7 +106,7 @@ class SystemInfoDialog(ctk.CTkToplevel):
         self.disk_read_chart.pack(fill="both", expand=True, pady=5)
         self.disk_write_chart = LineChart(chart_frame, "Disk Write", "#f28e2b")
         self.disk_write_chart.pack(fill="both", expand=True, pady=(0, 5))
-        NavigationToolbar2Tk(self.cpu_chart._canvas, chart_frame).pack(
+        NavigationToolbar2Tk(self.cpu_chart._mpl_canvas, chart_frame).pack(
             side="bottom", fill="x"
         )
 

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -1,0 +1,35 @@
+import os
+import customtkinter as ctk
+import pytest
+
+from src.components import LineChart, BarChart
+
+
+@pytest.mark.skipif(os.environ.get("DISPLAY") is None, reason="No display available")
+def test_line_chart_separate_canvas():
+    root = ctk.CTk()
+    chart = LineChart(root, "CPU")
+    chart.pack()
+    root.update_idletasks()
+    # CTkFrame retains its internal canvas
+    assert hasattr(chart, "_canvas")
+    assert chart._canvas.winfo_exists()
+    # Matplotlib canvas stored separately
+    assert hasattr(chart, "_mpl_canvas")
+    assert chart._mpl_canvas.get_tk_widget().winfo_exists() == 1
+    chart.destroy()
+    root.destroy()
+
+
+@pytest.mark.skipif(os.environ.get("DISPLAY") is None, reason="No display available")
+def test_bar_chart_separate_canvas():
+    root = ctk.CTk()
+    chart = BarChart(root, "Per Core")
+    chart.pack()
+    root.update_idletasks()
+    assert hasattr(chart, "_canvas")
+    assert chart._canvas.winfo_exists()
+    assert hasattr(chart, "_mpl_canvas")
+    assert chart._mpl_canvas.get_tk_widget().winfo_exists() == 1
+    chart.destroy()
+    root.destroy()


### PR DESCRIPTION
## Summary
- keep Matplotlib canvas separate from CTkFrame internal canvas in `LineChart`
- store Matplotlib canvas separately in `BarChart`
- fix toolbar reference after canvas rename
- expose figure size, color updates, and clear methods in chart widgets
- add tests ensuring chart widgets retain internal canvas
- document debug VM fallback

## Testing
- `pytest -q`
- `python scripts/run_vm_debug.py --list`


------
https://chatgpt.com/codex/tasks/task_e_685fee7859cc832ba5915f95c7ca58b7