### PR TITLE
Improve kill overlay accuracy

### DIFF
--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -2,16 +2,41 @@ from __future__ import annotations
 
 """Overlay for selecting a window by clicking it."""
 
+import os
 import tkinter as tk
 from typing import Optional
 
-from src.utils.window_utils import get_window_under_cursor, WindowInfo
+from src.utils.window_utils import (
+    get_active_window,
+    get_window_under_cursor,
+    WindowInfo,
+)
 
 
 class ClickOverlay(tk.Toplevel):
-    """Fullscreen transparent window used to select another window."""
+    """Fullscreen transparent window used to select another window.
 
-    def __init__(self, parent: tk.Misc, highlight: str = "red") -> None:
+    Parameters
+    ----------
+    parent:
+        The parent ``tk`` widget owning the overlay.
+    highlight:
+        Color used for the selection rectangle and crosshair lines.
+    probe_attempts:
+        Number of times to retry window detection when the cursor is over one
+        of this process's windows.
+    timeout:
+        Automatically close the overlay after this many seconds if provided.
+    """
+
+    def __init__(
+        self,
+        parent: tk.Misc,
+        *,
+        highlight: str = "red",
+        probe_attempts: int = 5,
+        timeout: float | None = None,
+    ) -> None:
         super().__init__(parent)
         # Configure fullscreen before enabling override-redirect to avoid
         # "can't set fullscreen attribute" errors on some platforms.
@@ -28,32 +53,82 @@ class ClickOverlay(tk.Toplevel):
         self.rect = self.canvas.create_rectangle(
             0, 0, 1, 1, outline=highlight, width=2
         )
+        # crosshair lines spanning the entire screen for precise selection
+        self.hline = self.canvas.create_line(0, 0, 0, 0, fill=highlight, dash=(4, 2))
+        self.vline = self.canvas.create_line(0, 0, 0, 0, fill=highlight, dash=(4, 2))
         self.label = self.canvas.create_text(
             0, 0, anchor="nw", fill=highlight, text="", font=("TkDefaultFont", 10, "bold")
         )
+        self.probe_attempts = probe_attempts
+        self.timeout = timeout
         self._after_id: Optional[str] = None
+        self._timeout_id: Optional[str] = None
         self.pid: int | None = None
         self.title_text: str | None = None
+        self._own_pid = os.getpid()
+
+    def _position_label(self, px: int, py: int, sw: int, sh: int) -> None:
+        """Place the info label near the cursor while keeping it on-screen."""
+        x = px + 10
+        y = py + 10
+        bbox = self.canvas.bbox(self.label)
+        if bbox:
+            width = bbox[2] - bbox[0]
+            height = bbox[3] - bbox[1]
+            if x + width > sw:
+                x = px - width - 10
+            if y + height > sh:
+                y = py - height - 10
+        self.canvas.coords(self.label, x, y)
+
+    def _query_window(self) -> WindowInfo:
+        """Return the window info below the cursor, ignoring this overlay."""
+        info = get_window_under_cursor()
+        if info.pid == self._own_pid or info.pid is None:
+            alpha = float(self.attributes("-alpha")) if self.attributes("-alpha") != "" else 1.0
+            try:
+                self.attributes("-alpha", 0.0)
+                # Probe multiple times in case other windows from this process are stacked
+                for _ in range(self.probe_attempts):
+                    info = get_window_under_cursor()
+                    if info.pid not in (self._own_pid, None):
+                        break
+            finally:
+                self.attributes("-alpha", alpha)
+        if info.pid is None:
+            info = get_active_window()
+        return info
 
     def _update_rect(self, _e: object | None = None) -> None:
-        self.withdraw()
-        info: WindowInfo = get_window_under_cursor()
-        self.deiconify()
+        info: WindowInfo = self._query_window()
         self.lift()
         self.pid = info.pid
         self.title_text = info.title
