### PR TITLE
Refine kill by click overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ A modern, feature-rich desktop application built with Python and CustomTkinter.
 - **Security Center**: Toggle the Windows Firewall and Defender real-time protection directly from the app.
 - **Kill by Click CLI**: `scripts/kill_by_click.py` opens the crosshair overlay
   from the terminal so you can quickly select any window. Pass `--skip-confirm`
-  to close the overlay immediately without rechecking the click location.
+  to close the overlay immediately without rechecking the click location. Use
+  `--interval 0.1` to override the refresh rate without setting
+  `KILL_BY_CLICK_INTERVAL`.
 - **Dynamic Gauges**: Resource gauges automatically change color from green to yellow to red as usage increases for quick visual feedback.
 - **Stylish Setup**: Dependency installation is wrapped in a pulsing neon border
   with a dynamic spinner and live output for extra flair, even when triggered
@@ -55,7 +57,9 @@ A modern, feature-rich desktop application built with Python and CustomTkinter.
   start or aren't available it falls back to normal bindings and briefly ignores
   mouse events while polling the window under the cursor at ``KILL_BY_CLICK_INTERVAL``
   and tracks pointer coordinates from hook callbacks or motion events to keep
-  updates smooth without flicker. The window's normal interaction state is
+  updates smooth without flicker. Set ``KILL_BY_CLICK_INTERVAL`` to control the
+  refresh rate (defaults to ``0.05`` seconds) or pass ``--interval`` when using
+  ``scripts/kill_by_click.py``. The window's normal interaction state is
   restored automatically when the overlay closes. The overlay samples the window
   The highlight color defaults to ``red`` but can be customized by setting
   ``KILL_BY_CLICK_HIGHLIGHT`` in the environment. The ``scripts/kill_by_click.py``
@@ -355,7 +359,8 @@ others at the click location so background windows are less likely to be
 - The optional `pynput` package enables the Kill by Click overlay to remain
   fully click-through using global mouse hooks. If the hooks fail to start the
   overlay automatically falls back to event bindings that poll the cursor at
-  ``KILL_BY_CLICK_INTERVAL``.
+  ``KILL_BY_CLICK_INTERVAL`` (configurable via environment variable or the
+  ``--interval`` argument).
 
 ## 🛠️ Installation
 

--- a/scripts/kill_by_click.py
+++ b/scripts/kill_by_click.py
@@ -4,7 +4,7 @@
 import os
 import argparse
 import tkinter as tk
-from src.views.click_overlay import ClickOverlay
+from src.views.click_overlay import ClickOverlay, KILL_BY_CLICK_INTERVAL
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -14,11 +14,28 @@ def main(argv: list[str] | None = None) -> None:
         action="store_true",
         help="Close immediately without verifying the click position",
     )
+    parser.add_argument(
+        "--interval",
+        type=float,
+        help=(
+            "Refresh rate in seconds for the overlay. Overrides "
+            "KILL_BY_CLICK_INTERVAL if provided."
+        ),
+    )
     args = parser.parse_args(argv)
 
     root = tk.Tk()
     root.withdraw()
-    overlay = ClickOverlay(root, skip_confirm=args.skip_confirm)
+    kwargs = {"skip_confirm": args.skip_confirm}
+    if args.interval is not None:
+        interval = args.interval
+    else:
+        try:
+            interval = float(os.getenv("KILL_BY_CLICK_INTERVAL", str(KILL_BY_CLICK_INTERVAL)))
+        except ValueError:
+            interval = KILL_BY_CLICK_INTERVAL
+    kwargs["interval"] = interval
+    overlay = ClickOverlay(root, **kwargs)
     pid, title = overlay.choose()
     if pid is None:
         print("No window selected")

--- a/src/utils/scoring_engine.py
+++ b/src/utils/scoring_engine.py
@@ -14,7 +14,11 @@ from .window_utils import WindowInfo, list_windows_at
 class Tuning:
     """Weight and scoring parameters loaded from environment variables."""
 
-    interval: float = 0.01
+    # Increase the default overlay update interval slightly to
+    # reduce CPU usage when the click overlay is active. This
+    # still provides responsive tracking without the excessive
+    # overhead from the previous 10ms refresh rate.
+    interval: float = 0.05
     pid_history_size: int = 5
     sample_decay: float = 0.85
     history_decay: float = 0.9

