### PR TITLE
Improve kill overlay window selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ A modern, feature-rich desktop application built with Python and CustomTkinter.
 - **Cross-Platform**: Works on Windows, macOS, and Linux
 - **Expanded Utilities**: File and directory copy/move helpers, an enhanced file manager, a threaded port scanner, a flexible hash calculator with optional disk caching, a multi-threaded duplicate finder that persists file hashes for lightning fast rescans, a screenshot capture tool, and a built-in process manager that auto-refreshes and sorts by CPU usage. The system info viewer now reports CPU cores and memory usage.
 - **Security Center**: Toggle the Windows Firewall and Defender real-time protection directly from the app.
+- **Kill by Click CLI**: `scripts/kill_by_click.py` opens the crosshair overlay
+  from the terminal so you can quickly select any window.
 - **Dynamic Gauges**: Resource gauges automatically change color from green to yellow to red as usage increases for quick visual feedback.
   It also includes an advanced Force Quit utility with a searchable process
   list, automatic refresh, sort options, and multi-select termination. It can
@@ -50,6 +52,9 @@ A modern, feature-rich desktop application built with Python and CustomTkinter.
   and tracks pointer coordinates from hook callbacks or motion events to keep
   updates smooth without flicker. The window's normal interaction state is
   restored automatically when the overlay closes. The overlay samples the window
+  The highlight color defaults to ``red`` but can be customized by setting
+  ``KILL_BY_CLICK_HIGHLIGHT`` in the environment. The ``scripts/kill_by_click.py``
+  helper launches the overlay directly from the command line. The overlay samples the window
   repeatedly and mixes those results with a short hover history to choose the
   most stable PID even when windows overlap. ``KILL_BY_CLICK_HISTORY`` sets how
   many hover entries are kept while ``KILL_BY_CLICK_SAMPLE_DECAY`` and

