### PR TITLE
Add rainbow effect for setup installs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Iterable
 
 from src.utils.helpers import log, get_system_info
+from src.utils.rainbow import RainbowBorder
 
 
 MIN_PYTHON = (3, 10)
@@ -123,10 +124,12 @@ def _pip(args: Iterable[str], python: Path | None = None, *, upgrade_pip: bool =
     """Run ``pip`` using *python* with *args*, logging the command."""
     py = python or ensure_venv()
     if upgrade_pip:
-        subprocess.check_call([str(py), "-m", "pip", "install", "--upgrade", "pip"])
+        with RainbowBorder():
+            subprocess.check_call([str(py), "-m", "pip", "install", "--upgrade", "pip"])
     cmd = [str(py), "-m", "pip", *args]
     log("Running: " + " ".join(cmd))
-    subprocess.check_call(cmd)
+    with RainbowBorder():
+        subprocess.check_call(cmd)
 
 
 def run_tests(extra: Iterable[str] | None = None) -> None:

--- a/src/utils/rainbow.py
+++ b/src/utils/rainbow.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import shutil
+import threading
+import time
+from rich.console import Console
+from rich.text import Text
+
+class RainbowBorder:
+    """Animate a rainbow frame around the terminal without disrupting output."""
+
+    def __init__(self, speed: float = 0.05, console: Console | None = None) -> None:
+        self.speed = speed
+        self.console = console or Console()
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def __enter__(self) -> "RainbowBorder":
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.stop()
+
+    def start(self) -> None:
+        if self._thread is None:
+            self._stop.clear()
+            self.console.control("\x1b[?25l")  # hide cursor
+            self._thread = threading.Thread(target=self._run, daemon=True)
+            self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join()
+            self._thread = None
+            self._clear()
+            self.console.control("\x1b[?25h")  # show cursor
+
+    def _run(self) -> None:
+        offset = 0
+        while not self._stop.is_set():
+            self._draw(offset)
+            time.sleep(self.speed)
+            offset += 1
+
+    def _draw(self, offset: int) -> None:
+        width, height = shutil.get_terminal_size(fallback=(80, 24))
+        colors = ["red", "yellow", "green", "cyan", "blue", "magenta"]
+        c = len(colors)
+        self.console.control("\x1b7")  # save cursor
+
+        top = Text("─" * width)
+        for i in range(width):
+            top.stylize(colors[(offset + i) % c], i, i + 1)
+        self.console.control("\x1b[1;1H")
+        self.console.print(top, end="")
+
+        bottom = Text("─" * width)
+        for i in range(width):
+            bottom.stylize(colors[(offset + height + i) % c], i, i + 1)
+        self.console.control(f"\x1b[{height};1H")
+        self.console.print(bottom, end="")
+
+        for row in range(2, height):
+            left_style = colors[(offset + width + row) % c]
+            right_style = colors[(offset + width + height + row) % c]
+            self.console.control(f"\x1b[{row};1H")
+            self.console.print(Text("│", style=left_style), end="")
+            self.console.control(f"\x1b[{row};{width}H")
+            self.console.print(Text("│", style=right_style), end="")
+
+        self.console.control("\x1b8")  # restore cursor
+        self.console.file.flush()
+
+    def _clear(self) -> None:
+        width, height = shutil.get_terminal_size(fallback=(80, 24))
+        blank = " " * width
+        self.console.control("\x1b7")
+        self.console.control("\x1b[1;1H")
+        self.console.print(blank, end="")
+        for row in range(2, height):
+            self.console.control(f"\x1b[{row};1H")
+            self.console.print(" ", end="")
+            self.console.control(f"\x1b[{row};{width}H")
+            self.console.print(" ", end="")
+        self.console.control(f"\x1b[{height};1H")
+        self.console.print(blank, end="")
+        self.console.control("\x1b8")
+        self.console.file.flush()


### PR DESCRIPTION
## Summary
- draw an animated rainbow border around the terminal during dependency installation
- implement `RainbowBorder` helper using rich's live rendering

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6863026a1b48832ba74530d6e41c5427