### PR TITLE
Improve ForceQuit click-kill reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ A modern, feature-rich desktop application built with Python and CustomTkinter.
 - **Kill by Click CLI**: `scripts/kill_by_click.py` opens the crosshair overlay
   from the terminal so you can quickly select any window. Pass `--skip-confirm`
   to close the overlay immediately without rechecking the click location. Use
-  `--interval 0.1` to override the refresh rate without setting
-  `KILL_BY_CLICK_INTERVAL`.
+  `--interval` to set the base refresh rate and `--min-interval`,
+  `--max-interval` and `--delay-scale` to fine‑tune the dynamic update logic
+  (or set the matching `KILL_BY_CLICK_*` environment variables).
 - **Dynamic Gauges**: Resource gauges automatically change color from green to yellow to red as usage increases for quick visual feedback.
 - **Stylish Setup**: Dependency installation is wrapped in a pulsing neon border
   with a dynamic spinner and live output for extra flair, even when triggered
@@ -58,9 +59,13 @@ A modern, feature-rich desktop application built with Python and CustomTkinter.
   mouse events while polling the window under the cursor at ``KILL_BY_CLICK_INTERVAL``
   and tracks pointer coordinates from hook callbacks or motion events to keep
   updates smooth without flicker. Set ``KILL_BY_CLICK_INTERVAL`` to control the
-  refresh rate (defaults to ``0.05`` seconds) or pass ``--interval`` when using
-  ``scripts/kill_by_click.py``. The window's normal interaction state is
-  restored automatically when the overlay closes. The overlay samples the window
+  base refresh rate (defaults to ``0.1`` seconds) or pass ``--interval`` when using
+  ``scripts/kill_by_click.py``. The refresh interval expands and contracts
+  between ``KILL_BY_CLICK_MIN_INTERVAL`` (``0.025`` seconds) and
+  ``KILL_BY_CLICK_MAX_INTERVAL`` (``0.2`` seconds) using an exponential curve
+  tied to pointer velocity. ``KILL_BY_CLICK_DELAY_SCALE`` controls how strongly
+  speed influences this interval. Fast motion shortens the delay for responsive
+  tracking while slower movement stretches it to conserve CPU. The window's normal interaction state is restored automatically when the overlay closes. The Force Quit dialog uses this overlay when you choose *Kill by Click* and falls back to the window under the cursor if no PID is detected. Set ``FORCE_QUIT_CLICK_SKIP_CONFIRM=1`` to skip the termination prompt. The overlay samples the window
   The highlight color defaults to ``red`` but can be customized by setting
   ``KILL_BY_CLICK_HIGHLIGHT`` in the environment. The ``scripts/kill_by_click.py``
   helper launches the overlay directly from the command line. Use `--skip-confirm` to close it instantly without the final check. The overlay samples the window

--- a/scripts/kill_by_click.py
+++ b/scripts/kill_by_click.py
@@ -2,6 +2,7 @@
 """Select a window by clicking it and print the PID and title."""
 
 import argparse
+import os
 import tkinter as tk
 from src.views.click_overlay import ClickOverlay, KILL_BY_CLICK_INTERVAL
 
@@ -21,19 +22,34 @@ def main(argv: list[str] | None = None) -> None:
             "KILL_BY_CLICK_INTERVAL if provided."
         ),
     )
+    parser.add_argument(
+        "--min-interval",
+        type=float,
+        help="Smallest allowed refresh interval in seconds",
+    )
+    parser.add_argument(
+        "--max-interval",
+        type=float,
+        help="Largest allowed refresh interval in seconds",
+    )
+    parser.add_argument(
+        "--delay-scale",
+        type=float,
+        help="Controls how strongly pointer speed shortens the delay",
+    )
     args = parser.parse_args(argv)
 
     root = tk.Tk()
     root.withdraw()
     kwargs = {"skip_confirm": args.skip_confirm}
     if args.interval is not None:
-        interval = args.interval
-    else:
-        try:
-            interval = float(os.getenv("KILL_BY_CLICK_INTERVAL", str(KILL_BY_CLICK_INTERVAL)))
-        except ValueError:
-            interval = KILL_BY_CLICK_INTERVAL
-    kwargs["interval"] = interval
+        kwargs["interval"] = args.interval
+    if args.min_interval is not None:
+        kwargs["min_interval"] = args.min_interval
+    if args.max_interval is not None:
+        kwargs["max_interval"] = args.max_interval
+    if args.delay_scale is not None:
+        kwargs["delay_scale"] = args.delay_scale
     overlay = ClickOverlay(root, **kwargs)
     pid, title = overlay.choose()
     if pid is None:

--- a/src/utils/scoring_engine.py
+++ b/src/utils/scoring_engine.py
@@ -14,11 +14,21 @@ from .window_utils import WindowInfo, list_windows_at
 class Tuning:
     """Weight and scoring parameters loaded from environment variables."""
 
