### PR TITLE
Add accent color picker in Quick Settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ A modern, feature-rich desktop application built with Python and CustomTkinter.
   menu bar now includes recent files, a Quick Settings dialog and a fullscreen
   toggle. Quick Settings can also be launched from the toolbar or with the
   `Ctrl+Q` shortcut.
+- **Unified Styling**: All views and dialogs inherit from shared base classes
+  so fonts and accent colors update instantly when settings change.
 - **Cross-Platform**: Works on Windows, macOS, and Linux
 - **Expanded Utilities**: File and directory copy/move helpers, an enhanced file manager, a threaded port scanner, a flexible hash calculator with optional disk caching, a multi-threaded duplicate finder that persists file hashes for lightning fast rescans, a screenshot capture tool, and a built-in process manager that auto-refreshes and sorts by CPU usage. The system info viewer now reports CPU cores and memory usage.
 - **Dynamic Gauges**: Resource gauges automatically change color from green to yellow to red as usage increases for quick visual feedback.

--- a/src/components/menubar.py
+++ b/src/components/menubar.py
@@ -10,17 +10,20 @@ class MenuBar:
 
     def __init__(self, window: ctk.CTk, app):
         self.app = app
-        self.menu = tk.Menu(window)
+        size = int(app.config.get("font_size", 14))
+        self.font = ctk.CTkFont(size=size)
+        self.menu = tk.Menu(window, font=self.font)
         self._build_menus()
         window.config(menu=self.menu)
 
     # ------------------------------------------------------------------
     def _build_menus(self) -> None:
-        file_menu = tk.Menu(self.menu, tearoff=0)
+        self.menus: list[tk.Menu] = []
+        file_menu = tk.Menu(self.menu, tearoff=0, font=self.font)
         file_menu.add_command(label="Open", command=self._open)
         file_menu.add_command(label="Save", command=self._save)
 
-        self.recent_menu = tk.Menu(file_menu, tearoff=0)
+        self.recent_menu = tk.Menu(file_menu, tearoff=0, font=self.font)
         file_menu.add_cascade(label="Open Recent", menu=self.recent_menu)
         self.update_recent_files()
 
@@ -32,8 +35,9 @@ class MenuBar:
         file_menu.add_separator()
         file_menu.add_command(label="Exit", command=self.app._on_closing)
         self.menu.add_cascade(label="File", menu=file_menu)
+        self.menus.append(file_menu)
 
-        view_menu = tk.Menu(self.menu, tearoff=0)
+        view_menu = tk.Menu(self.menu, tearoff=0, font=self.font)
         self.toolbar_var = tk.BooleanVar(
             value=self.app.config.get("show_toolbar", True)
         )
@@ -54,10 +58,12 @@ class MenuBar:
             label="Full Screen", variable=self.fullscreen_var, command=self._toggle_fullscreen
         )
         self.menu.add_cascade(label="View", menu=view_menu)
+        self.menus.append(view_menu)
 
-        help_menu = tk.Menu(self.menu, tearoff=0)
+        help_menu = tk.Menu(self.menu, tearoff=0, font=self.font)
         help_menu.add_command(label="About", command=lambda: self.app.switch_view("about"))
         self.menu.add_cascade(label="Help", menu=help_menu)
+        self.menus.append(help_menu)
 
     # ------------------------------------------------------------------
     def _open_quick_settings(self) -> None:
@@ -117,3 +123,19 @@ class MenuBar:
     def _toggle_fullscreen(self) -> None:
         self.app.toggle_fullscreen()
         self.fullscreen_var.set(self.app.window.attributes("-fullscreen"))
+
+    def refresh_fonts(self) -> None:
+        """Update menu fonts from the current configuration."""
+        size = int(self.app.config.get("font_size", 14))
+        self.font.configure(size=size)
+        self.menu.configure(font=self.font)
+        for menu in self.menus:
+            menu.configure(font=self.font)
+        self.update_recent_files()
+
+    def refresh_theme(self) -> None:
+        """Refresh menu highlight colors from the current theme."""
+        accent = self.app.theme.get_theme().get("accent_color", "#1faaff")
+        self.menu.configure(activebackground=accent, activeforeground="white")
+        for menu in self.menus:
+            menu.configure(activebackground=accent, activeforeground="white")

--- a/src/components/sidebar.py
+++ b/src/components/sidebar.py
@@ -21,6 +21,12 @@ class Sidebar(ctk.CTkFrame):
         self.icons: Dict[str, str] = {}
         self.labels: Dict[str, str] = {}
         self._tooltips: Dict[str, Tooltip] = {}
+        size = int(app.config.get("font_size", 14))
+        self.font = ctk.CTkFont(size=size)
+        self.title_font = ctk.CTkFont(size=size + 10, weight="bold")
+        self.accent = app.theme.get_theme().get("accent_color", "#1faaff")
+        self.active_color = [self.accent, self.accent]
+        self.inactive_color = ["#3B8ED0", "#1F6AA5"]
         self.grid_propagate(False)
 
         # Configure grid
@@ -30,7 +36,7 @@ class Sidebar(ctk.CTkFrame):
         self.title = ctk.CTkLabel(
             self,
             text="CoolBox",
-            font=ctk.CTkFont(size=24, weight="bold"),
+            font=self.title_font,
         )
         self.title.grid(row=0, column=0, padx=20, pady=(20, 30))
 
@@ -52,6 +58,7 @@ class Sidebar(ctk.CTkFrame):
             text="🌙 Dark Mode",
             command=self._toggle_theme,
             height=32,
+            font=self.font,
         )
         self.theme_toggle.grid(row=6, column=0, padx=20, pady=(10, 5), sticky="ew")
 
@@ -74,7 +81,7 @@ class Sidebar(ctk.CTkFrame):
             command=lambda: self.app.switch_view(name),
             height=40,
             anchor="w",
-            font=ctk.CTkFont(size=14),
+            font=self.font,
         )
         button.grid(row=row, column=0, padx=20, pady=5, sticky="ew")
         self.buttons[name] = button
@@ -89,11 +96,11 @@ class Sidebar(ctk.CTkFrame):
         """Set the active button"""
         # Reset all buttons
         for button in self.buttons.values():
-            button.configure(fg_color=["#3B8ED0", "#1F6AA5"])
+            button.configure(fg_color=self.inactive_color)
 
         # Highlight active button
         if view_name in self.buttons:
-            self.buttons[view_name].configure(fg_color=["#1F6AA5", "#144870"])
+            self.buttons[view_name].configure(fg_color=self.active_color)
 
     def _toggle_theme(self):
         """Toggle between light and dark theme"""
@@ -109,3 +116,19 @@ class Sidebar(ctk.CTkFrame):
 
         # Save preference
         self.app.config.set("appearance_mode", new_mode)
+
+    def refresh_fonts(self) -> None:
+        """Update fonts based on the current configuration."""
+        size = int(self.app.config.get("font_size", 14))
+        self.font.configure(size=size)
+        self.title_font.configure(size=size + 10)
+        self.title.configure(font=self.title_font)
+        for btn in self.buttons.values():
+            btn.configure(font=self.font)
+        self.theme_toggle.configure(font=self.font)
+
+    def refresh_theme(self) -> None:
+        """Refresh accent colors."""
+        self.accent = self.app.theme.get_theme().get("accent_color", "#1faaff")
+        self.active_color = [self.accent, self.accent]
+        self.set_active(self.app.current_view or "home")