+
+        px = self.winfo_pointerx()
+        py = self.winfo_pointery()
+        sw = self.winfo_screenwidth()
+        sh = self.winfo_screenheight()
+        # Draw crosshair lines centered on the cursor
+        self.canvas.coords(self.hline, 0, py, sw, py)
+        self.canvas.coords(self.vline, px, 0, px, sh)
+
         if info.rect:
             x, y, w, h = info.rect
             self.canvas.coords(self.rect, x, y, x + w, y + h)
-            self.canvas.coords(self.label, x + 3, y + 3)
         else:
             self.canvas.coords(self.rect, -5, -5, -5, -5)
-            self.canvas.coords(self.label, -5, -5)
         text = info.title or ("PID " + str(info.pid) if info.pid else "")
         self.canvas.itemconfigure(self.label, text=text)
-        self._after_id = self.after(50, self._update_rect)
+        self._position_label(px, py, sw, sh)
+        # poll at ~30fps for smooth updates
+        self._after_id = self.after(30, self._update_rect)
 
     def _click(self, _e: object | None = None) -> None:
+        # Refresh window info on click to avoid stale selections when moving fast
+        info: WindowInfo = self._query_window()
+        self.pid = info.pid
+        self.title_text = info.title
         self.close()
 
     def close(self, _e: object | None = None) -> None:
@@ -63,6 +138,12 @@ class ClickOverlay(tk.Toplevel):
             except Exception:
                 pass
             self._after_id = None
+        if self._timeout_id is not None:
+            try:
+                self.after_cancel(self._timeout_id)
+            except Exception:
+                pass
+            self._timeout_id = None
         self.destroy()
 
     def choose(self) -> tuple[int | None, str | None]:
@@ -72,6 +153,8 @@ class ClickOverlay(tk.Toplevel):
         self.bind("<Escape>", self.close)
         self.protocol("WM_DELETE_WINDOW", self.close)
         self._update_rect()
+        if self.timeout is not None:
+            self._timeout_id = self.after(int(self.timeout * 1000), self.close)
         self.grab_set()
         self.wait_window()
         return self.pid, self.title_text

--- a/tests/test_click_overlay.py
+++ b/tests/test_click_overlay.py
@@ -1,8 +1,9 @@
 import os
 import unittest
 import tkinter as tk
+from unittest.mock import patch
 
-from src.views.click_overlay import ClickOverlay
+from src.views.click_overlay import ClickOverlay, WindowInfo
 
 
 class TestClickOverlay(unittest.TestCase):
@@ -11,6 +12,147 @@ class TestClickOverlay(unittest.TestCase):
         root = tk.Tk()
         overlay = ClickOverlay(root)
         self.assertIsInstance(overlay, tk.Toplevel)
