### PR TITLE
Enhance rainbow border and clean up tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -124,11 +124,11 @@ def _pip(args: Iterable[str], python: Path | None = None, *, upgrade_pip: bool =
     """Run ``pip`` using *python* with *args*, logging the command."""
     py = python or ensure_venv()
     if upgrade_pip:
-        with RainbowBorder():
+        with RainbowBorder(theme="awau", style="rounded"):
             subprocess.check_call([str(py), "-m", "pip", "install", "--upgrade", "pip"])
     cmd = [str(py), "-m", "pip", *args]
     log("Running: " + " ".join(cmd))
-    with RainbowBorder():
+    with RainbowBorder(theme="awau", style="rounded"):
         subprocess.check_call(cmd)
 
 

--- a/src/utils/security.py
+++ b/src/utils/security.py
@@ -31,6 +31,7 @@ def is_firewall_enabled() -> Optional[bool]:
                 return False
     return None
 
+
 def set_firewall_enabled(enabled: bool) -> bool:
     """Enable or disable the Windows firewall."""
     if platform.system() != "Windows":
@@ -75,6 +76,7 @@ def is_defender_enabled() -> Optional[bool]:
         return True
     return None
 
+
 def set_defender_enabled(enabled: bool) -> bool:
     """Enable or disable Windows Defender real-time protection."""
     if platform.system() != "Windows":
@@ -94,4 +96,3 @@ def set_defender_enabled(enabled: bool) -> bool:
         return True
     except Exception:
         return False
-

--- a/src/views/security_dialog.py
+++ b/src/views/security_dialog.py
@@ -73,4 +73,3 @@ class SecurityDialog(BaseDialog):
             messagebox.showwarning(
                 "Security Center", "Failed to apply some settings"
             )
-

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,7 +1,5 @@
 import subprocess
 import platform
-import subprocess
-import platform
 from types import SimpleNamespace
 
 from src.utils.security import (
@@ -14,6 +12,7 @@ from src.utils.security import (
 
 def test_is_firewall_enabled_true(monkeypatch):
     monkeypatch.setattr(platform, "system", lambda: "Windows")
+
     def fake_output(cmd, text=True, stderr=None):
         return "State ON"
     monkeypatch.setattr(subprocess, "check_output", fake_output)
@@ -22,6 +21,7 @@ def test_is_firewall_enabled_true(monkeypatch):
 
 def test_is_firewall_enabled_false(monkeypatch):
     monkeypatch.setattr(platform, "system", lambda: "Windows")
+
     def fake_output(cmd, text=True, stderr=None):
         return "State OFF"
     monkeypatch.setattr(subprocess, "check_output", fake_output)
@@ -31,6 +31,7 @@ def test_is_firewall_enabled_false(monkeypatch):
 def test_set_firewall_enabled(monkeypatch):
     monkeypatch.setattr(platform, "system", lambda: "Windows")
     called = {}
+
     def fake_run(cmd, check=True, stdout=None, stderr=None):
         called["cmd"] = cmd
         return SimpleNamespace(returncode=0)
@@ -41,6 +42,7 @@ def test_set_firewall_enabled(monkeypatch):
 
 def test_is_defender_enabled(monkeypatch):
     monkeypatch.setattr(platform, "system", lambda: "Windows")
+
     def fake_output(cmd, text=True, stderr=None):
         return "False"
     monkeypatch.setattr(subprocess, "check_output", fake_output)
@@ -50,6 +52,7 @@ def test_is_defender_enabled(monkeypatch):
 def test_set_defender_enabled(monkeypatch):
     monkeypatch.setattr(platform, "system", lambda: "Windows")
     called = {}
+
     def fake_run(cmd, check=True, stdout=None, stderr=None):
         called["cmd"] = cmd
         return SimpleNamespace(returncode=0)
@@ -60,4 +63,3 @@ def test_set_defender_enabled(monkeypatch):
         "-Command",
         "Set-MpPreference -DisableRealtimeMonitoring $true",
     ]
-

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,5 +1,4 @@
 import importlib
-from pathlib import Path
 
 import setup
 
@@ -22,4 +21,3 @@ def test_get_venv_dir_env(monkeypatch, tmp_path):
     monkeypatch.setenv("COOLBOX_VENV", str(tmp_path / "v"))
     importlib.reload(setup)
     assert setup.get_venv_dir() == tmp_path / "v"
-


### PR DESCRIPTION
## Summary
- extend `RainbowBorder` with theme and style configs
- use the awau theme in `setup.py` for pip commands
- fix lint errors in security helpers and views
- clean up security tests and setup tests

## Testing
- `python -m flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68638c24ae28832b8414f0641b3d4edb