--- a/src/components/status_bar.py
+++ b/src/components/status_bar.py
@@ -4,24 +4,29 @@ Status bar component for displaying messages
 
 import customtkinter as ctk
 from datetime import datetime
+from .tooltip import Tooltip
 
 
 class StatusBar(ctk.CTkFrame):
     """Application status bar"""
 
-    def __init__(self, parent):
+    def __init__(self, parent, app):
         """Initialize status bar"""
         super().__init__(parent, height=30, corner_radius=0)
+        self.app = app
 
         # Prevent frame from shrinking
         self.pack_propagate(False)
 
+        size = int(app.config.get("font_size", 14))
+        self.font = ctk.CTkFont(size=max(size - 2, 8))
         # Message label
+        self.accent = app.theme.get_theme().get("accent_color", "#1faaff")
         self.message_label = ctk.CTkLabel(
             self,
             text="Ready",
             anchor="w",
-            font=ctk.CTkFont(size=12),
+            font=self.font,
         )
         self.message_label.pack(side="left", padx=10)
 
@@ -33,18 +38,22 @@ class StatusBar(ctk.CTkFrame):
         # Use a monospaced font and fixed width to avoid jitter when the
         # time text updates every second. Measure the width of the
         # "00:00:00" string so the label size adapts to the chosen font.
-        time_font = ctk.CTkFont(size=12, family="Courier")
+        self.time_font = ctk.CTkFont(size=max(size - 2, 8), family="Courier")
         try:
-            width = time_font.measure("00:00:00")
+            width = self.time_font.measure("00:00:00")
         except Exception:  # pragma: no cover - measure may fail in headless env
             width = 70
         self.time_label = ctk.CTkLabel(
             right_frame,
             text="00:00:00",
-            font=time_font,
+            font=self.time_font,
             width=width,
         )
         self.time_label.pack(side="right", padx=10)
+
+        self._time_tip = Tooltip(self, "")
+        self.time_label.bind("<Enter>", lambda e: self._show_time())
+        self.time_label.bind("<Leave>", lambda e: self._time_tip.hide())
 
         # Progress bar (hidden by default)
         self.progress = ctk.CTkProgressBar(
@@ -52,21 +61,21 @@ class StatusBar(ctk.CTkFrame):
             width=200,
             height=10,
         )
+        self.progress.configure(progress_color=self.accent)
 
         # Update time
+        self.colors = {
+            "info": self.accent,
+            "success": "#00A65A",
+            "warning": "#F39C12",
+            "error": "#E74C3C",
+        }
         self._update_time()
 
     def set_message(self, message: str, msg_type: str = "info"):
         """Set status message with type"""
         # Set color based on type
-        colors = {
-            "info": "#3B8ED0",
-            "success": "#00A65A",
-            "warning": "#F39C12",
-            "error": "#E74C3C",
-        }
-
-        color = colors.get(msg_type, "#3B8ED0")
+        color = self.colors.get(msg_type, self.accent)
         self.message_label.configure(text=message, text_color=color)
 
         # Auto-clear after 5 seconds for non-info messages
@@ -88,3 +97,26 @@ class StatusBar(ctk.CTkFrame):
         self.time_label.configure(text=current_time)
         # Update every second
         self.after(1000, self._update_time)
+
+    def _show_time(self) -> None:
+        """Show tooltip with the current date under the clock."""
+        date_text = datetime.now().strftime("%A, %B %d, %Y")
+        self._time_tip.label.configure(text=date_text)
+        x = self.time_label.winfo_rootx() + self.time_label.winfo_width() // 2
+        y = self.time_label.winfo_rooty() + self.time_label.winfo_height() + 10
+        self._time_tip.show(x, y)
+
+    def refresh_fonts(self) -> None:
+        """Refresh fonts using the application's font size."""
+        size = int(self.app.config.get("font_size", 14))
+        self.font.configure(size=max(size - 2, 8))
+        self.time_font.configure(size=max(size - 2, 8))
+        self.message_label.configure(font=self.font)
+        self.time_label.configure(font=self.time_font)
+
+    def refresh_theme(self) -> None:
+        """Refresh accent color used for info messages."""
+        self.accent = self.app.theme.get_theme().get("accent_color", "#1faaff")
+        self.colors["info"] = self.accent
+        self.progress.configure(progress_color=self.accent)
+

--- a/src/components/widgets.py
+++ b/src/components/widgets.py
@@ -3,6 +3,11 @@
 import customtkinter as ctk
 
 
-def info_label(master: ctk.CTkBaseClass, text: str) -> ctk.CTkLabel:
-    """Return a grey informational label."""
-    return ctk.CTkLabel(master, text=text, text_color="gray")
+def info_label(master: ctk.CTkBaseClass, text: str, *, font=None) -> ctk.CTkLabel:
+    """Return a grey informational label using master's font when available."""
+    if font is None:
+        font = getattr(master, "font", None)
+    label = ctk.CTkLabel(master, text=text, text_color="gray", font=font)
+    if hasattr(master, "_mark_font_role"):
+        master._mark_font_role(label, "normal")
+    return label

--- a/src/config.py
+++ b/src/config.py
@@ -33,6 +33,7 @@ class Config:
             "show_toolbar": True,
             "show_statusbar": True,
             "show_menu": True,
+            "section_states": {},
             "force_quit_cpu_alert": 80.0,
             "force_quit_mem_alert": 500.0,
             "force_quit_auto_kill": "none",
@@ -160,6 +161,17 @@ class Config:
     def set(self, key: str, value: Any):
         """Set configuration value"""
         self.config[key] = value