--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -29,7 +29,12 @@ from src.utils.scoring_engine import ScoringEngine, tuning
 
 DEFAULT_HIGHLIGHT = os.getenv("KILL_BY_CLICK_HIGHLIGHT", "red")
 
-KILL_BY_CLICK_INTERVAL = tuning.interval
+# Allow the refresh interval to be configured via an environment
+# variable. Falling back to the tuning default keeps behaviour
+# consistent for tests while providing an easy knob for users.
+KILL_BY_CLICK_INTERVAL = float(
+    os.getenv("KILL_BY_CLICK_INTERVAL", str(tuning.interval))
+)
 
 
 class UpdateState(Enum):
@@ -122,10 +127,12 @@ class ClickOverlay(tk.Toplevel):
         self.pid: int | None = None
         self.title_text: str | None = None
         self._last_info: WindowInfo | None = None
+        self._screen_w = self.winfo_screenwidth()
+        self._screen_h = self.winfo_screenheight()
         self.engine = ScoringEngine(
             tuning,
-            self.winfo_screenwidth(),
-            self.winfo_screenheight(),
+            self._screen_w,
+            self._screen_h,
             os.getpid(),
         )
         self._own_pid = os.getpid()
@@ -412,8 +419,8 @@ class ClickOverlay(tk.Toplevel):
         px = int(self._cursor_x)
         py = int(self._cursor_y)
         cursor_changed = (px, py) != getattr(self, "_last_cursor", (None, None))
-        sw = self.winfo_screenwidth()
-        sh = self.winfo_screenheight()
+        sw = self._screen_w
+        sh = self._screen_h
         # Draw crosshair lines centered on the cursor only when moved
         if (
             cursor_changed

--- a/src/views/force_quit_dialog.py
+++ b/src/views/force_quit_dialog.py
@@ -2056,14 +2056,24 @@ class ForceQuitDialog(BaseDialog):
         self._populate()
 
     def _kill_by_click(self) -> None:
-        from .click_overlay import ClickOverlay
+        from .click_overlay import ClickOverlay, KILL_BY_CLICK_INTERVAL
 
         paused = self.paused
         if not paused:
             self._safe_pause()
         color = getattr(self, "hover_color", None) or getattr(self, "accent", "red")
         color = os.getenv("KILL_BY_CLICK_HIGHLIGHT", color)
-        overlay = ClickOverlay(self, highlight=color, on_hover=self._highlight_pid)
+        interval_env = os.getenv("KILL_BY_CLICK_INTERVAL")
+        kwargs = {
+            "highlight": color,
+            "on_hover": self._highlight_pid,
+        }
+        if interval_env is not None:
+            try:
+                kwargs["interval"] = float(interval_env)
+            except ValueError:
+                kwargs["interval"] = KILL_BY_CLICK_INTERVAL
+        overlay = ClickOverlay(self, **kwargs)
         self.withdraw()
         try:
             pid, title = overlay.choose()

--- a/tests/test_kill_by_click_cli.py
+++ b/tests/test_kill_by_click_cli.py
@@ -5,8 +5,9 @@ def test_main_invokes_overlay(monkeypatch):
     called = {}
 
     class DummyOverlay:
-        def __init__(self, root, *, skip_confirm=False):
+        def __init__(self, root, *, skip_confirm=False, interval=None):
             called['skip_confirm'] = skip_confirm
+            called['interval'] = interval
 
         def choose(self):
             called['choose'] = True
@@ -15,7 +16,8 @@ def test_main_invokes_overlay(monkeypatch):
     monkeypatch.setattr(kbc, 'ClickOverlay', DummyOverlay)
     monkeypatch.setattr(kbc.tk, 'Tk', lambda: type('T', (), {'withdraw': lambda self: None, 'destroy': lambda self: None})())
 
-    kbc.main(['--skip-confirm'])
+    kbc.main(['--skip-confirm', '--interval', '0.2'])
 
     assert called.get('choose')
     assert called.get('skip_confirm') is True
+    assert called.get('interval') == 0.2


### PR DESCRIPTION
## Summary
- add `--interval` argument to kill_by_click CLI to override refresh rate
- handle interval parsing in the script with env fallback
- document the new option in README
- test CLI interval handling

## Testing
- `pytest tests/test_kill_by_click_cli.py::test_main_invokes_overlay -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6863d65ea088832b870dcdb585cd975c