### PR TITLE
Fix debug helper script

### DIFF
--- a/scripts/run_debug.sh
+++ b/scripts/run_debug.sh
@@ -19,13 +19,11 @@ EOF
         python -m pip install --quiet debugpy
     fi
 else
-    python -m pip install --quiet debugpy
-    python -m pip install --quiet -r requirements.txt
-else
     if ! python -c 'import debugpy' >/dev/null 2>&1; then
         echo "debugpy not found; installing..." >&2
         python -m pip install --quiet debugpy
     fi
+    python -m pip install --quiet -r requirements.txt
 fi
 
 # Choose debug port

--- a/src/utils/vm.py
+++ b/src/utils/vm.py
@@ -58,8 +58,9 @@ def launch_vm_debug(
             print("warning: 'code' command not found; cannot open Visual Studio Code")
 
     backend = prefer or os.environ.get("PREFER_VM", "auto").lower()
+    detected = available_backends()
     for name in _pick_backend(backend):
-        if shutil.which(name):
+        if name in detected:
             print(f"Launching CoolBox in {name} for debugging...")
             env = os.environ.copy()
             env["DEBUG_PORT"] = str(port)
@@ -72,10 +73,10 @@ def launch_vm_debug(
                 script = root / "scripts" / "run_vagrant.sh"
                 subprocess.check_call([str(script)], env=env)
             return
-    else:
-        print("No VM backend available; launching locally under debugpy...")
-        env = os.environ.copy()
-        env["DEBUG_PORT"] = str(port)
-        if skip_deps:
-            env["SKIP_DEPS"] = "1"
-        subprocess.check_call([str(root / "scripts" / "run_debug.sh")], env=env)
+
+    print("No VM backend available; detected none. Launching locally under debugpy.")
+    env = os.environ.copy()
+    env["DEBUG_PORT"] = str(port)
+    if skip_deps:
+        env["SKIP_DEPS"] = "1"
+    subprocess.check_call([str(root / "scripts" / "run_debug.sh")], env=env)

--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -19,7 +19,11 @@ class ClickOverlay(tk.Toplevel):
         self.attributes("-fullscreen", True)
         self.overrideredirect(True)
         self.configure(cursor="crosshair")
-        self.canvas = tk.Canvas(self, bg="", highlightthickness=0)
+        # Using an empty string for the canvas background causes a TclError on
+        # some platforms. Use the parent's background color to keep the canvas
+        # visually unobtrusive while avoiding invalid color values.
+        bg_color = parent.cget("bg") if isinstance(parent, tk.Widget) else self.cget("bg")
+        self.canvas = tk.Canvas(self, bg=bg_color, highlightthickness=0)
         self.canvas.pack(fill="both", expand=True)
         self.rect = self.canvas.create_rectangle(
             0, 0, 1, 1, outline=highlight, width=2


### PR DESCRIPTION
## Summary
- avoid passing invalid empty string color to Canvas
- correct logic in run_debug.sh and add fallback installation of debugpy
- clarify message when no VM backend is found

## Testing
- `pytest -q`
- `xvfb-run -a python main.py` (terminated with Ctrl+C)


------
https://chatgpt.com/codex/tasks/task_e_68626052328c832bbb73559e677d1b46