### PR TITLE
Fix Force Quit overlay transparency

### DIFF
--- a/src/utils/window_utils.py
+++ b/src/utils/window_utils.py
@@ -293,7 +293,18 @@ def make_window_clickthrough(win: Any) -> bool:
             style = ctypes.windll.user32.GetWindowLongW(hwnd, GWL_EXSTYLE)
             style |= WS_EX_LAYERED | WS_EX_TRANSPARENT | WS_EX_NOACTIVATE
             ctypes.windll.user32.SetWindowLongW(hwnd, GWL_EXSTYLE, style)
-            ctypes.windll.user32.SetLayeredWindowAttributes(hwnd, 0, 255, 0x2)
+
+            # make the window visually transparent using a color key so drawn
+            # elements like the crosshair remain visible while the background
+            # is invisible. fall back to opaque if color parsing fails.
+            try:
+                r, g, b = (c >> 8 for c in win.winfo_rgb(win.cget("bg")))
+            except Exception:  # pragma: no cover - defensive
+                r, g, b = 0, 0, 0
+            colorref = b << 16 | g << 8 | r
+            ctypes.windll.user32.SetLayeredWindowAttributes(
+                hwnd, colorref, 255, 0x1
+            )
             return True
 
         if sys.platform == "darwin":

--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -57,15 +57,22 @@ class ClickOverlay(tk.Toplevel):
         self.attributes("-fullscreen", True)
         self.overrideredirect(True)
         self.configure(cursor="crosshair")
+
+        # use a unique background color that can be made transparent. this is
+        # applied before enabling click-through so the color key matches the
+        # actual background when ``make_window_clickthrough`` is called.
+        bg_color = (
+            parent.cget("bg") if isinstance(parent, tk.Widget) else "#000001"
+        )
+        self.configure(bg=bg_color)
+
         self._clickthrough = False
         if is_supported():
             self._clickthrough = make_window_clickthrough(self)
+
         # Using an empty string for the canvas background causes a TclError on
-        # some platforms. Use the parent's background color to keep the canvas
-        # visually unobtrusive while avoiding invalid color values.
-        bg_color = (
-            parent.cget("bg") if isinstance(parent, tk.Widget) else self.cget("bg")
-        )
+        # some platforms. Use the chosen background color so the canvas itself
+        # becomes transparent via the color key.
         self.canvas = tk.Canvas(self, bg=bg_color, highlightthickness=0)
         self.canvas.pack(fill="both", expand=True)
         self.rect = self.canvas.create_rectangle(0, 0, 1, 1, outline=highlight, width=2)


### PR DESCRIPTION
## Summary
- keep the crosshair overlay invisible while selecting windows
- use a unique bg color so the Force Quit ClickOverlay transparency works
- apply color key transparency on Windows in make_window_clickthrough

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862f69ab850832bb8e9d7a38503b565