-    # Increase the default overlay update interval slightly to
-    # reduce CPU usage when the click overlay is active. This
-    # still provides responsive tracking without the excessive
-    # overhead from the previous 10ms refresh rate.
-    interval: float = 0.05
+    # Increase the default overlay update interval to reduce CPU
+    # usage while tracking the cursor. A 100ms refresh keeps the
+    # overlay responsive without the heavy overhead of the prior
+    # 50ms rate which could cause noticeable lag on some systems.
+    interval: float = 0.1
+    # Dynamic adjustment bounds for the overlay refresh delay.
+    # The update interval scales between these values based on
+    # cursor velocity so quick movements feel responsive while
+    # idle periods use fewer resources.
+    min_interval: float = 0.025
+    max_interval: float = 0.2
+    # Divisor controlling how strongly pointer speed compresses the overlay
+    # refresh interval. Larger values make motion influence the delay more
+    # gradually while smaller values cause faster updates during quick moves.
+    delay_scale: float = 400.0
     pid_history_size: int = 5
     sample_decay: float = 0.85
     history_decay: float = 0.9

--- a/src/views/force_quit_dialog.py
+++ b/src/views/force_quit_dialog.py
@@ -2073,10 +2073,21 @@ class ForceQuitDialog(BaseDialog):
                 kwargs["interval"] = float(interval_env)
             except ValueError:
                 kwargs["interval"] = KILL_BY_CLICK_INTERVAL
+        for name in ("min_interval", "max_interval", "delay_scale"):
+            env = os.getenv(f"KILL_BY_CLICK_{name.upper()}")
+            if env is None:
+                continue
+            try:
+                kwargs[name] = float(env)
+            except ValueError:
+                pass
         overlay = ClickOverlay(self, **kwargs)
         self.withdraw()
         try:
             pid, title = overlay.choose()
+            if pid is None:
+                fallback = self._get_window_under_cursor()
+                pid, title = fallback.pid, fallback.title
         finally:
             self.deiconify()
             self._highlight_pid(None)

--- a/tests/test_force_quit.py
+++ b/tests/test_force_quit.py
@@ -1223,9 +1223,11 @@ class TestForceQuit(unittest.TestCase):
             dialog._kill_by_click()
             dialog._watcher.pause.assert_called_once()
             dialog._watcher.resume.assert_called_once()
-            CO.assert_called_once_with(
-                dialog, highlight=dialog.accent, on_hover=dialog._highlight_pid
-            )
+            CO.assert_called_once()
+            args, kwargs = CO.call_args
+            assert args[0] is dialog
+            assert kwargs.get("highlight") == dialog.accent
+            assert kwargs.get("on_hover") == dialog._highlight_pid
             MB.showerror.assert_called_once()
             dialog.after_idle.assert_called_with(dialog._update_hover)
 

--- a/tests/test_kill_by_click_cli.py
+++ b/tests/test_kill_by_click_cli.py
@@ -5,9 +5,21 @@ def test_main_invokes_overlay(monkeypatch):
     called = {}
 
     class DummyOverlay:
-        def __init__(self, root, *, skip_confirm=False, interval=None):
+        def __init__(
+            self,
+            root,
+            *,
+            skip_confirm=False,
+            interval=None,
+            min_interval=None,
+            max_interval=None,
+            delay_scale=None,
+        ):
             called['skip_confirm'] = skip_confirm
             called['interval'] = interval
+            called['min_interval'] = min_interval
+            called['max_interval'] = max_interval
+            called['delay_scale'] = delay_scale
 
         def choose(self):
             called['choose'] = True
@@ -16,8 +28,17 @@ def test_main_invokes_overlay(monkeypatch):
     monkeypatch.setattr(kbc, 'ClickOverlay', DummyOverlay)
     monkeypatch.setattr(kbc.tk, 'Tk', lambda: type('T', (), {'withdraw': lambda self: None, 'destroy': lambda self: None})())
 
-    kbc.main(['--skip-confirm', '--interval', '0.2'])
+    kbc.main([
+        '--skip-confirm',
+        '--interval', '0.2',
+        '--min-interval', '0.05',
+        '--max-interval', '0.3',
+        '--delay-scale', '500',
+    ])
 
     assert called.get('choose')
     assert called.get('skip_confirm') is True
     assert called.get('interval') == 0.2
+    assert called.get('min_interval') == 0.05
+    assert called.get('max_interval') == 0.3
+    assert called.get('delay_scale') == 500.0


### PR DESCRIPTION
## Summary
- tune scoring engine defaults for the click overlay
- document new dynamic refresh variables in README
- adapt ClickOverlay refresh rate based on pointer speed for smoother tracking
- refine overlay refresh with smooth velocity scaling
- allow delay scaling via `KILL_BY_CLICK_DELAY_SCALE`
- expose additional tuning parameters in CLI and ForceQuit
- document Force Quit environment variable and CLI options

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6863dba7bb30832b9f9ebb88c8fd3118