### PR TITLE
Improve kill by click overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ A modern, feature-rich desktop application built with Python and CustomTkinter.
 - **Expanded Utilities**: File and directory copy/move helpers, an enhanced file manager, a threaded port scanner, a flexible hash calculator with optional disk caching, a multi-threaded duplicate finder that persists file hashes for lightning fast rescans, a screenshot capture tool, and a built-in process manager that auto-refreshes and sorts by CPU usage. The system info viewer now reports CPU cores and memory usage.
 - **Security Center**: Toggle the Windows Firewall and Defender real-time protection directly from the app.
 - **Kill by Click CLI**: `scripts/kill_by_click.py` opens the crosshair overlay
-  from the terminal so you can quickly select any window.
+  from the terminal so you can quickly select any window. Pass `--skip-confirm`
+  to close the overlay immediately without rechecking the click location.
 - **Dynamic Gauges**: Resource gauges automatically change color from green to yellow to red as usage increases for quick visual feedback.
 - **Stylish Setup**: Dependency installation is wrapped in a pulsing neon border
   with a dynamic spinner and live output for extra flair, even when triggered
@@ -57,7 +58,7 @@ A modern, feature-rich desktop application built with Python and CustomTkinter.
   restored automatically when the overlay closes. The overlay samples the window
   The highlight color defaults to ``red`` but can be customized by setting
   ``KILL_BY_CLICK_HIGHLIGHT`` in the environment. The ``scripts/kill_by_click.py``
-  helper launches the overlay directly from the command line. The overlay samples the window
+  helper launches the overlay directly from the command line. Use `--skip-confirm` to close it instantly without the final check. The overlay samples the window
   repeatedly and mixes those results with a short hover history to choose the
   most stable PID even when windows overlap. ``KILL_BY_CLICK_HISTORY`` sets how
   many hover entries are kept while ``KILL_BY_CLICK_SAMPLE_DECAY`` and
@@ -118,6 +119,8 @@ others at the click location so background windows are less likely to be
   likely to be chosen. ``KILL_BY_CLICK_VEL_SMOOTH`` smooths cursor velocity
   updates before applying motion-based weighting, reducing noise from small
   jitters.
+  ``KILL_BY_CLICK_SKIP_CONFIRM`` disables the final window check after clicking
+  so the overlay closes instantly when accuracy is less important.
   so the overlay remains usable without extra dependencies. Process monitoring pauses while
   selecting so the overlay stays smooth. Click to
   immediately terminate that window's process. The confirmation dialog now includes the

--- a/main.py
+++ b/main.py
@@ -4,7 +4,6 @@ CoolBox - A Modern Desktop Application
 Main entry point for the application
 """
 import os
-import subprocess
 import sys
 from pathlib import Path
 from argparse import ArgumentParser

--- a/scripts/kill_by_click.py
+++ b/scripts/kill_by_click.py
@@ -1,14 +1,24 @@
 #!/usr/bin/env python3
 """Select a window by clicking it and print the PID and title."""
 
+import os
+import argparse
 import tkinter as tk
 from src.views.click_overlay import ClickOverlay
 
 
-def main() -> None:
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Select a window and output its PID")
+    parser.add_argument(
+        "--skip-confirm",
+        action="store_true",
+        help="Close immediately without verifying the click position",
+    )
+    args = parser.parse_args(argv)
+
     root = tk.Tk()
     root.withdraw()
-    overlay = ClickOverlay(root)
+    overlay = ClickOverlay(root, skip_confirm=args.skip_confirm)
     pid, title = overlay.choose()
     if pid is None:
         print("No window selected")

--- a/src/utils/rainbow.py
+++ b/src/utils/rainbow.py
@@ -10,7 +10,6 @@ from typing import Iterable, Tuple
 from rich.console import Console, Control
 from rich.text import Text
 
-from .helpers import adjust_color
 
 THEMES: dict[str, list[str]] = {
     "classic": ["red", "yellow", "green", "cyan", "blue", "magenta"],

--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -67,6 +67,7 @@ class ClickOverlay(tk.Toplevel):
         probe_attempts: int = 5,
         timeout: float | None = None,
         interval: float = KILL_BY_CLICK_INTERVAL,
+        skip_confirm: bool | None = None,
     ) -> None:
         super().__init__(parent)
         # Configure fullscreen before enabling override-redirect to avoid
@@ -105,6 +106,10 @@ class ClickOverlay(tk.Toplevel):
         self.probe_attempts = probe_attempts
         self.timeout = timeout
         self.interval = interval
+        if skip_confirm is None:
+            env = os.getenv("KILL_BY_CLICK_SKIP_CONFIRM")
+            skip_confirm = env not in (None, "0", "false", "no")
+        self.skip_confirm = skip_confirm
         self._after_id: Optional[str] = None
         self._timeout_id: Optional[str] = None
         self.update_state = UpdateState.IDLE
@@ -483,6 +488,10 @@ class ClickOverlay(tk.Toplevel):
 
         self.pid = info.pid
         self.title_text = info.title
+        if self.skip_confirm:
+            self.close()
+            return
+
         self.close()
 
         confirm = self._confirm_window()

--- a/tests/test_kill_by_click_cli.py
+++ b/tests/test_kill_by_click_cli.py
@@ -5,8 +5,8 @@ def test_main_invokes_overlay(monkeypatch):
     called = {}
 
     class DummyOverlay:
-        def __init__(self, root, **_):
-            called['init'] = True
+        def __init__(self, root, *, skip_confirm=False):
+            called['skip_confirm'] = skip_confirm
 
         def choose(self):
             called['choose'] = True
@@ -15,7 +15,7 @@ def test_main_invokes_overlay(monkeypatch):
     monkeypatch.setattr(kbc, 'ClickOverlay', DummyOverlay)
     monkeypatch.setattr(kbc.tk, 'Tk', lambda: type('T', (), {'withdraw': lambda self: None, 'destroy': lambda self: None})())
 
-    kbc.main()
+    kbc.main(['--skip-confirm'])
 
-    assert called.get('init')
     assert called.get('choose')
+    assert called.get('skip_confirm') is True

--- a/tests/test_rainbow.py
+++ b/tests/test_rainbow.py
@@ -15,4 +15,3 @@ def test_single_color_when_no_highlight():
     b = NeonPulseBorder(base_color="#123456", highlight_color="#123456")
     colors = b._generate_colors(8, 4)
     assert len(set(colors)) == 1
-


### PR DESCRIPTION
## Summary
- add optional skip_confirm logic to the click overlay
- expose `KILL_BY_CLICK_SKIP_CONFIRM` setting in the docs
- provide CLI `--skip-confirm` option
- address flake8 warnings

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6863c742f0e8832b8b2cbdeaeedb1cba