### PR TITLE
Improve setup with neon spinner

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ A modern, feature-rich desktop application built with Python and CustomTkinter.
 - **Expanded Utilities**: File and directory copy/move helpers, an enhanced file manager, a threaded port scanner, a flexible hash calculator with optional disk caching, a multi-threaded duplicate finder that persists file hashes for lightning fast rescans, a screenshot capture tool, and a built-in process manager that auto-refreshes and sorts by CPU usage. The system info viewer now reports CPU cores and memory usage.
 - **Security Center**: Toggle the Windows Firewall and Defender real-time protection directly from the app.
 - **Dynamic Gauges**: Resource gauges automatically change color from green to yellow to red as usage increases for quick visual feedback.
-- **Stylish Setup**: Dependency installation is wrapped in a swirling blue glow animation for extra flair.
+- **Stylish Setup**: Dependency installation is wrapped in a pulsing neon border
+  with a dynamic spinner and live output for extra flair, even when triggered
+  automatically on first launch.
   It also includes an advanced Force Quit utility with a searchable process
   list, automatic refresh, sort options, and multi-select termination. It can
   kill processes by name, command line pattern, port, host, open file, executable path
@@ -368,7 +370,8 @@ For a development environment with additional tools, use:
 python setup.py --dev
 ```
 This script installs all packages from `requirements.txt` and optional
-development extras like `debugpy` and `flake8`.
+development extras like `debugpy` and `flake8` while displaying a
+pulsing neon border and real-time progress.
 
 For a development environment with debugging tools, run:
 ```bash
@@ -393,7 +396,8 @@ python main.py
 By default, ``main.py`` computes a digest of ``requirements.txt``, ``setup.py``
 and your Python executable. It also verifies that all listed packages are
 installed. When either the digest has changed or any dependency is missing it
-silently runs ``setup.py install --skip-update`` before launching. Set
+automatically runs the setup routine with the same neon border and spinner
+for a seamless experience. Set
 ``SKIP_SETUP=1`` to bypass this check if you have already handled installation
 yourself.
 

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -13,8 +13,10 @@ from .helpers import (
     darken_color,
     adjust_color,
     hex_brightness,
+    run_with_spinner,
+    console,
 )
-from .rainbow import RainbowBorder, BlueGlowBorder
+from .rainbow import RainbowBorder, NeonPulseBorder
 from .vm import launch_vm_debug
 from .file_manager import (
     read_text,
@@ -110,8 +112,10 @@ __all__ = [
     "darken_color",
     "adjust_color",
     "hex_brightness",
+    "run_with_spinner",
+    "console",
     "RainbowBorder",
-    "BlueGlowBorder",
+    "NeonPulseBorder",
     "launch_vm_debug",
     "scan_ports",
     "async_scan_ports",

--- a/tests/test_auto_setup.py
+++ b/tests/test_auto_setup.py
@@ -1,4 +1,5 @@
 import importlib
+import os
 import sys
 from types import ModuleType
 
@@ -37,3 +38,29 @@ def test_requirements_satisfied_fail(monkeypatch, tmp_path):
 
     importlib.reload(main)
     assert main._requirements_satisfied(req) is False
+
+
+def test_run_setup_if_needed_imports_setup(monkeypatch, tmp_path):
+    setup_py = tmp_path / "setup.py"
+    setup_py.write_text(
+        """
+from pathlib import Path
+def show_setup_banner():
+    pass
+def check_python_version():
+    pass
+def install(skip_update=False):
+    Path('called').write_text(str(skip_update))
+"""
+    )
+    (tmp_path / "requirements.txt").write_text("")
+    monkeypatch.setattr(main, "_compute_setup_state", lambda root: "x")
+    monkeypatch.setattr(main, "_requirements_satisfied", lambda req: False)
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        main._run_setup_if_needed(tmp_path)
+    finally:
+        os.chdir(cwd)
+    assert (tmp_path / "called").read_text() == "True"
+    assert (tmp_path / ".setup_done").read_text() == "x"

--- a/tests/test_rainbow.py
+++ b/tests/test_rainbow.py
@@ -1,8 +1,8 @@
-from src.utils.rainbow import BlueGlowBorder
+from src.utils.rainbow import NeonPulseBorder
 
 
 def test_generate_colors_changes_with_phase():
-    b = BlueGlowBorder(speed=0.01)
+    b = NeonPulseBorder(speed=0.01)
     cols1 = b._generate_colors(10, 5)
     b._phase += 1.0
     cols2 = b._generate_colors(10, 5)
@@ -11,8 +11,8 @@ def test_generate_colors_changes_with_phase():
     assert all(c.startswith('#') for c in cols1)
 
 
-def test_generate_colors_amplitude_zero():
-    b = BlueGlowBorder(amplitude=0)
+def test_single_color_when_no_highlight():
+    b = NeonPulseBorder(base_color="#123456", highlight_color="#123456")
     colors = b._generate_colors(8, 4)
     assert len(set(colors)) == 1
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -35,7 +35,7 @@ def test_pip_uses_blue_glow(monkeypatch):
         def __exit__(self, exc_type, exc, tb):
             calls.append("exit")
 
-    monkeypatch.setattr(setup, "BlueGlowBorder", DummyBorder)
+    monkeypatch.setattr(setup, "NeonPulseBorder", DummyBorder)
     monkeypatch.setattr(
         setup.subprocess,
         "check_call",


### PR DESCRIPTION
## Summary
- revamp repo update to animate git commands with the neon spinner
- integrate setup.py directly into main so automatic setup shows the neon effect
- document the flashy automatic setup in the README
- add regression test for loading setup as a module
- cover new spinner helper with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686393298cd8832bbca3c0336da5e4c2