### PR TITLE
Fix accent theming error in settings view

### DIFF
--- a/src/components/status_bar.py
+++ b/src/components/status_bar.py
@@ -119,4 +119,3 @@ class StatusBar(ctk.CTkFrame):
         self.accent = self.app.theme.get_theme().get("accent_color", "#1faaff")
         self.colors["info"] = self.accent
         self.progress.configure(progress_color=self.accent)
-

--- a/src/components/toolbar.py
+++ b/src/components/toolbar.py
@@ -4,7 +4,6 @@ Toolbar component with common actions
 
 import customtkinter as ctk
 from tkinter import filedialog
-from pathlib import Path
 
 from ..utils import file_manager, open_path
 from ..utils.ui import center_window

--- a/src/utils/ui.py
+++ b/src/utils/ui.py
@@ -9,4 +9,3 @@ def center_window(window: ctk.CTkToplevel) -> None:
     x = (window.winfo_screenwidth() - width) // 2
     y = (window.winfo_screenheight() - height) // 2
     window.geometry(f"{width}x{height}+{x}+{y}")
-

--- a/src/views/about_view.py
+++ b/src/views/about_view.py
@@ -1,7 +1,6 @@
 """
 About view - Application info
 """
-import customtkinter as ctk
 from ..components.widgets import info_label
 from ..utils import open_path
 from .base_view import BaseView

--- a/src/views/auto_scan_dialog.py
+++ b/src/views/auto_scan_dialog.py
@@ -6,7 +6,6 @@ import threading
 
 from ..utils import (
     AutoScanInfo,
-    HTTPInfo,
     async_auto_scan,
     parse_ports,
     ports_as_range,

--- a/src/views/base_mixin.py
+++ b/src/views/base_mixin.py
@@ -419,8 +419,10 @@ class UIHelperMixin:
                 button_color=self.accent,
                 button_hover_color=self.accent,
             )
-        elif isinstance(parent, (ctk.CTkSwitch, ctk.CTkCheckBox)):
+        elif isinstance(parent, ctk.CTkSwitch):
             parent.configure(progress_color=self.accent, fg_color=self.accent)
+        elif isinstance(parent, ctk.CTkCheckBox):
+            parent.configure(border_color=self.accent, fg_color=self.accent)
         elif isinstance(parent, ctk.CTkRadioButton):
             parent.configure(border_color=self.accent, fg_color=self.accent)
         elif isinstance(parent, ctk.CTkSlider):

--- a/src/views/quick_settings.py
+++ b/src/views/quick_settings.py
@@ -98,14 +98,13 @@ class QuickSettingsDialog(BaseDialog):
 
         btn_frame = ctk.CTkFrame(container, fg_color="transparent")
         btn_frame.grid(row=10, column=0, columnspan=2, pady=10)
-        btn_frame.grid_columnconfigure((0,1,2), weight=1)
+        btn_frame.grid_columnconfigure((0, 1, 2), weight=1)
         self.apply_btn = self.grid_button(btn_frame, "Apply", self._apply, 0, column=0, columnspan=1)
         self.add_tooltip(self.apply_btn, "Save settings")
         self.reset_btn = self.grid_button(btn_frame, "Reset", self._reset, 0, column=1, columnspan=1)
         self.add_tooltip(self.reset_btn, "Restore previous values")
         self.cancel_btn = self.grid_button(btn_frame, "Cancel", self.destroy, 0, column=2, columnspan=1)
         self.add_tooltip(self.cancel_btn, "Close without saving")
-        
         container.grid_columnconfigure(0, weight=1)
         container.grid_columnconfigure(1, weight=1)
 

--- a/src/views/recent_files_dialog.py
+++ b/src/views/recent_files_dialog.py
@@ -67,4 +67,3 @@ class RecentFilesDialog(BaseDialog):
             self.app.config.save()
             self.app.refresh_recent_files()
         row.destroy()
-

--- a/src/views/settings_view.py
+++ b/src/views/settings_view.py
@@ -94,9 +94,12 @@ class SettingsView(BaseView):
             value=self.app.config.get("theme", {}).get("accent_color", "#007acc")
         )
         self.accent_display = ctk.CTkLabel(
-            color_frame, text=" ", width=20, fg_color=self.accent_color_var.get()
+            color_frame,
+            text=" ",
+            width=20,
+            fg_color=self.accent_color_var.get(),
         )
-        self.accent_display.pack(side="left", padx=6)
+        self.accent_display.grid(row=1, column=0, sticky="w", padx=6, pady=(6, 0))
 
         # Custom accent color picker
         accent_btn = ctk.CTkButton(
@@ -105,7 +108,7 @@ class SettingsView(BaseView):
             width=140,
             command=self._pick_accent_color,
         )
-        accent_btn.pack(side="left", padx=10)
+        accent_btn.grid(row=1, column=1, sticky="w", padx=10, pady=(6, 0))
         self.add_tooltip(accent_btn, "Pick a custom accent color")
 
         # Theme management buttons

--- a/src/views/tools_view.py
+++ b/src/views/tools_view.py
@@ -171,7 +171,6 @@ class ToolsView(BaseView):
         for name, desc, func in tools:
             self._create_tool_item(body, name, desc, func)
 
-
     def _create_tool_item(self, parent, name: str, description: str, command):
         """Create a tool item"""
         # Tool frame


### PR DESCRIPTION
## Summary
- adjust theme application logic for switches and checkboxes
- verify program launches under `xvfb`

## Testing
- `pip install -r requirements.txt`
- `flake8`
- `pytest -q`
- `xvfb-run -a python main.py`

------
https://chatgpt.com/codex/tasks/task_e_6860411ef534832b9e51a1c14eaac620