### PR TITLE
Ensure CoolBox logo loads everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A modern, feature-rich desktop application built with Python and CustomTkinter.
 - **Unified Styling**: All views and dialogs inherit from shared base classes
   so fonts and accent colors update instantly when settings change.
 - **Cross-Platform**: Works on Windows, macOS, and Linux
-- **Custom Icon**: Displays the CoolBox logo in the window title and on the dock
+- **Custom Icon**: Displays the CoolBox logo in the window title, taskbar and dock
 - **Expanded Utilities**: File and directory copy/move helpers, an enhanced file manager, a threaded port scanner, a flexible hash calculator with optional disk caching, a multi-threaded duplicate finder that persists file hashes for lightning fast rescans, a screenshot capture tool, and a built-in process manager that auto-refreshes and sorts by CPU usage. The system info viewer now reports CPU cores and memory usage.
 - **Security Center**: Toggle the Windows Firewall and Defender real-time protection directly from the app.
 - **Kill by Click CLI**: `scripts/kill_by_click.py` opens the crosshair overlay

--- a/src/views/base_dialog.py
+++ b/src/views/base_dialog.py
@@ -10,6 +10,13 @@ class BaseDialog(ctk.CTkToplevel, UIHelperMixin):
         UIHelperMixin.__init__(self, app)
         if hasattr(app, "register_dialog"):
             app.register_dialog(self)
+        if hasattr(app, "get_icon_photo"):
+            try:
+                icon_photo = app.get_icon_photo()
+                if icon_photo is not None:
+                    self.iconphoto(False, icon_photo)
+            except Exception:
+                pass
         if title:
             self.title(title)
         if geometry:


### PR DESCRIPTION
## Summary
- remove unused tkinter import
- let dialogs display the same CoolBox icon
- add helper to access icon and clean up temp file on close
- document taskbar icon support

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863d23a5058832bb3f5ecad4f88d781