+        overlay.destroy()
+        root.destroy()
+
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_click_refreshes_window_info(self) -> None:
+        root = tk.Tk()
+        overlay = ClickOverlay(root)
+
+        info1 = WindowInfo(1, (0, 0, 10, 10), "One")
+        info2 = WindowInfo(2, (10, 10, 20, 20), "Two")
+
+        with patch("src.views.click_overlay.get_window_under_cursor") as gwuc:
+            gwuc.side_effect = [info1, info2]
+            overlay._update_rect()
+
+            self.assertEqual(overlay.pid, 1)
+            self.assertEqual(overlay.title_text, "One")
+
+            # prevent destruction so we can inspect values
+            overlay.close = lambda _e=None: None
+            overlay._click()
+
+        self.assertEqual(overlay.pid, 2)
+        self.assertEqual(overlay.title_text, "Two")
+
+        overlay.destroy()
+        root.destroy()
+
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_query_ignores_own_window(self) -> None:
+        root = tk.Tk()
+        overlay = ClickOverlay(root)
+
+        info_self = WindowInfo(overlay._own_pid, (0, 0, 10, 10), "Self")
+        info_target = WindowInfo(123, (5, 5, 10, 10), "Target")
+
+        with patch("src.views.click_overlay.get_window_under_cursor") as gwuc:
+            gwuc.side_effect = [info_self, info_target]
+            result = overlay._query_window()
+
+        self.assertEqual(result.pid, 123)
+
+        overlay.destroy()
+        root.destroy()
+
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_query_loops_until_foreign_window(self) -> None:
+        root = tk.Tk()
+        overlay = ClickOverlay(root)
+
+        info_self = WindowInfo(overlay._own_pid, (0, 0, 5, 5), "Self")
+        info_other = WindowInfo(321, (5, 5, 10, 10), "Other")
+
+        with patch("src.views.click_overlay.get_window_under_cursor") as gwuc:
+            gwuc.side_effect = [info_self, info_self, info_other]
+            result = overlay._query_window()
+
+        self.assertEqual(result.pid, 321)
+
+        overlay.destroy()
+        root.destroy()
+
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_position_label_keeps_on_screen(self) -> None:
+        root = tk.Tk()
+        overlay = ClickOverlay(root)
+
+        overlay.canvas.bbox = lambda _item: (0, 0, 20, 10)
+        overlay.winfo_screenwidth = lambda: 100
+        overlay.winfo_screenheight = lambda: 50
+        overlay._position_label(95, 45, 100, 50)
+
+        x, y = overlay.canvas.coords(overlay.label)
+        self.assertLessEqual(x + 20, 100)
+        self.assertLessEqual(y + 10, 50)
+
+        overlay.destroy()
+        root.destroy()
+
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_probe_attempts_respected(self) -> None:
+        root = tk.Tk()
+        overlay = ClickOverlay(root, probe_attempts=3)
+
+        info_self = WindowInfo(overlay._own_pid, (0, 0, 10, 10), "Self")
+        info_other = WindowInfo(999, (5, 5, 10, 10), "Other")
+
+        with patch("src.views.click_overlay.get_window_under_cursor") as gwuc:
+            gwuc.side_effect = [info_self, info_self, info_self, info_other]
+            result = overlay._query_window()
+
+        self.assertEqual(result.pid, 999)
+        self.assertEqual(gwuc.call_count, 4)
+
+        overlay.destroy()
+        root.destroy()
+
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_crosshair_lines_follow_cursor(self) -> None:
+        root = tk.Tk()
+        overlay = ClickOverlay(root)
+
+        overlay.winfo_pointerx = lambda: 40
+        overlay.winfo_pointery = lambda: 30
+        overlay.winfo_screenwidth = lambda: 100
+        overlay.winfo_screenheight = lambda: 80
+        overlay._query_window = lambda: WindowInfo(1, None, "")
+        overlay._update_rect()
+
+        self.assertEqual(overlay.canvas.coords(overlay.hline), [0.0, 30.0, 100.0, 30.0])
+        self.assertEqual(overlay.canvas.coords(overlay.vline), [40.0, 0.0, 40.0, 80.0])
+
+        overlay.destroy()
+        root.destroy()
+
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_choose_sets_timeout(self) -> None:
+        root = tk.Tk()
+        overlay = ClickOverlay(root, timeout=1.5)
+
+        calls: list[int | str] = []
+
+        def fake_after(delay: int, func) -> str:
+            calls.append(delay)
+            return "id"
+
+        def fake_after_cancel(ident: str) -> None:
+            calls.append("cancel")
+
+        overlay.after = fake_after
+        overlay.after_cancel = fake_after_cancel
+        overlay._update_rect = lambda e=None: None
+        overlay.grab_set = lambda: None
+        overlay.wait_window = lambda: None
+
+        overlay.choose()
+        self.assertEqual(calls[0], int(1.5 * 1000))
+
+        overlay.close()
+        self.assertIn("cancel", calls)
+
         overlay.destroy()
         root.destroy()
 


### PR DESCRIPTION
## Summary
- refine window querying to temporarily hide the overlay and loop until a foreign window is found
- reposition info label intelligently so it stays on-screen
- fallback to active window when cursor detection fails
- add crosshair overlay lines centered on the cursor
- update overlay to refresh the target window info when clicked
- add configurable probe attempts and automatic timeout when choosing a window
- add tests for label positioning, multi-query logic, crosshair updates, probe attempts, and timeout scheduling

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6862a633494c832ba73e624660cdeba2