--- a/scripts/kill_by_click.py
+++ b/scripts/kill_by_click.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+"""Select a window by clicking it and print the PID and title."""
+
+import tkinter as tk
+from src.views.click_overlay import ClickOverlay
+
+
+def main() -> None:
+    root = tk.Tk()
+    root.withdraw()
+    overlay = ClickOverlay(root)
+    pid, title = overlay.choose()
+    if pid is None:
+        print("No window selected")
+    else:
+        print(f"{pid} {title or ''}")
+    root.destroy()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -77,6 +77,7 @@ from .network import (
 
 from .ui import center_window
 from .kill_utils import kill_process, kill_process_tree
+from .scoring_engine import ScoringEngine, Tuning, tuning
 from .security import (
     is_firewall_enabled,
     set_firewall_enabled,
@@ -164,4 +165,7 @@ __all__ = [
     "set_firewall_enabled",
     "is_defender_enabled",
     "set_defender_enabled",
+    "ScoringEngine",
+    "Tuning",
+    "tuning",
 ]

--- a/src/utils/scoring_engine.py
+++ b/src/utils/scoring_engine.py
@@ -1,0 +1,355 @@
+from __future__ import annotations
+
+import math
+import os
+import time
+from collections import deque
+from dataclasses import dataclass, fields
+from typing import Deque, Dict, List, Tuple
+
+from .window_utils import WindowInfo, list_windows_at
+
+
+@dataclass(slots=True)
+class Tuning:
+    """Weight and scoring parameters loaded from environment variables."""
+
+    interval: float = 0.01
+    pid_history_size: int = 5
+    sample_decay: float = 0.85
+    history_decay: float = 0.9
+    sample_weight: float = 1.0
+    history_weight: float = 0.7
+    active_bonus: float = 2.0
+    area_weight: float = 0.0
+    confidence_ratio: float = 1.2
+    extra_attempts: int = 3
+    score_decay: float = 0.9
+    score_min: float = 0.1
+    softmax_temp: float = 1.0
+    dominance: float = 0.55
+    stability_threshold: int = 1
+    velocity_scale: float = 0.0
+    stability_weight: float = 0.0
+    center_weight: float = 0.0
+    edge_penalty: float = 0.0
+    edge_buffer: int = 5
+    vel_stab_scale: float = 0.0
+    path_history: int = 15
+    path_weight: float = 0.0
+    heatmap_res: int = 64
+    heatmap_decay: float = 0.9
+    heatmap_weight: float = 0.0
+    streak_weight: float = 0.0
+    tracker_ratio: float = 1.5
+    recency_weight: float = 0.0
+    duration_weight: float = 0.0
+    confirm_delay: float = 0.0
+    confirm_weight: float = 1.0
+    zorder_weight: float = 0.0
+    gaze_decay: float = 0.9
+    gaze_weight: float = 0.0
+    active_history_size: int = 5
+    active_history_weight: float = 0.0
+    active_history_decay: float = 0.9
+    near_radius: int = 2
+    velocity_smooth: float = 0.5
+    flash_duration_ms: int = 150
+
+    @classmethod
+    def from_env(cls, prefix: str = "") -> "Tuning":
+        params = {}
+        for f in fields(cls):
+            env = os.getenv(f"{prefix}{f.name.upper()}")
+            if env is None:
+                params[f.name] = f.default
+                continue
+            try:
+                if f.type is int:
+                    params[f.name] = int(env)
+                elif f.type is float:
+                    params[f.name] = float(env)
+                else:
+                    params[f.name] = env
+            except Exception:
+                params[f.name] = f.default
+        return cls(**params)
+
+
+def softmax(weights: Dict[int, float], temp: float) -> Dict[int, float]:
+    if not weights:
+        return {}
+    scale = 1.0 / max(temp, 1e-6)
+    exps = {pid: math.exp(w * scale) for pid, w in weights.items()}
+    total = sum(exps.values())
+    if total <= 0.0:
+        return {}
+    return {pid: val / total for pid, val in exps.items()}
+
+
+class CursorHeatmap:
+    def __init__(self, width: int, height: int, tuning: Tuning) -> None:
+        self.tuning = tuning
+        self.res = max(1, tuning.heatmap_res)
+        self.decay = tuning.heatmap_decay
+        self.w = width // self.res + 1
+        self.h = height // self.res + 1
+        self.grid = [[0.0 for _ in range(self.w)] for _ in range(self.h)]
+
+    def update(self, x: int, y: int) -> None:
+        gx = min(int(x / self.res), self.w - 1)
+        gy = min(int(y / self.res), self.h - 1)
+        for row in self.grid:
+            for i in range(len(row)):
+                row[i] *= self.decay
+        self.grid[gy][gx] += 1.0
+
+    def region_score(self, rect: Tuple[int, int, int, int] | None) -> float:
+        if not rect:
+            return 0.0
+        x, y, w, h = rect
+        gx1 = max(0, int(x / self.res))
+        gy1 = max(0, int(y / self.res))
+        gx2 = min(self.w - 1, int((x + w) / self.res))
+        gy2 = min(self.h - 1, int((y + h) / self.res))
+        total = 0.0
+        cells = 0
+        for gy in range(gy1, gy2 + 1):
+            row = self.grid[gy]
+            for gx in range(gx1, gx2 + 1):
+                total += row[gx]
+                cells += 1
+        return total / max(cells, 1)
+
+
+class WindowTracker:
+    def __init__(self, tuning: Tuning) -> None:
+        self.tuning = tuning
+        self.scores: Dict[int, float] = {}
+        self.info_history: Deque[WindowInfo] = deque(maxlen=tuning.pid_history_size)
+        self.last_seen: Dict[int, float] = {}
+        self.durations: Dict[int, float] = {}
+
+    def decay(self) -> None:
+        for pid in list(self.scores):
+            self.scores[pid] *= self.tuning.score_decay
+            if self.scores[pid] < self.tuning.score_min:
+                del self.scores[pid]
+
+    def add(self, info: WindowInfo, active: int | None = None) -> None:
+        if info.pid is None:
+            return
+        self.decay()
+        weight = self.tuning.sample_weight
+        if active is not None and info.pid == active:
+            weight *= self.tuning.active_bonus
+        if info.rect and self.tuning.area_weight:
+            area = info.rect[2] * info.rect[3]
+            if area:
+                weight += self.tuning.area_weight / float(area)
+        self.scores[info.pid] = self.scores.get(info.pid, 0.0) + weight
+        self.info_history.append(info)
+        now = time.monotonic()
+        last = self.last_seen.get(info.pid)
+        if last is not None:
+            self.durations[info.pid] = self.durations.get(info.pid, 0.0) + now - last
+        self.last_seen[info.pid] = now
+
+    def best(self) -> WindowInfo | None:
+        if not self.scores:
+            return None
+        pid = max(self.scores.items(), key=lambda i: i[1])[0]
+        for info in reversed(self.info_history):
+            if info.pid == pid:
+                return info
+        return WindowInfo(pid)
+
+    def best_with_confidence(self) -> Tuple[WindowInfo | None, float]:
+        if not self.scores:
+            return None, 0.0
+        ordered = sorted(self.scores.items(), key=lambda i: i[1], reverse=True)
+        best_pid, best_score = ordered[0]
+        second_score = ordered[1][1] if len(ordered) > 1 else 0.0
+        info = self.best()
+        return info, best_score / (second_score or 1e-6)
+
+
+class ScoringEngine:
+    def __init__(self, tuning: Tuning, width: int, height: int, own_pid: int) -> None:
+        self.tuning = tuning
+        self.own_pid = own_pid
+        self.tracker = WindowTracker(tuning)
+        self.pid_history: Deque[int] = deque(maxlen=tuning.pid_history_size)
+        self.info_history: Deque[WindowInfo] = deque(maxlen=tuning.pid_history_size)
+        self.pid_stability: Dict[int, int] = {}
+        self.current_pid: int | None = None
+        self.current_streak = 0
+        self.gaze_duration: Dict[int, float] = {}
+        self.active_history: Deque[Tuple[int, float]] = deque(
+            maxlen=tuning.active_history_size
+        )
+        self.heatmap = CursorHeatmap(width, height, tuning)
+
+    def score_samples(
+        self,
+        samples: List[WindowInfo],
+        cursor_x: float,
+        cursor_y: float,
+        velocity: float,
+        path_history: Deque[Tuple[int, int]],
+        initial_active_pid: int | None,
+    ) -> Dict[int, float]:
+        weights: Dict[int, float] = dict(self.tracker.scores)
+        active = initial_active_pid
+
+        power = 1.0
+        for info in reversed([s for s in samples if s.pid not in (self.own_pid, None)]):
+            vel_factor = 1.0 / (1.0 + velocity * self.tuning.velocity_scale)
+            w = self.tuning.sample_weight * power * vel_factor
+            if info.pid == active:
+                w *= self.tuning.active_bonus
+            if info.rect and self.tuning.area_weight:
+                area = info.rect[2] * info.rect[3]
+                if area:
+                    w += self.tuning.area_weight / float(area)
+            if info.rect and self.tuning.center_weight:
+                cx = info.rect[0] + info.rect[2] / 2
+                cy = info.rect[1] + info.rect[3] / 2
+                dist = math.hypot(cx - cursor_x, cy - cursor_y)
+                diag = math.hypot(info.rect[2], info.rect[3])
+                if diag:
+                    w += self.tuning.center_weight * (1 - min(dist / diag, 1.0))
+            if info.rect and self.tuning.edge_penalty:
+                left = info.rect[0]
+                top = info.rect[1]
+                right = left + info.rect[2]
+                bottom = top + info.rect[3]
+                near_x = min(abs(cursor_x - left), abs(cursor_x - right))
+                near_y = min(abs(cursor_y - top), abs(cursor_y - bottom))
+                if (
+                    near_x <= self.tuning.edge_buffer
+                    or near_y <= self.tuning.edge_buffer
+                ):
+                    w *= max(0.0, 1.0 - self.tuning.edge_penalty)
+            if info.rect and self.tuning.path_weight and path_history:
+                inside = 0
+                for px, py in path_history:
+                    if (
+                        info.rect[0] <= px <= info.rect[0] + info.rect[2]
+                        and info.rect[1] <= py <= info.rect[1] + info.rect[3]
+                    ):
+                        inside += 1
+                w += self.tuning.path_weight * inside / len(path_history)
+            if self.tuning.heatmap_weight and info.rect:
+                heat = self.heatmap.region_score(info.rect)
+                area = info.rect[2] * info.rect[3] or 1
+                w += self.tuning.heatmap_weight * heat / float(area)
+            weights[info.pid] = weights.get(info.pid, 0.0) + w
+            power *= self.tuning.sample_decay
+
+        power = 1.0
+        for pid in reversed(self.pid_history):
+            vel_factor = 1.0 / (1.0 + velocity * self.tuning.velocity_scale)
+            w = self.tuning.history_weight * power * vel_factor
+            if pid == active:
+                w *= self.tuning.active_bonus
+            weights[pid] = weights.get(pid, 0.0) + w
+            power *= self.tuning.history_decay
+
+        if self.tuning.stability_weight:
+            for pid, count in self.pid_stability.items():
+                weights[pid] = (
+                    weights.get(pid, 0.0) + count * self.tuning.stability_weight
+                )
+
+        if self.tuning.streak_weight and self.current_pid is not None:
+            weights[self.current_pid] = (
+                weights.get(self.current_pid, 0.0)
+                + self.current_streak * self.tuning.streak_weight
+            )
+
+        now = time.monotonic()
+        if self.tuning.recency_weight:
+            for pid, last in self.tracker.last_seen.items():
+                weights[pid] = weights.get(pid, 0.0) + self.tuning.recency_weight / (
+                    now - last + 1e-6
+                )
+        if self.tuning.duration_weight:
+            for pid, dur in self.tracker.durations.items():
+                weights[pid] = weights.get(pid, 0.0) + dur * self.tuning.duration_weight
+
+        if self.tuning.zorder_weight:
+            stack = list_windows_at(int(cursor_x), int(cursor_y))
+            for idx, info in enumerate(stack):
+                if info.pid is None:
+                    continue
+                weights[info.pid] = weights.get(
+                    info.pid, 0.0
+                ) + self.tuning.zorder_weight / (idx + 1)
+
+        if self.tuning.gaze_weight:
+            for pid, dur in self.gaze_duration.items():
+                weights[pid] = weights.get(pid, 0.0) + dur * self.tuning.gaze_weight
+
+        if self.tuning.active_history_weight and self.active_history:
+            power = 1.0
+            for pid, _ in reversed(self.active_history):
+                weights[pid] = (
+                    weights.get(pid, 0.0) + self.tuning.active_history_weight * power
+                )
+                power *= self.tuning.active_history_decay
+
+        return weights
+
+    def select_from_weights(
+        self, samples: List[WindowInfo], weights: Dict[int, float]
+    ) -> WindowInfo | None:
+        if not weights:
+            return None
+        pid = max(weights.items(), key=lambda item: item[1])[0]
+        for info in reversed(samples):
+            if info.pid == pid:
+                return info
+        for info in reversed(self.info_history):
+            if info.pid == pid:
+                return info
+        return WindowInfo(pid)
+
+    def weighted_choice(
+        self,
+        samples: List[WindowInfo],
+        cursor_x: float,
+        cursor_y: float,
+        velocity: float,
+        path_history: Deque[Tuple[int, int]],
+        initial_active_pid: int | None,
+    ) -> WindowInfo | None:
+        weights = self.score_samples(
+            samples, cursor_x, cursor_y, velocity, path_history, initial_active_pid
+        )
+        return self.select_from_weights(samples, weights)
+
+    def weighted_confidence(
+        self,
+        samples: List[WindowInfo],
+        cursor_x: float,
+        cursor_y: float,
+        velocity: float,
+        path_history: Deque[Tuple[int, int]],
+        initial_active_pid: int | None,
+    ) -> Tuple[WindowInfo | None, float, float]:
+        weights = self.score_samples(
+            samples, cursor_x, cursor_y, velocity, path_history, initial_active_pid
+        )
+        if not weights:
+            return None, 0.0, 0.0
+        probs = softmax(weights, self.tuning.softmax_temp)
+        ordered = sorted(probs.items(), key=lambda i: i[1], reverse=True)
+        best_pid, best_prob = ordered[0]
+        second_prob = ordered[1][1] if len(ordered) > 1 else 0.0
+        ratio = best_prob / (second_prob or 1e-6)
+        info = self.select_from_weights(samples, weights)
+        return info, ratio, best_prob
+
+
+tuning = Tuning.from_env(prefix="KILL_BY_CLICK_")

--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -14,6 +14,7 @@ import math
 import tkinter as tk
 from collections import deque
 from typing import Optional
+from enum import Enum, auto
 
 from src.utils.window_utils import (
     get_active_window,
@@ -24,148 +25,22 @@ from src.utils.window_utils import (
     WindowInfo,
 )
 from src.utils.mouse_listener import capture_mouse, is_supported
+from src.utils.scoring_engine import ScoringEngine, tuning
 
-# Polling delay used when global hooks aren't available
-KILL_BY_CLICK_INTERVAL = float(os.getenv("KILL_BY_CLICK_INTERVAL", "0.01"))
-PID_HISTORY_SIZE = int(os.getenv("KILL_BY_CLICK_HISTORY", "5"))
-SAMPLE_DECAY = float(os.getenv("KILL_BY_CLICK_SAMPLE_DECAY", "0.85"))
-HISTORY_DECAY = float(os.getenv("KILL_BY_CLICK_HISTORY_DECAY", "0.9"))
-SAMPLE_WEIGHT = float(os.getenv("KILL_BY_CLICK_SAMPLE_WEIGHT", "1.0"))
-HISTORY_WEIGHT = float(os.getenv("KILL_BY_CLICK_HISTORY_WEIGHT", "0.7"))
-ACTIVE_BONUS = float(os.getenv("KILL_BY_CLICK_ACTIVE_BONUS", "2.0"))
-AREA_WEIGHT = float(os.getenv("KILL_BY_CLICK_AREA_WEIGHT", "0.0"))
-CONFIDENCE_RATIO = float(os.getenv("KILL_BY_CLICK_CONFIDENCE", "1.2"))
-EXTRA_ATTEMPTS = int(os.getenv("KILL_BY_CLICK_EXTRA_ATTEMPTS", "3"))
-SCORE_DECAY = float(os.getenv("KILL_BY_CLICK_SCORE_DECAY", "0.9"))
-SCORE_MIN = float(os.getenv("KILL_BY_CLICK_SCORE_MIN", "0.1"))
-SOFTMAX_TEMP = float(os.getenv("KILL_BY_CLICK_SOFTMAX_TEMP", "1.0"))
-DOMINANCE = float(os.getenv("KILL_BY_CLICK_DOMINANCE", "0.55"))
-STABILITY_THRESHOLD = int(os.getenv("KILL_BY_CLICK_STABILITY", "1"))
-VELOCITY_SCALE = float(os.getenv("KILL_BY_CLICK_VELOCITY_SCALE", "0.0"))
-STABILITY_WEIGHT = float(os.getenv("KILL_BY_CLICK_STABILITY_WEIGHT", "0.0"))
-CENTER_WEIGHT = float(os.getenv("KILL_BY_CLICK_CENTER_WEIGHT", "0.0"))
-EDGE_PENALTY = float(os.getenv("KILL_BY_CLICK_EDGE_PENALTY", "0.0"))
-EDGE_BUFFER = int(os.getenv("KILL_BY_CLICK_EDGE_BUFFER", "5"))
-VEL_STAB_SCALE = float(os.getenv("KILL_BY_CLICK_VEL_STAB_SCALE", "0.0"))
-PATH_HISTORY = int(os.getenv("KILL_BY_CLICK_PATH_HISTORY", "15"))
-PATH_WEIGHT = float(os.getenv("KILL_BY_CLICK_PATH_WEIGHT", "0.0"))
-HEATMAP_RES = int(os.getenv("KILL_BY_CLICK_HEATMAP_RES", "64"))
-HEATMAP_DECAY = float(os.getenv("KILL_BY_CLICK_HEATMAP_DECAY", "0.9"))
-HEATMAP_WEIGHT = float(os.getenv("KILL_BY_CLICK_HEATMAP_WEIGHT", "0.0"))
-STREAK_WEIGHT = float(os.getenv("KILL_BY_CLICK_STREAK_WEIGHT", "0.0"))
-TRACKER_RATIO = float(os.getenv("KILL_BY_CLICK_TRACKER_RATIO", "1.5"))
-RECENCY_WEIGHT = float(os.getenv("KILL_BY_CLICK_RECENCY_WEIGHT", "0.0"))
-DURATION_WEIGHT = float(os.getenv("KILL_BY_CLICK_DURATION_WEIGHT", "0.0"))
-CONFIRM_DELAY = float(os.getenv("KILL_BY_CLICK_CONFIRM_DELAY", "0.0"))
-CONFIRM_WEIGHT = float(os.getenv("KILL_BY_CLICK_CONFIRM_WEIGHT", "1.0"))
-ZORDER_WEIGHT = float(os.getenv("KILL_BY_CLICK_ZORDER_WEIGHT", "0.0"))
-GAZE_DECAY = float(os.getenv("KILL_BY_CLICK_GAZE_DECAY", "0.9"))
-GAZE_WEIGHT = float(os.getenv("KILL_BY_CLICK_GAZE_WEIGHT", "0.0"))
-ACTIVE_HISTORY_SIZE = int(os.getenv("KILL_BY_CLICK_ACTIVE_HISTORY", "5"))
-ACTIVE_HISTORY_WEIGHT = float(os.getenv("KILL_BY_CLICK_ACTIVE_WEIGHT", "0.0"))
-ACTIVE_HISTORY_DECAY = float(os.getenv("KILL_BY_CLICK_ACTIVE_DECAY", "0.9"))
-VELOCITY_SMOOTH = float(os.getenv("KILL_BY_CLICK_VEL_SMOOTH", "0.5"))
+DEFAULT_HIGHLIGHT = os.getenv("KILL_BY_CLICK_HIGHLIGHT", "red")
+
+KILL_BY_CLICK_INTERVAL = tuning.interval
 
 
-def _softmax(weights: dict[int, float]) -> dict[int, float]:
-    """Return softmax probabilities for ``weights`` using ``SOFTMAX_TEMP``."""
-    if not weights:
-        return {}
-    scale = 1.0 / max(SOFTMAX_TEMP, 1e-6)
-    exps = {pid: math.exp(w * scale) for pid, w in weights.items()}
-    total = sum(exps.values())
-    if total <= 0.0:
-        return {}
-    return {pid: val / total for pid, val in exps.items()}
+class UpdateState(Enum):
+    IDLE = auto()
+    PENDING = auto()
 
 
-class CursorHeatmap:
-    """Track cursor dwell time across the screen using a decaying grid."""
-
-    def __init__(self, width: int, height: int) -> None:
-        self.res = max(1, HEATMAP_RES)
-        self.decay = HEATMAP_DECAY
-        self.w = width // self.res + 1
-        self.h = height // self.res + 1
-        self.grid = [[0.0 for _ in range(self.w)] for _ in range(self.h)]
-
-    def update(self, x: int, y: int) -> None:
-        gx = min(int(x / self.res), self.w - 1)
-        gy = min(int(y / self.res), self.h - 1)
-        for row in self.grid:
-            for i in range(len(row)):
-                row[i] *= self.decay
-        self.grid[gy][gx] += 1.0
-
-    def region_score(self, rect: tuple[int, int, int, int] | None) -> float:
-        if not rect:
-            return 0.0
-        x, y, w, h = rect
-        gx1 = max(0, int(x / self.res))
-        gy1 = max(0, int(y / self.res))
-        gx2 = min(self.w - 1, int((x + w) / self.res))
-        gy2 = min(self.h - 1, int((y + h) / self.res))
-        total = 0.0
-        cells = 0
-        for gy in range(gy1, gy2 + 1):
-            row = self.grid[gy]
-            for gx in range(gx1, gx2 + 1):
-                total += row[gx]
-                cells += 1
-        return total / max(cells, 1)
-
-
-class WindowTracker:
-    """Track window weights with exponential decay."""
-
-    def __init__(self) -> None:
-        self.scores: dict[int, float] = {}
-        self.info_history: deque[WindowInfo] = deque(maxlen=PID_HISTORY_SIZE)
-        self.last_seen: dict[int, float] = {}
-        self.durations: dict[int, float] = {}
-
-    def decay(self) -> None:
-        for pid in list(self.scores):
-            self.scores[pid] *= SCORE_DECAY
-            if self.scores[pid] < SCORE_MIN:
-                del self.scores[pid]
-
-    def add(self, info: WindowInfo, active: int | None = None) -> None:
-        if info.pid is None:
-            return
-        self.decay()
-        weight = SAMPLE_WEIGHT
-        if active is not None and info.pid == active:
-            weight *= ACTIVE_BONUS
-        if info.rect and AREA_WEIGHT:
-            area = info.rect[2] * info.rect[3]
-            if area:
-                weight += AREA_WEIGHT / float(area)
-        self.scores[info.pid] = self.scores.get(info.pid, 0.0) + weight
-        self.info_history.append(info)
-        now = time.monotonic()
-        last = self.last_seen.get(info.pid)
-        if last is not None:
-            self.durations[info.pid] = self.durations.get(info.pid, 0.0) + now - last
-        self.last_seen[info.pid] = now
-
-    def best(self) -> WindowInfo | None:
-        if not self.scores:
-            return None
-        pid = max(self.scores.items(), key=lambda i: i[1])[0]
-        for info in reversed(self.info_history):
-            if info.pid == pid:
-                return info
-        return WindowInfo(pid)
-
-    def best_with_confidence(self) -> tuple[WindowInfo | None, float]:
-        if not self.scores:
-            return None, 0.0
-        ordered = sorted(self.scores.items(), key=lambda i: i[1], reverse=True)
-        best_pid, best_score = ordered[0]
-        second_score = ordered[1][1] if len(ordered) > 1 else 0.0
-        info = self.best()
-        return info, best_score / (second_score or 1e-6)
+class OverlayState(Enum):
+    INIT = auto()
+    HOOKED = auto()
+    POLLING = auto()
 
 
 class ClickOverlay(tk.Toplevel):
@@ -188,7 +63,7 @@ class ClickOverlay(tk.Toplevel):
         self,
         parent: tk.Misc,
         *,
-        highlight: str = "red",
+        highlight: str = DEFAULT_HIGHLIGHT,
         probe_attempts: int = 5,
         timeout: float | None = None,
         interval: float = KILL_BY_CLICK_INTERVAL,
@@ -207,9 +82,8 @@ class ClickOverlay(tk.Toplevel):
         bg_color = parent.cget("bg") if isinstance(parent, tk.Widget) else "#000001"
         self.configure(bg=bg_color)
 
-        self._clickthrough = False
         if is_supported():
-            self._clickthrough = make_window_clickthrough(self)
+            make_window_clickthrough(self)
 
         # Using an empty string for the canvas background causes a TclError on
         # some platforms. Use the chosen background color so the canvas itself
@@ -233,24 +107,26 @@ class ClickOverlay(tk.Toplevel):
         self.interval = interval
         self._after_id: Optional[str] = None
         self._timeout_id: Optional[str] = None
-        self._update_pending = False
-        self._using_hooks = False
+        self.update_state = UpdateState.IDLE
+        self.state = OverlayState.INIT
         self.pid: int | None = None
         self.title_text: str | None = None
         self._last_info: WindowInfo | None = None
-        self._pid_history = deque(maxlen=PID_HISTORY_SIZE)
-        self._info_history = deque(maxlen=PID_HISTORY_SIZE)
-        self._tracker = WindowTracker()
+        self.engine = ScoringEngine(
+            tuning,
+            self.winfo_screenwidth(),
+            self.winfo_screenheight(),
+            os.getpid(),
+        )
         self._own_pid = os.getpid()
         self._initial_active_pid: int | None = None
         self._velocity = 0.0
-        self._path_history: deque[tuple[int, int]] = deque(maxlen=PATH_HISTORY)
+        self._path_history: deque[tuple[int, int]] = deque(maxlen=tuning.path_history)
         self._last_move_time = time.time()
         self._last_move_pos = (0, 0)
         self._pid_stability: dict[int, int] = {}
-        self._heatmap = CursorHeatmap(
-            self.winfo_screenwidth(), self.winfo_screenheight()
-        )
+        self._pid_history = deque(maxlen=tuning.pid_history_size)
+        self._info_history = deque(maxlen=tuning.pid_history_size)
         self._current_pid: int | None = None
         self._current_streak: int = 0
         self._click_x = 0
@@ -259,7 +135,11 @@ class ClickOverlay(tk.Toplevel):
         self._hover_start = time.monotonic()
         self._last_gaze_pid: int | None = None
         self._last_active_query = 0.0
-        self._active_history: deque[tuple[int, float]] = deque(maxlen=ACTIVE_HISTORY_SIZE)
+        self._active_history: deque[tuple[int, float]] = deque(
+            maxlen=tuning.active_history_size
+        )
+        self._last_pid: int | None = None
+        self._flash_id: str | None = None
         try:
             self._cursor_x = self.winfo_pointerx()
             self._cursor_y = self.winfo_pointery()
@@ -268,138 +148,19 @@ class ClickOverlay(tk.Toplevel):
         self._cursor_y = 0
         self._last_move_pos = (self._cursor_x, self._cursor_y)
 
-    def _score_samples(self, samples: list[WindowInfo]) -> dict[int, float]:
-        """Return a PID->weight mapping from ``samples`` and hover history."""
+    def _flash_highlight(self) -> None:
+        """Temporarily thicken the highlight rectangle when the target changes."""
 
-        weights: dict[int, float] = dict(self._tracker.scores)
-        active = self._initial_active_pid
-
-        power = 1.0
-        for info in reversed(
-            [s for s in samples if s.pid not in (self._own_pid, None)]
-        ):
-            vel_factor = 1.0 / (1.0 + self._velocity * VELOCITY_SCALE)
-            w = SAMPLE_WEIGHT * power * vel_factor
-            if info.pid == active:
-                w *= ACTIVE_BONUS
-            if info.rect and AREA_WEIGHT:
-                area = info.rect[2] * info.rect[3]
-                if area:
-                    w += AREA_WEIGHT / float(area)
-            if info.rect and CENTER_WEIGHT:
-                cx = info.rect[0] + info.rect[2] / 2
-                cy = info.rect[1] + info.rect[3] / 2
-                dist = math.hypot(cx - self._cursor_x, cy - self._cursor_y)
-                diag = math.hypot(info.rect[2], info.rect[3])
-                if diag:
-                    w += CENTER_WEIGHT * (1 - min(dist / diag, 1.0))
-            if info.rect and EDGE_PENALTY:
-                left = info.rect[0]
-                top = info.rect[1]
-                right = left + info.rect[2]
-                bottom = top + info.rect[3]
-                near_x = min(abs(self._cursor_x - left), abs(self._cursor_x - right))
-                near_y = min(abs(self._cursor_y - top), abs(self._cursor_y - bottom))
-                if near_x <= EDGE_BUFFER or near_y <= EDGE_BUFFER:
-                    w *= max(0.0, 1.0 - EDGE_PENALTY)
-            if info.rect and PATH_WEIGHT and self._path_history:
-                inside = 0
-                for px, py in self._path_history:
-                    if (
-                        info.rect[0] <= px <= info.rect[0] + info.rect[2]
-                        and info.rect[1] <= py <= info.rect[1] + info.rect[3]
-                    ):
-                        inside += 1
-                w += PATH_WEIGHT * inside / len(self._path_history)
-            if HEATMAP_WEIGHT and info.rect:
-                heat = self._heatmap.region_score(info.rect)
-                area = info.rect[2] * info.rect[3] or 1
-                w += HEATMAP_WEIGHT * heat / float(area)
-            weights[info.pid] = weights.get(info.pid, 0.0) + w
-            power *= SAMPLE_DECAY
-
-        power = 1.0
-        for pid in reversed(self._pid_history):
-            vel_factor = 1.0 / (1.0 + self._velocity * VELOCITY_SCALE)
-            w = HISTORY_WEIGHT * power * vel_factor
-            if pid == active:
-                w *= ACTIVE_BONUS
-            weights[pid] = weights.get(pid, 0.0) + w
-            power *= HISTORY_DECAY
-
-        if STABILITY_WEIGHT:
-            for pid, count in self._pid_stability.items():
-                weights[pid] = weights.get(pid, 0.0) + count * STABILITY_WEIGHT
-
-        if STREAK_WEIGHT and self._current_pid is not None:
-            weights[self._current_pid] = (
-                weights.get(self._current_pid, 0.0) + self._current_streak * STREAK_WEIGHT
-            )
-
-        now = time.monotonic()
-        if RECENCY_WEIGHT:
-            for pid, last in self._tracker.last_seen.items():
-                weights[pid] = weights.get(pid, 0.0) + RECENCY_WEIGHT / (now - last + 1e-6)
-        if DURATION_WEIGHT:
-            for pid, dur in self._tracker.durations.items():
-                weights[pid] = weights.get(pid, 0.0) + dur * DURATION_WEIGHT
-
-        if ZORDER_WEIGHT:
-            stack = list_windows_at(int(self._cursor_x), int(self._cursor_y))
-            for idx, info in enumerate(stack):
-                if info.pid is None:
-                    continue
-                weights[info.pid] = weights.get(info.pid, 0.0) + ZORDER_WEIGHT / (idx + 1)
-
-        if GAZE_WEIGHT:
-            for pid, dur in self._gaze_duration.items():
-                weights[pid] = weights.get(pid, 0.0) + dur * GAZE_WEIGHT
-
-        if ACTIVE_HISTORY_WEIGHT and self._active_history:
-            power = 1.0
-            for pid, _ in reversed(self._active_history):
-                weights[pid] = weights.get(pid, 0.0) + ACTIVE_HISTORY_WEIGHT * power
-                power *= ACTIVE_HISTORY_DECAY
-
-        return weights
-
-    def _select_from_weights(
-        self, samples: list[WindowInfo], weights: dict[int, float]
-    ) -> WindowInfo | None:
-        if not weights:
-            return None
-
-        pid = max(weights.items(), key=lambda item: item[1])[0]
-        for info in reversed(samples):
-            if info.pid == pid:
-                return info
-        for info in reversed(self._info_history):
-            if info.pid == pid:
-                return info
-        return WindowInfo(pid)
-
-    def _weighted_choice(self, samples: list[WindowInfo]) -> WindowInfo | None:
-        """Return the best guess from samples and recent history using weights."""
-
-        weights = self._score_samples(samples)
-        return self._select_from_weights(samples, weights)
-
-    def _weighted_confidence(
-        self, samples: list[WindowInfo]
-    ) -> tuple[WindowInfo | None, float, float]:
-        """Return the best guess, confidence ratio and probability."""
-
-        weights = self._score_samples(samples)
-        if not weights:
-            return None, 0.0, 0.0
-
-        probs = _softmax(weights)
-        ordered = sorted(probs.items(), key=lambda i: i[1], reverse=True)
-        best_pid, best_prob = ordered[0]
-        second_prob = ordered[1][1] if len(ordered) > 1 else 0.0
-        ratio = best_prob / (second_prob or 1e-6)
-        info = self._select_from_weights(samples, weights)
-        return info, ratio, best_prob
+        self.canvas.itemconfigure(self.rect, width=3)
+        if self._flash_id is not None:
+            try:
+                self.after_cancel(self._flash_id)
+            except Exception:
+                pass
+        self._flash_id = self.after(
+            tuning.flash_duration_ms,
+            lambda: self.canvas.itemconfigure(self.rect, width=2),
+        )
 
     def _position_label(self, px: int, py: int, sw: int, sh: int) -> None:
         """Place the info label near the cursor while keeping it on-screen."""
@@ -428,11 +189,14 @@ class ClickOverlay(tk.Toplevel):
             dt = now - self._last_move_time
             if dt > 0:
                 vel = math.hypot(dx, dy) / dt
-                self._velocity = self._velocity * (1 - VELOCITY_SMOOTH) + vel * VELOCITY_SMOOTH
+                self._velocity = (
+                    self._velocity * (1 - tuning.velocity_smooth)
+                    + vel * tuning.velocity_smooth
+                )
             self._last_move_time = now
             self._last_move_pos = (_e.x_root, _e.y_root)
             self._path_history.append((_e.x_root, _e.y_root))
-            self._heatmap.update(_e.x_root, _e.y_root)
+            self.engine.heatmap.update(_e.x_root, _e.y_root)
             self._cursor_x = _e.x_root
             self._cursor_y = _e.y_root
         else:
@@ -441,12 +205,12 @@ class ClickOverlay(tk.Toplevel):
                 self._cursor_y = self.winfo_pointery()
             except Exception:
                 pass
-        if not self._update_pending:
-            self._update_pending = True
+        if self.update_state is UpdateState.IDLE:
+            self.update_state = UpdateState.PENDING
             self.after_idle(self._process_update)
 
     def _process_update(self) -> None:
-        self._update_pending = False
+        self.update_state = UpdateState.IDLE
         try:
             self._cursor_x = self.winfo_pointerx()
             self._cursor_y = self.winfo_pointery()
@@ -469,11 +233,14 @@ class ClickOverlay(tk.Toplevel):
         dt = now - self._last_move_time
         if dt > 0:
             vel = math.hypot(dx, dy) / dt
-            self._velocity = self._velocity * (1 - VELOCITY_SMOOTH) + vel * VELOCITY_SMOOTH
+            self._velocity = (
+                self._velocity * (1 - tuning.velocity_smooth)
+                + vel * tuning.velocity_smooth
+            )
         self._last_move_time = now
         self._last_move_pos = (x, y)
         self._path_history.append((x, y))
-        self._heatmap.update(x, y)
+        self.engine.heatmap.update(x, y)
         self._cursor_x = x
         self._cursor_y = y
         self._queue_update()
@@ -483,22 +250,38 @@ class ClickOverlay(tk.Toplevel):
 
         return self._query_window_at(int(self._cursor_x), int(self._cursor_y))
 
+    def _probe_point(self, x: int, y: int) -> WindowInfo:
+        """Return window info at ``(x, y)`` applying fallbacks."""
+
+        info = get_window_at(x, y)
+        if info.pid is not None and info.rect is None:
+            for win in list_windows_at(x, y):
+                if win.pid == info.pid:
+                    info = WindowInfo(info.pid, win.rect, info.title or win.title)
+                    break
+        if info.pid in (self._own_pid, None):
+            for win in list_windows_at(x, y):
+                if win.pid not in (self._own_pid, None):
+                    info = win
+                    break
+        return info
+
     def _query_window_at(self, x: int, y: int) -> WindowInfo:
         """Return the window info at ``(x, y)`` in screen coordinates."""
 
         def probe() -> WindowInfo:
-            return get_window_at(x, y)
+            return self._probe_point(x, y)
 
         samples: list[WindowInfo] = []
 
-        if self._clickthrough:
+        if self.state is OverlayState.HOOKED:
             info = probe()
             samples.append(info)
-            self._tracker.add(info, self._initial_active_pid)
+            self.engine.tracker.add(info, self._initial_active_pid)
             for _ in range(self.probe_attempts):
                 confirm = probe()
                 samples.append(confirm)
-                self._tracker.add(confirm, self._initial_active_pid)
+                self.engine.tracker.add(confirm, self._initial_active_pid)
                 if info.pid not in (self._own_pid, None) and confirm.pid == info.pid:
                     break
                 info = confirm
@@ -507,11 +290,11 @@ class ClickOverlay(tk.Toplevel):
             try:
                 info = probe()
                 samples.append(info)
-                self._tracker.add(info, self._initial_active_pid)
+                self.engine.tracker.add(info, self._initial_active_pid)
                 for _ in range(self.probe_attempts):
                     confirm = probe()
                     samples.append(confirm)
-                    self._tracker.add(confirm, self._initial_active_pid)
+                    self.engine.tracker.add(confirm, self._initial_active_pid)
                     if (
                         info.pid not in (self._own_pid, None)
                         and confirm.pid == info.pid
@@ -522,18 +305,53 @@ class ClickOverlay(tk.Toplevel):
                 if was_click:
                     remove_window_clickthrough(self)
 
-        choice, ratio, prob = self._weighted_confidence(samples)
+        choice, ratio, prob = self.engine.weighted_confidence(
+            samples,
+            self._cursor_x,
+            self._cursor_y,
+            self._velocity,
+            self._path_history,
+            self._initial_active_pid,
+        )
         if choice is not None:
             info = choice
         attempts = 0
-        while (ratio < CONFIDENCE_RATIO or prob < DOMINANCE) and attempts < EXTRA_ATTEMPTS:
+        while (
+            ratio < tuning.confidence_ratio or prob < tuning.dominance
+        ) and attempts < tuning.extra_attempts:
             more = probe()
             samples.append(more)
-            self._tracker.add(more, self._initial_active_pid)
-            choice, ratio, prob = self._weighted_confidence(samples)
+            self.engine.tracker.add(more, self._initial_active_pid)
+            choice, ratio, prob = self.engine.weighted_confidence(
+                samples,
+                self._cursor_x,
+                self._cursor_y,
+                self._velocity,
+                self._path_history,
+                self._initial_active_pid,
+            )
             if choice is not None:
                 info = choice
             attempts += 1
+
+        if info.pid in (self._own_pid, None):
+            for dx in range(-tuning.near_radius, tuning.near_radius + 1):
+                for dy in range(-tuning.near_radius, tuning.near_radius + 1):
+                    if dx == 0 and dy == 0:
+                        continue
+                    alt = self._probe_point(x + dx, y + dy)
+                    samples.append(alt)
+                    self.engine.tracker.add(alt, self._initial_active_pid)
+            choice = self.engine.weighted_choice(
+                samples,
+                self._cursor_x,
+                self._cursor_y,
+                self._velocity,
+                self._path_history,
+                self._initial_active_pid,
+            )
+            if choice is not None:
+                info = choice
 
         if info.pid is None:
             if self._last_info is not None:
@@ -561,14 +379,14 @@ class ClickOverlay(tk.Toplevel):
             self._hover_start = now
         self._last_gaze_pid = info.pid
         for pid in list(self._gaze_duration):
-            self._gaze_duration[pid] *= GAZE_DECAY
-            if self._gaze_duration[pid] < SCORE_MIN:
+            self._gaze_duration[pid] *= tuning.gaze_decay
+            if self._gaze_duration[pid] < tuning.score_min:
                 del self._gaze_duration[pid]
         if info.pid not in (self._own_pid, None):
             self._last_info = info
             self._pid_history.append(info.pid)
             self._info_history.append(info)
-            self._tracker.add(info, self._initial_active_pid)
+            self.engine.tracker.add(info, self._initial_active_pid)
             self._pid_stability[info.pid] = self._pid_stability.get(info.pid, 0) + 1
             for pid in list(self._pid_stability):
                 if pid != info.pid:
@@ -583,10 +401,15 @@ class ClickOverlay(tk.Toplevel):
 
         px = int(self._cursor_x)
         py = int(self._cursor_y)
+        cursor_changed = (px, py) != getattr(self, "_last_cursor", (None, None))
         sw = self.winfo_screenwidth()
         sh = self.winfo_screenheight()
         # Draw crosshair lines centered on the cursor only when moved
-        if not hasattr(self, "_last_pos") or self._last_pos != (px, py, sw, sh):
+        if (
+            cursor_changed
+            or not hasattr(self, "_last_pos")
+            or self._last_pos != (px, py, sw, sh)
+        ):
             self.canvas.coords(self.hline, 0, py, sw, py)
             self.canvas.coords(self.vline, px, 0, px, sh)
             self._last_pos = (px, py, sw, sh)
@@ -602,12 +425,22 @@ class ClickOverlay(tk.Toplevel):
                 info.rect[1] + info.rect[3],
             )
             text = info.title or f"PID {info.pid}" if info.pid else ""
-        if rect != getattr(self, "_last_rect", None):
+        old_pid = getattr(self, "_last_pid", None)
+        window_changed = (
+            rect != getattr(self, "_last_rect", None) or info.pid != old_pid
+        )
+        if window_changed:
             self.canvas.coords(self.rect, *rect)
             self._last_rect = rect
-        if text != getattr(self, "_last_text", None):
+            if info.pid != old_pid:
+                self._flash_highlight()
+        if text != getattr(self, "_last_text", None) or info.pid != old_pid:
             self.canvas.itemconfigure(self.label, text=text)
             self._last_text = text
+        if not cursor_changed and not window_changed:
+            return
+        self._last_cursor = (px, py)
+        self._last_pid = info.pid
         self._position_label(px, py, sw, sh)
 
     def _stable_info(self) -> WindowInfo | None:
@@ -615,7 +448,9 @@ class ClickOverlay(tk.Toplevel):
         if not self._pid_stability:
             return None
         pid, count = max(self._pid_stability.items(), key=lambda i: i[1])
-        threshold = STABILITY_THRESHOLD + int(self._velocity * VEL_STAB_SCALE)
+        threshold = tuning.stability_threshold + int(
+            self._velocity * tuning.vel_stab_scale
+        )
         if count < threshold:
             return None
         for info in reversed(self._info_history):
@@ -626,7 +461,7 @@ class ClickOverlay(tk.Toplevel):
     def _confirm_window(self) -> WindowInfo:
         """Re-query the click location after the overlay closes."""
         info = get_window_at(int(self._click_x), int(self._click_y))
-        self._tracker.add(info, self._initial_active_pid)
+        self.engine.tracker.add(info, self._initial_active_pid)
         return info
 
     def _on_click(self) -> None:
@@ -636,8 +471,8 @@ class ClickOverlay(tk.Toplevel):
             if stable is not None:
                 info = stable
             else:
-                tracked, ratio = self._tracker.best_with_confidence()
-                if tracked is not None and ratio >= TRACKER_RATIO:
+                tracked, ratio = self.engine.tracker.best_with_confidence()
+                if tracked is not None and ratio >= tuning.tracker_ratio:
                     info = tracked
                 elif self._last_info is not None:
                     info = self._last_info
@@ -652,10 +487,17 @@ class ClickOverlay(tk.Toplevel):
 
         confirm = self._confirm_window()
         samples = [info, confirm]
-        weights = self._score_samples(samples)
+        weights = self.engine.score_samples(
+            samples,
+            self._cursor_x,
+            self._cursor_y,
+            self._velocity,
+            self._path_history,
+            self._initial_active_pid,
+        )
         if confirm.pid not in (self._own_pid, None):
-            weights[confirm.pid] = weights.get(confirm.pid, 0.0) + CONFIRM_WEIGHT
-        choice = self._select_from_weights(samples, weights)
+            weights[confirm.pid] = weights.get(confirm.pid, 0.0) + tuning.confirm_weight
+        choice = self.engine.select_from_weights(samples, weights)
         if choice is not None:
             self.pid = choice.pid
             self.title_text = choice.title
@@ -688,8 +530,13 @@ class ClickOverlay(tk.Toplevel):
             except Exception:
                 pass
             self._timeout_id = None
-        if self._clickthrough:
-            remove_window_clickthrough(self)
+        if self._flash_id is not None:
+            try:
+                self.after_cancel(self._flash_id)
+            except Exception:
+                pass
+            self._flash_id = None
+        remove_window_clickthrough(self)
         self.destroy()
 
     def choose(self) -> tuple[int | None, str | None]:
@@ -697,7 +544,7 @@ class ClickOverlay(tk.Toplevel):
         self.bind("<Escape>", self.close)
         self._initial_active_pid = get_active_window().pid
         self.protocol("WM_DELETE_WINDOW", self.close)
-        use_hooks = self._clickthrough and is_supported()
+        use_hooks = is_supported()
         if use_hooks:
             with capture_mouse(
                 on_move=self._on_move,
@@ -705,11 +552,10 @@ class ClickOverlay(tk.Toplevel):
             ) as listener:
                 if listener is None:
                     use_hooks = False
-                    if self._clickthrough:
-                        remove_window_clickthrough(self)
-                        self._clickthrough = False
+                    remove_window_clickthrough(self)
+                    self.state = OverlayState.POLLING
                 else:
-                    self._using_hooks = True
+                    self.state = OverlayState.HOOKED
                     self._queue_update()
                     if self.timeout is not None:
                         self._timeout_id = self.after(
@@ -718,7 +564,9 @@ class ClickOverlay(tk.Toplevel):
                     self.wait_window()
                     return self.pid, self.title_text
 
-        self._using_hooks = False
+        if not use_hooks:
+            remove_window_clickthrough(self)
+            self.state = OverlayState.POLLING
         self.bind("<Motion>", self._queue_update)
         self.bind("<Button-1>", self._click_event)
         self._queue_update()

--- a/src/views/force_quit_dialog.py
+++ b/src/views/force_quit_dialog.py
@@ -1996,6 +1996,7 @@ class ForceQuitDialog(BaseDialog):
             except Exception:
                 pass
         color = getattr(self, "hover_color", None) or getattr(self, "accent", "red")
+        color = os.getenv("KILL_BY_CLICK_HIGHLIGHT", color)
         overlay = ClickOverlay(self, highlight=color)
         self.withdraw()
         try:

--- a/tests/test_kill_by_click_cli.py
+++ b/tests/test_kill_by_click_cli.py
@@ -1,0 +1,21 @@
+import scripts.kill_by_click as kbc
+
+
+def test_main_invokes_overlay(monkeypatch):
+    called = {}
+
+    class DummyOverlay:
+        def __init__(self, root, **_):
+            called['init'] = True
+
+        def choose(self):
+            called['choose'] = True
+            return (123, 'title')
+
+    monkeypatch.setattr(kbc, 'ClickOverlay', DummyOverlay)
+    monkeypatch.setattr(kbc.tk, 'Tk', lambda: type('T', (), {'withdraw': lambda self: None, 'destroy': lambda self: None})())
+
+    kbc.main()
+
+    assert called.get('init')
+    assert called.get('choose')


### PR DESCRIPTION
## Summary
- refactor click overlay scoring into a dedicated `ScoringEngine`
- bundle weights and constants in a new `Tuning` dataclass
- adopt enum-based overlay state and reduce redraws with change tracking
- add overlay state enums and highlight flash improvements
- allow overriding the overlay highlight color via the `KILL_BY_CLICK_HIGHLIGHT` environment variable
- provide a new `kill_by_click.py` script for command-line window selection

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6863923f3cec832b85c2cef9c035b8fc