### PR TITLE
Fix overlay fullscreen init

### DIFF
--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -13,9 +13,11 @@ class ClickOverlay(tk.Toplevel):
 
     def __init__(self, parent: tk.Misc, highlight: str = "red") -> None:
         super().__init__(parent)
-        self.overrideredirect(True)
+        # Configure fullscreen before enabling override-redirect to avoid
+        # "can't set fullscreen attribute" errors on some platforms.
         self.attributes("-topmost", True)
         self.attributes("-fullscreen", True)
+        self.overrideredirect(True)
         self.configure(cursor="crosshair")
         self.canvas = tk.Canvas(self, bg="", highlightthickness=0)
         self.canvas.pack(fill="both", expand=True)

--- a/tests/test_click_overlay.py
+++ b/tests/test_click_overlay.py
@@ -1,0 +1,19 @@
+import os
+import unittest
+import tkinter as tk
+
+from src.views.click_overlay import ClickOverlay
+
+
+class TestClickOverlay(unittest.TestCase):
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_overlay_creation(self) -> None:
+        root = tk.Tk()
+        overlay = ClickOverlay(root)
+        self.assertIsInstance(overlay, tk.Toplevel)
+        overlay.destroy()
+        root.destroy()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- prevent fullscreen error when using ClickOverlay
- test ClickOverlay construction

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68625d05e004832b9a993eb7696db366