+
+    def get_section_state(self, key: str, default: bool = True) -> bool:
+        """Return persisted expand/collapse state for *key*."""
+        states = self.config.setdefault("section_states", {})
+        return states.get(key, default)
+
+    def set_section_state(self, key: str, value: bool) -> None:
+        """Persist expand/collapse state for *key*."""
+        states = self.config.setdefault("section_states", {})
+        states[key] = value
+        self.save()
 
     def add_recent_file(self, filepath: str):
         """Add a file to recent files list"""

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -3,6 +3,7 @@
 from .helpers import (
     log,
     open_path,
+    slugify,
     calc_hash,
     calc_hash_cached,
     calc_hashes,
@@ -55,6 +56,8 @@ from .network import (
     clear_host_cache,
 )
 
+from .ui import center_window
+
 from . import file_manager
 
 __all__ = [
@@ -70,6 +73,7 @@ __all__ = [
     "move_dir",
     "delete_dir",
     "open_path",
+    "slugify",
     "calc_hash",
     "calc_hash_cached",
     "calc_hashes",
@@ -108,4 +112,5 @@ __all__ = [
     "file_manager",
     "ProcessEntry",
     "ProcessWatcher",
+    "center_window",
 ]

--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -32,6 +32,13 @@ def open_path(path: str) -> None:
         subprocess.Popen(["xdg-open", path])
 
 
+def slugify(text: str) -> str:
+    """Return *text* lowercased with non-alphanumerics replaced by underscores."""
+    return "_".join(
+        filter(None, ["".join(ch.lower() if ch.isalnum() else "" for ch in part) for part in text.split()])
+    )
+
+
 def calc_hash(path: str, algo: Literal["md5", "sha1", "sha256"] = "md5") -> str:
     """Return the hexadecimal hash of ``path`` using *algo*."""
     hash_func = getattr(hashlib, algo)()

--- a/src/utils/ui.py
+++ b/src/utils/ui.py
@@ -1,0 +1,12 @@
+import customtkinter as ctk
+
+
+def center_window(window: ctk.CTkToplevel) -> None:
+    """Center *window* on the screen."""
+    window.update_idletasks()
+    width = window.winfo_width()
+    height = window.winfo_height()
+    x = (window.winfo_screenwidth() - width) // 2
+    y = (window.winfo_screenheight() - height) // 2
+    window.geometry(f"{width}x{height}+{x}+{y}")
+

--- a/src/views/__init__.py
+++ b/src/views/__init__.py
@@ -1,5 +1,8 @@
 """Expose application views."""
 
+from .base_view import BaseView
+from .base_dialog import BaseDialog
+from .base_mixin import UIHelperMixin
 from .home_view import HomeView
 from .tools_view import ToolsView
 from .settings_view import SettingsView
@@ -8,8 +11,12 @@ from .quick_settings import QuickSettingsDialog
 from .auto_scan_dialog import AutoNetworkScanDialog
 from .force_quit_dialog import ForceQuitDialog
 from .system_info_dialog import SystemInfoDialog
+from .recent_files_dialog import RecentFilesDialog
 
 __all__ = [
+    "BaseView",
+    "BaseDialog",
+    "UIHelperMixin",
     "HomeView",
     "ToolsView",
     "SettingsView",
@@ -18,4 +25,5 @@ __all__ = [
     "AutoNetworkScanDialog",
     "ForceQuitDialog",
     "SystemInfoDialog",
+    "RecentFilesDialog",
 ]

--- a/src/views/about_view.py
+++ b/src/views/about_view.py
@@ -3,36 +3,45 @@ About view - Application info
 """
 import customtkinter as ctk
 from ..components.widgets import info_label
+from ..utils import open_path
+from .base_view import BaseView
 
 
-class AboutView(ctk.CTkFrame):
+class AboutView(BaseView):
     """About screen view"""
 
     def __init__(self, parent, app):
         """Initialize about view"""
-        super().__init__(parent, corner_radius=0)
-        self.app = app
+        super().__init__(parent, app)
 
         # Create layout
         self._create_layout()
 
+        # Apply current styling
+        self.refresh_fonts()
+        self.refresh_theme()
+
     def _create_layout(self):
         """Create the about view layout"""
-        container = ctk.CTkFrame(self)
-        container.pack(fill="both", expand=True, padx=20, pady=20)
+        container = self.create_container()
 
-        title = ctk.CTkLabel(
-            container,
-            text="About CoolBox",
-            font=ctk.CTkFont(size=24, weight="bold"),
-        )
-        title.pack(pady=(0, 20))
+        self.add_title(container, "About CoolBox")
 
         info = info_label(
             container,
             "CoolBox - A Modern Desktop App\nVersion 1.0",
+            font=self.font,
         )
         info.pack(anchor="w")
 
-        credits = info_label(container, "Created by mikkel32")
+        credits = info_label(container, "Created by mikkel32", font=self.font)
         credits.pack(anchor="w", pady=(20, 0))
+        self.add_tooltip(credits, "Visit the CoolBox repository")
+        self.credits_label = credits
+        credits.configure(cursor="hand2", text_color=self.accent)
+        credits.bind("<Button-1>", lambda e: open_path("https://github.com/mikkel32/CoolBox"))
+
+    def refresh_theme(self) -> None:  # type: ignore[override]
+        super().refresh_theme()
+        if hasattr(self, "credits_label"):
+            self.credits_label.configure(text_color=self.accent)

--- a/src/views/base_dialog.py
+++ b/src/views/base_dialog.py
@@ -1,0 +1,29 @@
+import customtkinter as ctk
+from .base_mixin import UIHelperMixin
+
+
+class BaseDialog(ctk.CTkToplevel, UIHelperMixin):
+    """Base class for dialogs providing shared styling."""
+
+    def __init__(self, app, *, title: str = "", geometry: str | None = None, resizable: tuple[bool, bool] = (False, False)):
+        ctk.CTkToplevel.__init__(self, app.window)
+        UIHelperMixin.__init__(self, app)
+        if hasattr(app, "register_dialog"):
+            app.register_dialog(self)
+        if title:
+            self.title(title)
+        if geometry:
+            self.geometry(geometry)
+        self.resizable(*resizable)
+        self.bind("<Escape>", lambda e: self.destroy())
+
+    def center_window(self) -> None:  # type: ignore[override]
+        UIHelperMixin.center_window(self)
+
+    def refresh_theme(self) -> None:  # type: ignore[override]
+        UIHelperMixin.refresh_theme(self)
+
+    def destroy(self) -> None:  # type: ignore[override]
+        if hasattr(self.app, "unregister_dialog"):
+            self.app.unregister_dialog(self)
+        super().destroy()

--- a/src/views/base_mixin.py
+++ b/src/views/base_mixin.py
@@ -1,0 +1,433 @@
+import customtkinter as ctk
+from src.components.tooltip import Tooltip
+from src.utils.ui import center_window
+
+
+class UIHelperMixin:
+    """Mixin providing common UI helpers for views and dialogs."""
+
+    def __init__(self, app):
+        self.app = app
+        self.padx = 20
+        self.pady = 20
+        self.gpadx = 5
+        self.gpady = 5
+        size = int(app.config.get("font_size", 14))
+        self.font = ctk.CTkFont(size=size)
+        self.title_font = ctk.CTkFont(size=size + 10, weight="bold")
+        self.section_font = ctk.CTkFont(size=size + 4, weight="bold")
+        self.accent = app.theme.get_theme().get("accent_color", "#1faaff")
+
+    # ------------------------------------------------------------------ font utils
+    def _mark_font_role(self, widget: ctk.CTkBaseClass, role: str) -> None:
+        """Store *role* on *widget* so fonts can be refreshed later."""
+        setattr(widget, "_font_role", role)
+
+    def _apply_font(self, widget: ctk.CTkBaseClass) -> None:
+        role = getattr(widget, "_font_role", "normal")
+        font = self.font
+        if role == "title":
+            font = self.title_font
+        elif role == "section":
+            font = self.section_font
+        try:
+            widget.configure(font=font)
+        except Exception:
+            pass
+
+    def apply_fonts(self, parent: ctk.CTkBaseClass | None = None) -> None:
+        """Recursively apply fonts to *parent* and its children."""
+        parent = parent or self
+        if hasattr(parent, "configure"):
+            self._apply_font(parent)
+        for child in parent.winfo_children():
+            self.apply_fonts(child)
+
+    def create_container(self, parent=None):
+        """Return a padded container frame."""
+        parent = parent or self
+        container = ctk.CTkFrame(parent)
+        container.pack(fill="both", expand=True, padx=self.padx, pady=self.pady)
+        return container
+
+    def add_title(self, parent, text: str, *, use_pack: bool = True):
+        """Return a title label and optionally pack it."""
+        label = ctk.CTkLabel(parent, text=text, font=self.title_font)
+        self._mark_font_role(label, "title")
+        if use_pack:
+            label.pack(pady=(0, self.pady))
+        return label
+
+    def add_section(self, parent, title: str):
+        """Create a section frame with a heading."""
+        section = ctk.CTkFrame(parent)
+        section.pack(fill="x", pady=(0, self.pady))
+        header = ctk.CTkLabel(
+            section,
+            text=title,
+            font=self.section_font,
+        )
+        self._mark_font_role(header, "section")
+        header.pack(anchor="w", padx=self.padx, pady=(self.padx // 2, self.padx // 2))
+        return section
+
+    def add_collapsible_section(
+        self, parent, title: str, *, key: str | None = None, expanded: bool = True
+    ) -> tuple[ctk.CTkFrame, ctk.CTkFrame]:
+        """Create a section that can be collapsed/expanded."""
+        if key is not None:
+            expanded = self.app.config.get_section_state(key, expanded)
+        section = ctk.CTkFrame(parent)
+        section.pack(fill="x", pady=(0, self.pady))
+
+        header = ctk.CTkFrame(section, fg_color="transparent")
+        header.pack(fill="x")
+        icon = ctk.CTkLabel(header, text="▼" if expanded else "▶", width=20)
+        icon.pack(side="left")
+        label = ctk.CTkLabel(header, text=title, font=self.section_font)
+        self._mark_font_role(label, "section")
+        label.pack(side="left", padx=5)
+
+        content = ctk.CTkFrame(section)
+        if expanded:
+            content.pack(fill="x", padx=self.padx)
+
+        def _toggle(_=None):
+            nonlocal expanded
+            expanded = not expanded
+            icon.configure(text="▼" if expanded else "▶")
+            if expanded:
+                content.pack(fill="x", padx=self.padx)
+            else:
+                content.pack_forget()
+            if key is not None:
+                self.app.config.set_section_state(key, expanded)
+
+        header.bind("<Button-1>", _toggle)
+        label.bind("<Button-1>", _toggle)
+        icon.bind("<Button-1>", _toggle)
+
+        return section, content
+
+    # ------------------------------------------------------------------ grid helpers
+    def grid_entry(
+        self,
+        parent: ctk.CTkFrame,
+        label: str,
+        variable: ctk.StringVar | ctk.IntVar,
+        row: int,
+        **entry_kwargs,
+    ) -> ctk.CTkEntry:
+        """Create a labeled entry row on a grid layout."""
+        lbl = ctk.CTkLabel(parent, text=label, font=self.font)
+        self._mark_font_role(lbl, "normal")
+        lbl.grid(row=row, column=0, sticky="w", padx=self.gpadx, pady=self.gpady)
+        entry = ctk.CTkEntry(parent, textvariable=variable, **entry_kwargs)
+        self._mark_font_role(entry, "normal")
+        entry.grid(row=row, column=1, sticky="ew", padx=self.gpadx, pady=self.gpady)
+        parent.grid_columnconfigure(1, weight=1)
+        return entry
+
+    def grid_switch(
+        self,
+        parent: ctk.CTkFrame,
+        text: str,
+        variable: ctk.BooleanVar,
+        row: int,
+    ) -> ctk.CTkSwitch:
+        """Create a switch row in a grid layout."""
+        switch = ctk.CTkSwitch(parent, text=text, variable=variable, font=self.font)
+        self._mark_font_role(switch, "normal")
+        switch.grid(row=row, column=0, columnspan=2, sticky="w", padx=self.gpadx, pady=self.gpady)
+        return switch
+
+    def grid_checkbox(
+        self,
+        parent: ctk.CTkFrame,
+        text: str,
+        variable: ctk.BooleanVar,
+        row: int,
+        columnspan: int = 2,
+    ) -> ctk.CTkCheckBox:
+        """Create a check box row in a grid layout."""
+        cb = ctk.CTkCheckBox(parent, text=text, variable=variable, font=self.font)
+        self._mark_font_role(cb, "normal")
+        cb.grid(row=row, column=0, columnspan=columnspan, sticky="w", padx=self.gpadx, pady=self.gpady)
+        return cb
+
+    def grid_optionmenu(
+        self,
+        parent: ctk.CTkFrame,
+        label: str,
+        variable: ctk.StringVar,
+        values: list[str],
+        row: int,
+        **menu_kwargs,
+    ) -> ctk.CTkOptionMenu:
+        """Create a labeled option menu row on a grid layout."""
+        lbl = ctk.CTkLabel(parent, text=label, font=self.font)
+        self._mark_font_role(lbl, "normal")
+        lbl.grid(row=row, column=0, sticky="w", padx=self.gpadx, pady=self.gpady)
+        menu = ctk.CTkOptionMenu(
+            parent, variable=variable, values=values, **menu_kwargs
+        )
+        self._mark_font_role(menu, "normal")
+        menu.grid(row=row, column=1, sticky="ew", padx=self.gpadx, pady=self.gpady)
+        parent.grid_columnconfigure(1, weight=1)
+        return menu
+
+    def grid_button(
+        self,
+        parent: ctk.CTkFrame,
+        text: str,
+        command,
+        row: int,
+        column: int = 0,
+        columnspan: int = 2,
+        **btn_kwargs,
+    ) -> ctk.CTkButton:
+        """Create a button row in a grid layout."""
+        btn = ctk.CTkButton(parent, text=text, command=command, font=self.font, **btn_kwargs)
+        self._mark_font_role(btn, "normal")
+        btn.grid(
+            row=row,
+            column=column,
+            columnspan=columnspan,
+            sticky="ew",
+            padx=self.gpadx,
+            pady=self.gpady,
+        )
+        return btn
+
+    def grid_label(
+        self,
+        parent: ctk.CTkFrame,
+        text: str,
+        row: int,
+        column: int = 0,
+        columnspan: int = 2,
+    ) -> ctk.CTkLabel:
+        """Create a label row in a grid layout."""
+        lbl = ctk.CTkLabel(parent, text=text, font=self.font)
+        self._mark_font_role(lbl, "normal")
+        lbl.grid(
+            row=row,
+            column=column,
+            columnspan=columnspan,
+            sticky="w",
+            padx=self.gpadx,
+            pady=self.gpady,
+        )
+        return lbl
+
+    def grid_separator(
+        self,
+        parent: ctk.CTkFrame,
+        row: int,
+        column: int = 0,
+        columnspan: int = 2,
+    ) -> ctk.CTkFrame:
+        """Insert a thin separator line across the grid."""
+        sep = ctk.CTkFrame(parent, height=1, fg_color=("gray60", "gray30"))
+        sep.grid(
+            row=row,
+            column=column,
+            columnspan=columnspan,
+            sticky="ew",
+            padx=self.gpadx,
+            pady=self.gpady,
+        )
+        parent.grid_columnconfigure(column, weight=1)
+        return sep
+
+    def grid_slider(
+        self,
+        parent: ctk.CTkFrame,
+        label: str,
+        variable: ctk.DoubleVar | ctk.IntVar,
+        row: int,
+        from_: float,
+        to: float,
+        **slider_kwargs,
+    ) -> tuple[ctk.CTkSlider, ctk.CTkLabel]:
+        """Create a labeled slider row returning the slider and value label."""
+        lbl = ctk.CTkLabel(parent, text=label, font=self.font)
+        self._mark_font_role(lbl, "normal")
+        lbl.grid(row=row, column=0, sticky="w", padx=self.gpadx, pady=self.gpady)
+        slider = ctk.CTkSlider(
+            parent, variable=variable, from_=from_, to=to, **slider_kwargs
+        )
+        self._mark_font_role(slider, "normal")
+        slider.grid(row=row, column=1, sticky="ew", padx=self.gpadx, pady=self.gpady)
+        value_lbl = ctk.CTkLabel(parent, text=str(int(variable.get())), font=self.font)
+        self._mark_font_role(value_lbl, "normal")
+        value_lbl.grid(row=row, column=2, padx=self.gpadx, pady=self.gpady)
+        parent.grid_columnconfigure(1, weight=1)
+
+        def _update(val: float) -> None:
+            value_lbl.configure(text=str(int(float(val))))
+
+        slider.configure(command=_update)
+        return slider, value_lbl
+
+    def grid_file_entry(
+        self,
+        parent: ctk.CTkFrame,
+        label: str,
+        variable: ctk.StringVar,
+        row: int,
+        command,
+        button_text: str = "Browse",
+        **entry_kwargs,
+    ) -> tuple[ctk.CTkEntry, ctk.CTkButton]:
+        """Create a labeled entry with a browse button."""
+        lbl = ctk.CTkLabel(parent, text=label, font=self.font)
+        self._mark_font_role(lbl, "normal")
+        lbl.grid(row=row, column=0, sticky="w", padx=self.gpadx, pady=self.gpady)
+        entry = ctk.CTkEntry(parent, textvariable=variable, **entry_kwargs)
+        self._mark_font_role(entry, "normal")
+        entry.grid(row=row, column=1, sticky="ew", padx=self.gpadx, pady=self.gpady)
+        btn = ctk.CTkButton(parent, text=button_text, command=command, width=80)
+        self._mark_font_role(btn, "normal")
+        btn.grid(row=row, column=2, padx=self.gpadx, pady=self.gpady)
+        parent.grid_columnconfigure(1, weight=1)
+        return entry, btn
+
+    def grid_textbox(
+        self,
+        parent: ctk.CTkFrame,
+        label: str,
+        row: int,
+        height: int = 150,
+    ) -> ctk.CTkTextbox:
+        """Create a labeled textbox occupying a single row."""
+        lbl = ctk.CTkLabel(parent, text=label, font=self.font)
+        self._mark_font_role(lbl, "normal")
+        lbl.grid(row=row, column=0, sticky="nw", padx=self.gpadx, pady=self.gpady)
+        box = ctk.CTkTextbox(parent, height=height)
+        self._mark_font_role(box, "normal")
+        box.grid(row=row, column=1, columnspan=2, sticky="nsew", padx=self.gpadx, pady=self.gpady)
+        parent.grid_rowconfigure(row, weight=1)
+        parent.grid_columnconfigure(1, weight=1)
+        return box
+
+    def grid_segmented(
+        self,
+        parent: ctk.CTkFrame,
+        label: str,
+        variable: ctk.StringVar | ctk.IntVar,
+        values: list[str],
+        row: int,
+        **seg_kwargs,
+    ) -> ctk.CTkSegmentedButton:
+        """Create a labeled segmented button row on a grid."""
+        lbl = ctk.CTkLabel(parent, text=label, font=self.font)
+        self._mark_font_role(lbl, "normal")
+        lbl.grid(row=row, column=0, sticky="w", padx=self.gpadx, pady=self.gpady)
+        seg = ctk.CTkSegmentedButton(
+            parent, values=values, variable=variable, **seg_kwargs
+        )
+        self._mark_font_role(seg, "normal")
+        seg.grid(row=row, column=1, sticky="ew", padx=self.gpadx, pady=self.gpady)
+        parent.grid_columnconfigure(1, weight=1)
+        return seg
+
+    def create_search_box(
+        self,
+        parent: ctk.CTkFrame,
+        variable: ctk.StringVar,
+        placeholder: str,
+        callback,
+    ) -> ctk.CTkEntry:
+        """Return an entry configured for search filtering."""
+        entry = ctk.CTkEntry(
+            parent,
+            textvariable=variable,
+            placeholder_text=placeholder,
+        )
+        self._mark_font_role(entry, "normal")
+        entry.bind("<KeyRelease>", lambda e: callback())
+        entry.bind("<Escape>", lambda e: (variable.set(""), callback()))
+        return entry
+
+    def create_scrollable_container(self) -> ctk.CTkScrollableFrame:
+        """Return a scrollable frame with standard padding."""
+        frame = ctk.CTkScrollableFrame(self)
+        frame.pack(fill="both", expand=True, padx=self.padx, pady=self.pady)
+        return frame
+
+    def add_tooltip(self, widget: ctk.CTkBaseClass, text: str) -> Tooltip:
+        """Attach a tooltip to *widget* and return it.
+
+        Some customtkinter widgets like ``CTkSegmentedButton`` do not implement
+        ``bind``. In that case we attach events to their internal buttons
+        instead so the tooltip still appears on hover.
+        """
+        tip = Tooltip(self, text)
+        try:
+            widget.bind(
+                "<Enter>",
+                lambda e, w=widget, t=tip: self._show_tooltip(w, t),
+            )
+            widget.bind("<Leave>", lambda e, t=tip: t.hide())
+        except (NotImplementedError, AttributeError):
+            if isinstance(widget, ctk.CTkSegmentedButton):
+                for btn in widget._buttons_dict.values():
+                    btn.bind(
+                        "<Enter>",
+                        lambda e, w=widget, t=tip: self._show_tooltip(w, t),
+                    )
+                    btn.bind("<Leave>", lambda e, t=tip: t.hide())
+        return tip
+
+    def _show_tooltip(self, widget: ctk.CTkBaseClass, tooltip: Tooltip) -> None:
+        x = widget.winfo_rootx() + widget.winfo_width() // 2
+        y = widget.winfo_rooty() + widget.winfo_height() + 10
+        tooltip.show(x, y)
+
+    def center_window(self, window: ctk.CTkToplevel | None = None) -> None:
+        """Center *window* or self if no window provided."""
+        if window is None and isinstance(self, ctk.CTkToplevel):
+            window = self
+        if window is not None:
+            center_window(window)
+
+    def refresh_fonts(self) -> None:
+        """Update fonts based on the current config."""
+        size = int(self.app.config.get("font_size", 14))
+        self.font.configure(size=size)
+        self.title_font.configure(size=size + 10)
+        self.section_font.configure(size=size + 4)
+        self.apply_fonts()
+
+    def refresh_theme(self) -> None:
+        """Refresh cached theme colors."""
+        self.accent = self.app.theme.get_theme().get("accent_color", "#1faaff")
+        self.apply_theme()
+
+    # ------------------------------------------------------------------ theme helpers
+    def apply_theme(self, parent: ctk.CTkBaseClass | None = None) -> None:
+        """Recursively apply accent colors to buttons and inputs."""
+        parent = parent or self
+        if isinstance(parent, ctk.CTkButton):
+            parent.configure(fg_color=self.accent, hover_color=self.accent)
+        elif isinstance(parent, ctk.CTkSegmentedButton):
+            parent.configure(fg_color=self.accent, selected_color=self.accent)
+        elif isinstance(parent, ctk.CTkOptionMenu):
+            parent.configure(
+                fg_color=self.accent,
+                button_color=self.accent,
+                button_hover_color=self.accent,
+            )
+        elif isinstance(parent, (ctk.CTkSwitch, ctk.CTkCheckBox)):
+            parent.configure(progress_color=self.accent, fg_color=self.accent)
+        elif isinstance(parent, ctk.CTkRadioButton):
+            parent.configure(border_color=self.accent, fg_color=self.accent)
+        elif isinstance(parent, ctk.CTkSlider):
+            parent.configure(progress_color=self.accent)
+        elif isinstance(parent, ctk.CTkEntry):
+            parent.configure(border_color=self.accent)
+        elif isinstance(parent, ctk.CTkProgressBar):
+            parent.configure(progress_color=self.accent)
+        for child in parent.winfo_children():
+            self.apply_theme(child)

--- a/src/views/base_view.py
+++ b/src/views/base_view.py
@@ -1,0 +1,13 @@
+import customtkinter as ctk
+from .base_mixin import UIHelperMixin
+
+
+class BaseView(ctk.CTkFrame, UIHelperMixin):
+    """Base class for application views providing consistent styling."""
+
+    def __init__(self, parent, app):
+        ctk.CTkFrame.__init__(self, parent, corner_radius=0)
+        UIHelperMixin.__init__(self, app)
+
+    def refresh_theme(self) -> None:  # type: ignore[override]
+        UIHelperMixin.refresh_theme(self)

--- a/src/views/quick_settings.py
+++ b/src/views/quick_settings.py
@@ -1,55 +1,138 @@
 """Quick settings dialog."""
+from tkinter import colorchooser
 import customtkinter as ctk
 
+from .base_dialog import BaseDialog
 
-class QuickSettingsDialog(ctk.CTkToplevel):
+
+class QuickSettingsDialog(BaseDialog):
     """Simple dialog for toggling common options."""
 
     def __init__(self, app):
-        super().__init__(app.window)
-        self.app = app
-        self.title("Quick Settings")
-        self.resizable(False, False)
-        self.geometry("300x300")
+        super().__init__(app, title="Quick Settings", geometry="300x300")
 
-        ctk.CTkLabel(
-            self,
-            text="Quick Settings",
-            font=ctk.CTkFont(size=18, weight="bold"),
-        ).pack(pady=10)
+        container = self.create_container()
+
+        self.add_title(container, "Quick Settings", use_pack=False).grid(
+            row=0, column=0, columnspan=2, pady=(0, self.pady)
+        )
 
         self.menu_var = ctk.BooleanVar(value=app.config.get("show_menu", True))
         self.toolbar_var = ctk.BooleanVar(value=app.config.get("show_toolbar", True))
         self.status_var = ctk.BooleanVar(value=app.config.get("show_statusbar", True))
         self.theme_var = ctk.StringVar(value=app.config.get("appearance_mode", "dark").title())
         self.color_var = ctk.StringVar(value=app.config.get("color_theme", "blue"))
+        self.accent_var = ctk.StringVar(
+            value=app.theme.get_theme().get("accent_color", "#007acc")
+        )
+        self.font_size_var = ctk.IntVar(value=app.config.get("font_size", 14))
 
-        ctk.CTkCheckBox(self, text="Show Menu Bar", variable=self.menu_var).pack(anchor="w", padx=20, pady=5)
-        ctk.CTkCheckBox(self, text="Show Toolbar", variable=self.toolbar_var).pack(anchor="w", padx=20, pady=5)
-        ctk.CTkCheckBox(self, text="Show Status Bar", variable=self.status_var).pack(anchor="w", padx=20, pady=5)
+        sw_menu = self.grid_switch(container, "Show Menu Bar", self.menu_var, 1)
+        self.add_tooltip(sw_menu, "Toggle the main menu")
+        sw_toolbar = self.grid_switch(container, "Show Toolbar", self.toolbar_var, 2)
+        self.add_tooltip(sw_toolbar, "Toggle the toolbar")
+        sw_status = self.grid_switch(container, "Show Status Bar", self.status_var, 3)
+        self.add_tooltip(sw_status, "Toggle the status bar")
+        self.grid_separator(container, 4)
 
-        ctk.CTkLabel(self, text="Appearance:").pack(anchor="w", padx=20, pady=(10, 0))
-        ctk.CTkOptionMenu(
-            self,
-            values=["Light", "Dark", "System"],
-            variable=self.theme_var,
+        theme_seg = self.grid_segmented(
+            container,
+            "Appearance:",
+            self.theme_var,
+            ["Light", "Dark", "System"],
+            5,
             command=self._change_theme,
-            width=120,
-        ).pack(anchor="w", padx=20, pady=5)
-
-        ctk.CTkLabel(self, text="Color Theme:").pack(anchor="w", padx=20, pady=(10, 0))
-        ctk.CTkOptionMenu(
-            self,
-            values=["blue", "green", "dark-blue"],
-            variable=self.color_var,
+        )
+        self.add_tooltip(theme_seg, "Preview appearance mode")
+        color_seg = self.grid_segmented(
+            container,
+            "Color Theme:",
+            self.color_var,
+            ["blue", "green", "dark-blue"],
+            6,
             command=self._change_color_theme,
-            width=120,
-        ).pack(anchor="w", padx=20, pady=5)
+        )
+        self.add_tooltip(color_seg, "Preview color theme")
 
-        btn_frame = ctk.CTkFrame(self, fg_color="transparent")
-        btn_frame.pack(pady=10)
-        ctk.CTkButton(btn_frame, text="Apply", command=self._apply).pack(side="left", padx=10)
-        ctk.CTkButton(btn_frame, text="Cancel", command=self.destroy).pack(side="left", padx=10)
+        accent_btn = self.grid_button(
+            container,
+            "Accent Color...",
+            self._choose_accent,
+            7,
+            columnspan=1,
+        )
+        self.accent_display = ctk.CTkLabel(container, textvariable=self.accent_var)
+        self._mark_font_role(self.accent_display, "normal")
+        self.accent_display.grid(row=7, column=1, sticky="w", padx=self.gpadx, pady=self.gpady)
+        self.add_tooltip(accent_btn, "Select custom accent color")
+        self._update_accent_preview()
+
+        slider, lbl = self.grid_slider(
+            container,
+            "Font Size:",
+            self.font_size_var,
+            8,
+            from_=10,
+            to=20,
+        )
+        self.add_tooltip(slider, "Preview font size")
+        self.sample_font = ctk.CTkFont(size=self.font_size_var.get())
+
+        def _update_preview(val: float) -> None:
+            size = int(float(val))
+            self.sample_font.configure(size=size)
+            for child in self.preview.winfo_children():
+                if isinstance(child, ctk.CTkButton) or isinstance(child, ctk.CTkEntry):
+                    child.configure(font=self.sample_font)
+
+        slider.configure(command=_update_preview)
+
+        self.preview = ctk.CTkFrame(container)
+        self.preview.grid(row=9, column=0, columnspan=2, sticky="ew", pady=(10, 0))
+        self.preview.grid_columnconfigure(1, weight=1)
+        lbl_preview = self.grid_label(self.preview, "Preview:", 0, columnspan=2)
+        lbl_preview.configure(font=self.section_font)
+        self.sample_button = ctk.CTkButton(self.preview, text="Button", fg_color=self.accent, hover_color=self.accent)
+        self.sample_button.grid(row=1, column=0, padx=self.gpadx, pady=self.gpady)
+        ctk.CTkEntry(self.preview, placeholder_text="Entry").grid(row=1, column=1, sticky="ew", padx=self.gpadx, pady=self.gpady)
+
+        btn_frame = ctk.CTkFrame(container, fg_color="transparent")
+        btn_frame.grid(row=10, column=0, columnspan=2, pady=10)
+        btn_frame.grid_columnconfigure((0,1,2), weight=1)
+        self.apply_btn = self.grid_button(btn_frame, "Apply", self._apply, 0, column=0, columnspan=1)
+        self.add_tooltip(self.apply_btn, "Save settings")
+        self.reset_btn = self.grid_button(btn_frame, "Reset", self._reset, 0, column=1, columnspan=1)
+        self.add_tooltip(self.reset_btn, "Restore previous values")
+        self.cancel_btn = self.grid_button(btn_frame, "Cancel", self.destroy, 0, column=2, columnspan=1)
+        self.add_tooltip(self.cancel_btn, "Close without saving")
+        
+        container.grid_columnconfigure(0, weight=1)
+        container.grid_columnconfigure(1, weight=1)
+
+        self.center_window()
+
+        # Apply current styling
+        self.refresh_fonts()
+        self.refresh_theme()
+
+    def refresh_fonts(self) -> None:  # type: ignore[override]
+        super().refresh_fonts()
+        for child in self.preview.winfo_children():
+            if isinstance(child, (ctk.CTkButton, ctk.CTkEntry)):
+                child.configure(font=self.sample_font)
+        self.sample_font.configure(size=self.font_size_var.get())
+
+    def refresh_theme(self) -> None:  # type: ignore[override]
+        super().refresh_theme()
+        self.accent_var.set(self.accent)
+        self._update_accent_preview()
+        for btn in (
+            self.sample_button,
+            self.apply_btn,
+            self.reset_btn,
+            self.cancel_btn,
+        ):
+            btn.configure(fg_color=self.accent, hover_color=self.accent)
 
     def _apply(self) -> None:
         cfg = self.app.config
@@ -58,13 +141,35 @@ class QuickSettingsDialog(ctk.CTkToplevel):
         cfg.set("show_statusbar", self.status_var.get())
         cfg.set("appearance_mode", self.theme_var.get().lower())
         cfg.set("color_theme", self.color_var.get())
+        theme_cfg = cfg.get("theme", {})
+        theme_cfg["accent_color"] = self.accent_var.get()
+        cfg.set("theme", theme_cfg)
+        cfg.set("font_size", self.font_size_var.get())
         cfg.save()
 
         ctk.set_appearance_mode(cfg.get("appearance_mode", "dark"))
         ctk.set_default_color_theme(cfg.get("color_theme", "blue"))
         self.app.theme.apply_theme(cfg.get("theme", {}))
         self.app.update_ui_visibility()
+        self.app.update_fonts()
+        self.app.update_theme()
         self.destroy()
+
+    def _reset(self) -> None:
+        cfg = self.app.config
+        self.menu_var.set(cfg.get("show_menu", True))
+        self.toolbar_var.set(cfg.get("show_toolbar", True))
+        self.status_var.set(cfg.get("show_statusbar", True))
+        self.theme_var.set(cfg.get("appearance_mode", "dark").title())
+        self.color_var.set(cfg.get("color_theme", "blue"))
+        self.accent_var.set(cfg.get("theme", {}).get("accent_color", "#007acc"))
+        self.font_size_var.set(cfg.get("font_size", 14))
+        ctk.set_appearance_mode(cfg.get("appearance_mode", "dark"))
+        ctk.set_default_color_theme(cfg.get("color_theme", "blue"))
+        self.app.theme.apply_theme(cfg.get("theme", {}))
+        self.app.update_fonts()
+        self.app.update_theme()
+        self._update_accent_preview()
 
     def _change_theme(self, value: str) -> None:
         """Preview the selected appearance mode immediately."""
@@ -73,3 +178,16 @@ class QuickSettingsDialog(ctk.CTkToplevel):
     def _change_color_theme(self, value: str) -> None:
         """Preview the selected color theme immediately."""
         ctk.set_default_color_theme(value)
+
+    def _choose_accent(self) -> None:
+        """Open a color picker and update the accent preview."""
+        color = colorchooser.askcolor(initialcolor=self.accent_var.get(), parent=self)
+        if color and color[1]:
+            self.accent_var.set(color[1])
+            self._update_accent_preview()
+
+    def _update_accent_preview(self) -> None:
+        """Refresh sample widget colors using the selected accent."""
+        color = self.accent_var.get()
+        self.sample_button.configure(fg_color=color, hover_color=color)
+        self.accent_display.configure(text=color)

--- a/src/views/recent_files_dialog.py
+++ b/src/views/recent_files_dialog.py
@@ -1,0 +1,70 @@
+"""Dialog showing a list of recently opened files."""
+
+import customtkinter as ctk
+
+from pathlib import Path
+from ..utils import open_path
+from .base_dialog import BaseDialog
+
+
+class RecentFilesDialog(BaseDialog):
+    """Simple dialog listing recent files."""
+
+    def __init__(self, app, files: list[str]):
+        super().__init__(app, title="Recent Files", geometry="500x400")
+
+        self.rows: list[tuple[ctk.CTkFrame, str]] = []
+
+        frame = self.create_container()
+        self.add_title(frame, "Recent Files", use_pack=False).grid(
+            row=0, column=0, columnspan=3, pady=(0, self.pady)
+        )
+
+        self.search_var = ctk.StringVar()
+        entry = self.create_search_box(frame, self.search_var, "Search files...", self._filter)
+        entry.grid(row=1, column=0, columnspan=3, sticky="ew", pady=(0, self.gpady))
+        self.add_tooltip(entry, "Filter recent files by name")
+
+        start_row = 2
+        for idx, path in enumerate(files, start=start_row):
+            row = ctk.CTkFrame(frame, fg_color="transparent")
+            row.grid(row=idx, column=0, columnspan=3, sticky="ew", pady=2)
+            lbl = ctk.CTkLabel(row, text=path, anchor="w")
+            self._mark_font_role(lbl, "normal")
+            lbl.grid(row=0, column=0, sticky="ew", padx=self.gpadx)
+            open_btn = ctk.CTkButton(row, text="Open", width=70, command=lambda p=path: open_path(p))
+            open_btn.grid(row=0, column=1, padx=self.gpadx)
+            folder_btn = ctk.CTkButton(row, text="Folder", width=70, command=lambda p=path: open_path(str(Path(p).parent)))
+            folder_btn.grid(row=0, column=2, padx=self.gpadx)
+            remove_btn = ctk.CTkButton(row, text="X", width=30, command=lambda p=path, r=row: self._remove(p, r))
+            remove_btn.grid(row=0, column=3, padx=self.gpadx)
+            self.rows.append((row, path))
+            self.add_tooltip(open_btn, "Open file")
+            self.add_tooltip(folder_btn, "Show in folder")
+            self.add_tooltip(remove_btn, "Remove from list")
+
+        frame.grid_columnconfigure(0, weight=1)
+
+        self.center_window()
+
+        # Apply current styling
+        self.refresh_fonts()
+        self.refresh_theme()
+
+    def _filter(self) -> None:
+        query = self.search_var.get().lower()
+        for row, path in self.rows:
+            if query in path.lower():
+                row.grid()
+            else:
+                row.grid_remove()
+
+    def _remove(self, path: str, row: ctk.CTkFrame) -> None:
+        files = self.app.config.get("recent_files", [])
+        if path in files:
+            files.remove(path)
+            self.app.config.set("recent_files", files)
+            self.app.config.save()
+            self.app.refresh_recent_files()
+        row.destroy()
+

--- a/src/views/system_info_dialog.py
+++ b/src/views/system_info_dialog.py
@@ -8,42 +8,47 @@ from matplotlib.backends.backend_tkagg import NavigationToolbar2Tk
 
 from ..utils import get_system_info, get_system_metrics
 from ..components import LineChart, Gauge, BarChart
+from .base_dialog import BaseDialog
 
 
-class SystemInfoDialog(ctk.CTkToplevel):
+class SystemInfoDialog(BaseDialog):
     """Modern dashboard window showing system metrics."""
 
     def __init__(self, app):
-        super().__init__(app.window)
-        self.app = app
-        self.title("System Info")
+        super().__init__(app, title="System Info", geometry="900x600", resizable=(True, True))
         # Provide a wider default size so all gauges and charts fit without
         # clipping. The previous width of 600px was not sufficient for the
         # six gauges displayed side by side. Increasing the width ensures the
         # interface is fully visible on start-up.
-        self.geometry("900x600")
-        self.resizable(True, True)
 
         self._after_id: int | None = None
         self.interval_var = tk.IntVar(value=1)
         self.paused = False
         self._create_layout()
         self._update_metrics()
+        self.center_window()
+
+        # Apply current styling
+        self.refresh_fonts()
+        self.refresh_theme()
 
     # ------------------------------------------------------------------ UI setup
     def _create_layout(self) -> None:
         toolbar = ctk.CTkFrame(self, fg_color="transparent")
         toolbar.pack(fill="x", padx=20, pady=(10, 0))
-        ctk.CTkButton(toolbar, text="Copy", width=100, command=self._copy_info).pack(
-            side="left", padx=5
-        )
-        ctk.CTkButton(
+        copy_btn = ctk.CTkButton(toolbar, text="Copy", width=100, command=self._copy_info)
+        copy_btn.pack(side="left", padx=5)
+        self.add_tooltip(copy_btn, "Copy system info to clipboard")
+        export_btn = ctk.CTkButton(
             toolbar, text="Export", width=100, command=self._export_json
-        ).pack(side="left", padx=5)
+        )
+        export_btn.pack(side="left", padx=5)
+        self.add_tooltip(export_btn, "Export metrics to JSON")
         self.pause_btn = ctk.CTkButton(
             toolbar, text="Pause", width=80, command=self._toggle_pause
         )
         self.pause_btn.pack(side="right")
+        self.add_tooltip(self.pause_btn, "Pause or resume updates")
         ctk.CTkOptionMenu(
             toolbar,
             variable=self.interval_var,
@@ -51,9 +56,9 @@ class SystemInfoDialog(ctk.CTkToplevel):
             command=lambda _: self._restart_loop(),
             width=80,
         ).pack(side="right", padx=5)
-        ctk.CTkButton(toolbar, text="Close", width=80, command=self.destroy).pack(
-            side="right", padx=5
-        )
+        close_btn = ctk.CTkButton(toolbar, text="Close", width=80, command=self.destroy)
+        close_btn.pack(side="right", padx=5)
+        self.add_tooltip(close_btn, "Close this window")
 
         tabview = ctk.CTkTabview(self)
         tabview.pack(fill="both", expand=True, padx=20, pady=20)
@@ -89,11 +94,11 @@ class SystemInfoDialog(ctk.CTkToplevel):
         perf_top = ctk.CTkFrame(self.perf_tab, fg_color="transparent")
         perf_top.pack(fill="x")
         self.net_label = ctk.CTkLabel(
-            perf_top, text="Network: 0 MB/s \u2191 / 0 MB/s \u2193"
+            perf_top, text="Network: 0 MB/s \u2191 / 0 MB/s \u2193", font=self.font
         )
         self.net_label.pack(anchor="w", padx=5)
         self.disk_io_label = ctk.CTkLabel(
-            perf_top, text="Disk I/O: 0 MB/s \u2193 / 0 MB/s \u2191"
+            perf_top, text="Disk I/O: 0 MB/s \u2193 / 0 MB/s \u2191", font=self.font
         )
         self.disk_io_label.pack(anchor="w", padx=5)
 
@@ -122,15 +127,15 @@ class SystemInfoDialog(ctk.CTkToplevel):
 
         other = ctk.CTkFrame(self.hw_tab, fg_color="transparent")
         other.pack(fill="x", pady=(10, 0))
-        self.freq_label = ctk.CTkLabel(other, text="CPU Freq: 0 MHz")
+        self.freq_label = ctk.CTkLabel(other, text="CPU Freq: 0 MHz", font=self.font)
         self.freq_label.pack(anchor="w")
-        self.temp_label = ctk.CTkLabel(other, text="CPU Temp: N/A")
+        self.temp_label = ctk.CTkLabel(other, text="CPU Temp: N/A", font=self.font)
         self.temp_label.pack(anchor="w")
-        self.mem_detail = ctk.CTkLabel(other, text="Memory: 0/0 GB")
+        self.mem_detail = ctk.CTkLabel(other, text="Memory: 0/0 GB", font=self.font)
         self.mem_detail.pack(anchor="w")
-        self.disk_detail = ctk.CTkLabel(other, text="Disk: 0/0 GB")
+        self.disk_detail = ctk.CTkLabel(other, text="Disk: 0/0 GB", font=self.font)
         self.disk_detail.pack(anchor="w")
-        self.battery_label = ctk.CTkLabel(other, text="Battery: N/A")
+        self.battery_label = ctk.CTkLabel(other, text="Battery: N/A", font=self.font)
         self.battery_label.pack(anchor="w")
 
     # --------------------------------------------------------------------- helpers


### PR DESCRIPTION
## Summary
- extend QuickSettingsDialog with a custom accent color picker
- update preview widgets and saved settings with the selected accent
- expand README with new note about shared styling
- fix tooltip helper for segmented buttons

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6860058d4f38832b945edbdc85340ec6