### PR TITLE
Add Security Center tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A modern, feature-rich desktop application built with Python and CustomTkinter.
   so fonts and accent colors update instantly when settings change.
 - **Cross-Platform**: Works on Windows, macOS, and Linux
 - **Expanded Utilities**: File and directory copy/move helpers, an enhanced file manager, a threaded port scanner, a flexible hash calculator with optional disk caching, a multi-threaded duplicate finder that persists file hashes for lightning fast rescans, a screenshot capture tool, and a built-in process manager that auto-refreshes and sorts by CPU usage. The system info viewer now reports CPU cores and memory usage.
+- **Security Center**: Toggle the Windows Firewall and Defender real-time protection directly from the app.
 - **Dynamic Gauges**: Resource gauges automatically change color from green to yellow to red as usage increases for quick visual feedback.
   It also includes an advanced Force Quit utility with a searchable process
   list, automatic refresh, sort options, and multi-select termination. It can

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -77,6 +77,12 @@ from .network import (
 
 from .ui import center_window
 from .kill_utils import kill_process, kill_process_tree
+from .security import (
+    is_firewall_enabled,
+    set_firewall_enabled,
+    is_defender_enabled,
+    set_defender_enabled,
+)
 
 from . import file_manager
 
@@ -154,4 +160,8 @@ __all__ = [
     "center_window",
     "kill_process",
     "kill_process_tree",
+    "is_firewall_enabled",
+    "set_firewall_enabled",
+    "is_defender_enabled",
+    "set_defender_enabled",
 ]

--- a/src/utils/security.py
+++ b/src/utils/security.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+"""Utilities for toggling common security settings on Windows."""
+
+import platform
+import subprocess
+from typing import Optional
+
+
+# ---------------------------------------------------------------------------
+# Firewall helpers
+# ---------------------------------------------------------------------------
+
+def is_firewall_enabled() -> Optional[bool]:
+    """Return ``True`` if the Windows firewall is enabled."""
+    if platform.system() != "Windows":
+        return None
+    try:
+        out = subprocess.check_output(
+            ["netsh", "advfirewall", "show", "allprofiles"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+    except Exception:
+        return None
+    for line in out.splitlines():
+        if "State" in line:
+            if "ON" in line.upper():
+                return True
+            if "OFF" in line.upper():
+                return False
+    return None
+
+def set_firewall_enabled(enabled: bool) -> bool:
+    """Enable or disable the Windows firewall."""
+    if platform.system() != "Windows":
+        return False
+    state = "on" if enabled else "off"
+    try:
+        subprocess.run(
+            ["netsh", "advfirewall", "set", "allprofiles", "state", state],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        return True
+    except Exception:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Windows Defender helpers
+# ---------------------------------------------------------------------------
+
+def is_defender_enabled() -> Optional[bool]:
+    """Return ``True`` if real-time protection is enabled."""
+    if platform.system() != "Windows":
+        return None
+    try:
+        out = subprocess.check_output(
+            [
+                "powershell",
+                "-Command",
+                "(Get-MpPreference).DisableRealtimeMonitoring",
+            ],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+    except Exception:
+        return None
+    val = out.strip().lower()
+    if val in {"true", "1"}:
+        return False
+    if val in {"false", "0"}:
+        return True
+    return None
+
+def set_defender_enabled(enabled: bool) -> bool:
+    """Enable or disable Windows Defender real-time protection."""
+    if platform.system() != "Windows":
+        return False
+    value = "$false" if enabled else "$true"
+    try:
+        subprocess.run(
+            [
+                "powershell",
+                "-Command",
+                f"Set-MpPreference -DisableRealtimeMonitoring {value}",
+            ],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        return True
+    except Exception:
+        return False
+

--- a/src/views/__init__.py
+++ b/src/views/__init__.py
@@ -13,6 +13,7 @@ from .force_quit_dialog import ForceQuitDialog
 from .click_overlay import ClickOverlay
 from .system_info_dialog import SystemInfoDialog
 from .recent_files_dialog import RecentFilesDialog
+from .security_dialog import SecurityDialog
 
 __all__ = [
     "BaseView",
@@ -28,4 +29,5 @@ __all__ = [
     "ClickOverlay",
     "SystemInfoDialog",
     "RecentFilesDialog",
+    "SecurityDialog",
 ]

--- a/src/views/security_dialog.py
+++ b/src/views/security_dialog.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+"""Dialog for toggling firewall and Defender."""
+
+import platform
+from tkinter import messagebox
+import customtkinter as ctk
+
+from .base_dialog import BaseDialog
+from ..utils.security import (
+    is_firewall_enabled,
+    set_firewall_enabled,
+    is_defender_enabled,
+    set_defender_enabled,
+)
+
+
+class SecurityDialog(BaseDialog):
+    """UI for basic security switches."""
+
+    def __init__(self, app):
+        super().__init__(app, title="Security Center", geometry="320x200")
+        container = self.create_container()
+        self.add_title(container, "Security Center", use_pack=False).grid(
+            row=0, column=0, columnspan=2, pady=(0, self.pady)
+        )
+
+        self.firewall_var = ctk.BooleanVar()
+        self.defender_var = ctk.BooleanVar()
+
+        self.firewall_sw = self.grid_switch(
+            container, "Enable Firewall", self.firewall_var, 1
+        )
+        self.defender_sw = self.grid_switch(
+            container, "Enable Defender", self.defender_var, 2
+        )
+
+        btn_frame = ctk.CTkFrame(container, fg_color="transparent")
+        btn_frame.grid(row=3, column=0, columnspan=2, pady=10)
+        btn_frame.grid_columnconfigure((0, 1, 2), weight=1)
+
+        self.grid_button(btn_frame, "Refresh", self._refresh, 0, column=0, columnspan=1)
+        self.grid_button(btn_frame, "Apply", self._apply, 0, column=1, columnspan=1)
+        self.grid_button(btn_frame, "Close", self.destroy, 0, column=2, columnspan=1)
+
+        container.grid_columnconfigure(0, weight=1)
+        container.grid_columnconfigure(1, weight=1)
+
+        self._refresh()
+        self.center_window()
+        self.refresh_fonts()
+        self.refresh_theme()
+
+    def _refresh(self) -> None:
+        if platform.system() != "Windows":
+            self.firewall_sw.configure(state="disabled")
+            self.defender_sw.configure(state="disabled")
+            return
+        self.firewall_var.set(is_firewall_enabled() or False)
+        self.defender_var.set(is_defender_enabled() or False)
+
+    def _apply(self) -> None:
+        if platform.system() != "Windows":
+            messagebox.showinfo(
+                "Security Center", "Firewall and Defender control is Windows only."
+            )
+            return
+        ok_fw = set_firewall_enabled(self.firewall_var.get())
+        ok_def = set_defender_enabled(self.defender_var.get())
+        if ok_fw and ok_def:
+            messagebox.showinfo("Security Center", "Settings applied successfully")
+        else:
+            messagebox.showwarning(
+                "Security Center", "Failed to apply some settings"
+            )
+

--- a/src/views/tools_view.py
+++ b/src/views/tools_view.py
@@ -149,6 +149,11 @@ class ToolsView(BaseView):
                 "Run CoolBox in a VM and wait for debugger",
                 self._launch_vm_debug,
             ),
+            (
+                "Security Center",
+                "Toggle Firewall and Defender",
+                self._security_center,
+            ),
         ]
 
         for name, desc, func in tools:
@@ -666,6 +671,12 @@ class ToolsView(BaseView):
                     self.app.window.after(0, self.app.status_bar.hide_progress)
 
         threading.Thread(target=run, daemon=True).start()
+
+    def _security_center(self) -> None:
+        """Open the Security Center dialog."""
+        from .security_dialog import SecurityDialog
+
+        SecurityDialog(self.app)
 
     def _text_editor(self):
         """Open a simple text editor window."""

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,63 @@
+import subprocess
+import platform
+import subprocess
+import platform
+from types import SimpleNamespace
+
+from src.utils.security import (
+    is_firewall_enabled,
+    set_firewall_enabled,
+    is_defender_enabled,
+    set_defender_enabled,
+)
+
+
+def test_is_firewall_enabled_true(monkeypatch):
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    def fake_output(cmd, text=True, stderr=None):
+        return "State ON"
+    monkeypatch.setattr(subprocess, "check_output", fake_output)
+    assert is_firewall_enabled() is True
+
+
+def test_is_firewall_enabled_false(monkeypatch):
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    def fake_output(cmd, text=True, stderr=None):
+        return "State OFF"
+    monkeypatch.setattr(subprocess, "check_output", fake_output)
+    assert is_firewall_enabled() is False
+
+
+def test_set_firewall_enabled(monkeypatch):
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    called = {}
+    def fake_run(cmd, check=True, stdout=None, stderr=None):
+        called["cmd"] = cmd
+        return SimpleNamespace(returncode=0)
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    assert set_firewall_enabled(True) is True
+    assert called["cmd"] == ["netsh", "advfirewall", "set", "allprofiles", "state", "on"]
+
+
+def test_is_defender_enabled(monkeypatch):
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    def fake_output(cmd, text=True, stderr=None):
+        return "False"
+    monkeypatch.setattr(subprocess, "check_output", fake_output)
+    assert is_defender_enabled() is True
+
+
+def test_set_defender_enabled(monkeypatch):
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    called = {}
+    def fake_run(cmd, check=True, stdout=None, stderr=None):
+        called["cmd"] = cmd
+        return SimpleNamespace(returncode=0)
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    assert set_defender_enabled(False) is True
+    assert called["cmd"] == [
+        "powershell",
+        "-Command",
+        "Set-MpPreference -DisableRealtimeMonitoring $true",
+    ]
+


### PR DESCRIPTION
## Summary
- implement firewall and Defender toggles in new Security Center
- integrate security utilities into utils package
- expose Security Center tool in Tools view and include docs
- add unit tests for security helpers

## Testing
- `flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686305e260e0832bb2c4758024ce588b