### PR TITLE
Improve Kill by Click responsiveness

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,23 @@ A modern, feature-rich desktop application built with Python and CustomTkinter.
   ``KILL_BY_CLICK_MAX_INTERVAL`` (``0.2`` seconds) using an exponential curve
   tied to pointer velocity. ``KILL_BY_CLICK_DELAY_SCALE`` controls how strongly
   speed influences this interval. Fast motion shortens the delay for responsive
-  tracking while slower movement stretches it to conserve CPU. The window's normal interaction state is restored automatically when the overlay closes. The Force Quit dialog uses this overlay when you choose *Kill by Click* and falls back to the window under the cursor if no PID is detected. Set ``FORCE_QUIT_CLICK_SKIP_CONFIRM=1`` to skip the termination prompt. The overlay samples the window
+tracking while slower movement stretches it to conserve CPU. The window's normal interaction state is restored automatically when the overlay closes. The Force Quit dialog uses this overlay when you choose *Kill by Click* and falls back to the window under the cursor if no PID is detected. Set ``FORCE_QUIT_CLICK_SKIP_CONFIRM=1`` to skip the termination prompt. The overlay samples the window
+  information using dedicated worker threads so UI events never block even when
+  window queries are slow. Set ``KILL_BY_CLICK_BACKGROUND=0`` to disable
+  background polling. ``KILL_BY_CLICK_WORKERS`` controls how many threads run
+  these queries concurrently.
+  The overlay also caches the most recent window information while the cursor
+  remains inside that window's bounds, eliminating redundant system queries
+  during slow motions or brief pauses. Set ``KILL_BY_CLICK_CACHE=0`` to disable
+  this optimisation or ``KILL_BY_CLICK_CACHE_TIMEOUT`` to control how long
+  cached results remain valid.
   The highlight color defaults to ``red`` but can be customized by setting
   ``KILL_BY_CLICK_HIGHLIGHT`` in the environment. The ``scripts/kill_by_click.py``
-  helper launches the overlay directly from the command line. Use `--skip-confirm` to close it instantly without the final check. The overlay samples the window
+  helper launches the overlay directly from the command line. Use `--skip-confirm` to close it instantly without the final check. Pass `--background` or
+  `--no-background` to explicitly enable or disable threaded detection. Use
+  `--workers` to control the number of detection threads. Pass `--cache` or
+  `--no-cache` to override caching and `--cache-timeout` to set the expiration.
+  The overlay samples the window
   repeatedly and mixes those results with a short hover history to choose the
   most stable PID even when windows overlap. ``KILL_BY_CLICK_HISTORY`` sets how
   many hover entries are kept while ``KILL_BY_CLICK_SAMPLE_DECAY`` and

--- a/scripts/kill_by_click.py
+++ b/scripts/kill_by_click.py
@@ -37,6 +37,43 @@ def main(argv: list[str] | None = None) -> None:
         type=float,
         help="Controls how strongly pointer speed shortens the delay",
     )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        help="Number of threads to use for background window detection",
+    )
+    parser.add_argument(
+        "--cache-timeout",
+        type=float,
+        help="Seconds to keep cached window info valid",
+    )
+    cache = parser.add_mutually_exclusive_group()
+    cache.add_argument(
+        "--cache",
+        dest="cache",
+        action="store_true",
+        help="Enable caching of window info",
+    )
+    cache.add_argument(
+        "--no-cache",
+        dest="cache",
+        action="store_false",
+        help="Disable cached window info",
+    )
+    bg = parser.add_mutually_exclusive_group()
+    bg.add_argument(
+        "--background",
+        dest="background",
+        action="store_true",
+        help="Query the window on a background thread",
+    )
+    bg.add_argument(
+        "--no-background",
+        dest="background",
+        action="store_false",
+        help="Disable threaded window detection",
+    )
+    parser.set_defaults(background=None, cache=None)
     args = parser.parse_args(argv)
 
     root = tk.Tk()
@@ -50,6 +87,14 @@ def main(argv: list[str] | None = None) -> None:
         kwargs["max_interval"] = args.max_interval
     if args.delay_scale is not None:
         kwargs["delay_scale"] = args.delay_scale
+    if args.workers is not None:
+        kwargs["workers"] = args.workers
+    if args.background is not None:
+        kwargs["background"] = args.background
+    if args.cache_timeout is not None:
+        kwargs["cache_timeout"] = args.cache_timeout
+    if args.cache is not None:
+        kwargs["cache"] = args.cache
     overlay = ClickOverlay(root, **kwargs)
     pid, title = overlay.choose()
     if pid is None:

--- a/src/utils/security.py
+++ b/src/utils/security.py
@@ -9,6 +9,8 @@ from typing import Optional
 from pathlib import Path
 import sys
 import psutil
+from dataclasses import dataclass
+import socket
 from .kill_utils import kill_process, kill_process_tree
 
 
@@ -211,10 +213,6 @@ def require_admin(prompt: str = "Administrator access is required.") -> None:
 
     if not ensure_admin(prompt):
         raise PermissionError("Administrator privileges are required")
-
-
-from dataclasses import dataclass
-import socket
 
 
 @dataclass(slots=True)

--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -14,6 +14,7 @@ import math
 import tkinter as tk
 from collections import deque
 from typing import Optional, Callable
+import threading
 from enum import Enum, auto
 
 from src.utils.window_utils import (
@@ -28,6 +29,34 @@ from src.utils.mouse_listener import capture_mouse, is_supported
 from src.utils.scoring_engine import ScoringEngine, tuning
 
 DEFAULT_HIGHLIGHT = os.getenv("KILL_BY_CLICK_HIGHLIGHT", "red")
+
+# Default number of background worker threads for window queries. The
+# value can be overridden by ``KILL_BY_CLICK_WORKERS`` or the ``workers``
+# argument when creating :class:`ClickOverlay`.
+DEFAULT_WORKERS = 1
+
+# Enable background window detection by default so cursor tracking remains
+# responsive even when system commands are slow. Set this to "0" or "false"
+# to restore synchronous behaviour which simplifies testing.
+BACKGROUND_QUERY = os.getenv("KILL_BY_CLICK_BACKGROUND", "1").lower() not in (
+    "0",
+    "false",
+    "no",
+)
+
+# Cache the window information while the cursor remains inside the
+# last queried rectangle. This significantly reduces expensive window
+# lookups during slow motion or brief pauses. The cache expires after
+# ``DEFAULT_CACHE_TIMEOUT`` seconds so newly opened windows are still
+# detected promptly. Set ``KILL_BY_CLICK_CACHE=0`` to disable caching or
+# adjust ``KILL_BY_CLICK_CACHE_TIMEOUT`` to change the expiration.
+DEFAULT_CACHE_TIMEOUT = 0.1
+CACHE_RESULTS = os.getenv("KILL_BY_CLICK_CACHE", "1").lower() not in (
+    "0",
+    "false",
+    "no",
+)
+CACHE_TIMEOUT = float(os.getenv("KILL_BY_CLICK_CACHE_TIMEOUT", str(DEFAULT_CACHE_TIMEOUT)))
 
 # Allow the refresh interval to be configured via an environment
 # variable. Falling back to the tuning default keeps behaviour
@@ -80,6 +109,10 @@ class ClickOverlay(tk.Toplevel):
         delay_scale: float | None = None,
         skip_confirm: bool | None = None,
         on_hover: Callable[[int | None, str | None], None] | None = None,
+        background: bool | None = None,
+        workers: int | None = None,
+        cache: bool | None = None,
+        cache_timeout: float | None = None,
     ) -> None:
         super().__init__(parent)
         # Configure fullscreen before enabling override-redirect to avoid
@@ -149,6 +182,35 @@ class ClickOverlay(tk.Toplevel):
             self.delay_scale = delay_scale
         if self.delay_scale <= 0:
             self.delay_scale = tuning.delay_scale
+        if workers is None:
+            env = os.getenv("KILL_BY_CLICK_WORKERS")
+            if env is not None:
+                try:
+                    self.workers = max(1, int(env))
+                except ValueError:
+                    self.workers = DEFAULT_WORKERS
+            else:
+                self.workers = DEFAULT_WORKERS
+        else:
+            self.workers = max(1, workers)
+        if cache is None:
+            env = os.getenv("KILL_BY_CLICK_CACHE")
+            if env is not None:
+                cache = env.lower() not in ("0", "false", "no")
+            else:
+                cache = CACHE_RESULTS
+        self.cache = cache
+        if cache_timeout is None:
+            env = os.getenv("KILL_BY_CLICK_CACHE_TIMEOUT")
+            if env is not None:
+                try:
+                    self.cache_timeout = float(env)
+                except ValueError:
+                    self.cache_timeout = CACHE_TIMEOUT
+            else:
+                self.cache_timeout = CACHE_TIMEOUT
+        else:
+            self.cache_timeout = max(0.0, cache_timeout)
         if skip_confirm is None:
             env = os.getenv("KILL_BY_CLICK_SKIP_CONFIRM")
             skip_confirm = env not in (None, "0", "false", "no")
@@ -191,6 +253,11 @@ class ClickOverlay(tk.Toplevel):
         )
         self._last_pid: int | None = None
         self._flash_id: str | None = None
+        # Remember the last rectangle returned from a window query so we can
+        # reuse the result while the cursor remains inside it. This avoids
+        # expensive system calls when hovering over the same window.
+        self._last_query_rect: tuple[int, int, int, int] | None = None
+        self._cache_time: float = 0.0
         try:
             self._cursor_x = self.winfo_pointerx()
             self._cursor_y = self.winfo_pointery()
@@ -198,6 +265,18 @@ class ClickOverlay(tk.Toplevel):
             self._cursor_x = 0
         self._cursor_y = 0
         self._last_move_pos = (self._cursor_x, self._cursor_y)
+        if background is None:
+            background = BACKGROUND_QUERY
+        self.background = background
+        self._pending_info: WindowInfo | None = None
+        self._stop_event: threading.Event | None = None
+        self._workers: list[threading.Thread] = []
+        if self.background:
+            self._stop_event = threading.Event()
+            for _ in range(self.workers):
+                t = threading.Thread(target=self._worker_loop, daemon=True)
+                t.start()
+                self._workers.append(t)
 
     def _flash_highlight(self) -> None:
         """Temporarily thicken the highlight rectangle when the target changes."""
@@ -260,6 +339,17 @@ class ClickOverlay(tk.Toplevel):
             self.update_state = UpdateState.PENDING
             self.after_idle(self._process_update)
 
+    def _worker_loop(self) -> None:
+        while self._stop_event is not None and not self._stop_event.is_set():
+            try:
+                info = self._query_window()
+                self._pending_info = info
+            except Exception:
+                pass
+            delay = self._next_delay() / 1000.0
+            if self._stop_event.wait(delay):
+                break
+
     def _next_delay(self) -> int:
         """Return the delay in milliseconds until the next update."""
         base_ms = self.interval * 1000.0
@@ -279,7 +369,12 @@ class ClickOverlay(tk.Toplevel):
             self._cursor_y = self.winfo_pointery()
         except Exception:
             pass
-        self._update_rect()
+        info: WindowInfo | None = None
+        if not self.background:
+            info = self._query_window()
+        else:
+            info = self._pending_info or self._last_info
+        self._update_rect(info)
         now = time.monotonic()
         if now - self._last_active_query >= self.interval:
             active = get_active_window().pid
@@ -311,7 +406,26 @@ class ClickOverlay(tk.Toplevel):
     def _query_window(self) -> WindowInfo:
         """Return the window info below the cursor, ignoring this overlay."""
 
-        return self._query_window_at(int(self._cursor_x), int(self._cursor_y))
+        x = int(self._cursor_x)
+        y = int(self._cursor_y)
+        rect = self._last_query_rect
+        if (
+            self.cache
+            and rect is not None
+            and rect[0] <= x <= rect[0] + rect[2]
+            and rect[1] <= y <= rect[1] + rect[3]
+            and self._last_info is not None
+            and time.monotonic() - self._cache_time <= self.cache_timeout
+        ):
+            return self._last_info
+
+        info = self._query_window_at(x, y)
+        if info.rect is not None:
+            self._last_query_rect = info.rect
+            self._cache_time = time.monotonic()
+        else:
+            self._cache_time = 0.0
+        return info
 
     def _probe_point(self, x: int, y: int) -> WindowInfo:
         """Return window info at ``(x, y)`` applying fallbacks."""
@@ -426,7 +540,10 @@ class ClickOverlay(tk.Toplevel):
 
     def _update_rect(self, info: WindowInfo | None = None) -> None:
         if info is None:
-            info = self._query_window()
+            if self.background:
+                info = self._pending_info or self._last_info or WindowInfo(None)
+            else:
+                info = self._query_window()
         if not getattr(self, "_raised", False):
             self.lift()
             self._raised = True
@@ -459,8 +576,13 @@ class ClickOverlay(tk.Toplevel):
             else:
                 self._current_pid = info.pid
                 self._current_streak = 1
+            if info.rect is not None:
+                self._last_query_rect = info.rect
+                self._cache_time = time.monotonic()
         elif info.pid is None:
             self._last_info = None
+            self._last_query_rect = None
+            self._cache_time = 0.0
 
         px = int(self._cursor_x)
         py = int(self._cursor_y)
@@ -608,6 +730,17 @@ class ClickOverlay(tk.Toplevel):
             except Exception:
                 pass
             self._flash_id = None
+        if self._stop_event is not None:
+            self._stop_event.set()
+            for t in self._workers:
+                try:
+                    t.join(timeout=0.1)
+                except Exception:
+                    pass
+            self._workers.clear()
+            self._pending_info = None
+        self._last_query_rect = None
+        self._cache_time = 0.0
         remove_window_clickthrough(self)
         self.destroy()
 

--- a/src/views/force_quit_dialog.py
+++ b/src/views/force_quit_dialog.py
@@ -2078,6 +2078,24 @@ class ForceQuitDialog(BaseDialog):
             "highlight": color,
             "on_hover": self._highlight_pid,
         }
+        bg_env = os.getenv("KILL_BY_CLICK_BACKGROUND")
+        if bg_env is not None:
+            kwargs["background"] = bg_env.lower() not in ("0", "false", "no")
+        workers_env = os.getenv("KILL_BY_CLICK_WORKERS")
+        if workers_env is not None:
+            try:
+                kwargs["workers"] = int(workers_env)
+            except ValueError:
+                pass
+        cache_env = os.getenv("KILL_BY_CLICK_CACHE")
+        if cache_env is not None:
+            kwargs["cache"] = cache_env.lower() not in ("0", "false", "no")
+        cache_to_env = os.getenv("KILL_BY_CLICK_CACHE_TIMEOUT")
+        if cache_to_env is not None:
+            try:
+                kwargs["cache_timeout"] = float(cache_to_env)
+            except ValueError:
+                pass
         if interval_env is not None:
             try:
                 kwargs["interval"] = float(interval_env)

--- a/tests/test_auto_setup.py
+++ b/tests/test_auto_setup.py
@@ -1,7 +1,5 @@
 import importlib
 import os
-import sys
-from types import ModuleType
 from importlib import metadata
 
 import main

--- a/tests/test_force_quit.py
+++ b/tests/test_force_quit.py
@@ -274,7 +274,7 @@ class TestForceQuit(unittest.TestCase):
             "time.sleep(30)"
         )
         proc = subprocess.Popen([sys.executable, "-c", script])
-        time.sleep(0.2)
+        time.sleep(0.5)
         self.assertTrue(psutil.pid_exists(proc.pid))
         count = ForceQuitDialog.force_kill_above_threads(5)
         time.sleep(0.1)
@@ -1215,6 +1215,7 @@ class TestForceQuit(unittest.TestCase):
         dialog.deiconify = mock.Mock()
 
         with (
+            mock.patch.dict(os.environ, {"KILL_BY_CLICK_BACKGROUND": "0"}),
             mock.patch("src.views.click_overlay.ClickOverlay") as CO,
             mock.patch("src.views.force_quit_dialog.messagebox") as MB,
         ):
@@ -1228,6 +1229,7 @@ class TestForceQuit(unittest.TestCase):
             assert args[0] is dialog
             assert kwargs.get("highlight") == dialog.accent
             assert kwargs.get("on_hover") == dialog._highlight_pid
+            assert kwargs.get("background") is False
             MB.showerror.assert_called_once()
             dialog.after_idle.assert_called_with(dialog._update_hover)
 
@@ -1251,6 +1253,98 @@ class TestForceQuit(unittest.TestCase):
             dialog._kill_by_click()
             MB.askyesno.assert_not_called()
             MB.showinfo.assert_called_once()
+            dialog.force_kill.assert_called_once_with(123)
+
+    def test_kill_by_click_background_env(self) -> None:
+        dialog = ForceQuitDialog.__new__(ForceQuitDialog)
+        dialog.accent = "#f00"
+        dialog.paused = True
+        dialog._watcher = mock.Mock()
+        dialog._populate = mock.Mock()
+        dialog.withdraw = mock.Mock()
+        dialog.deiconify = mock.Mock()
+        dialog.force_kill = mock.Mock(return_value=True)
+        dialog.after_idle = mock.Mock()
+
+        with (
+            mock.patch.dict(os.environ, {"KILL_BY_CLICK_BACKGROUND": "0"}),
+            mock.patch("src.views.click_overlay.ClickOverlay") as CO,
+            mock.patch("src.views.force_quit_dialog.messagebox") as MB,
+        ):
+            CO.return_value.choose.return_value = (123, "foo")
+            dialog._kill_by_click()
+            args, kwargs = CO.call_args
+            assert kwargs.get("background") is False
+            MB.askyesno.assert_called_once()
+            dialog.force_kill.assert_called_once_with(123)
+
+    def test_kill_by_click_workers_env(self) -> None:
+        dialog = ForceQuitDialog.__new__(ForceQuitDialog)
+        dialog.accent = "#f00"
+        dialog.paused = True
+        dialog._watcher = mock.Mock()
+        dialog._populate = mock.Mock()
+        dialog.withdraw = mock.Mock()
+        dialog.deiconify = mock.Mock()
+        dialog.force_kill = mock.Mock(return_value=True)
+        dialog.after_idle = mock.Mock()
+
+        with (
+            mock.patch.dict(os.environ, {"KILL_BY_CLICK_WORKERS": "5"}),
+            mock.patch("src.views.click_overlay.ClickOverlay") as CO,
+            mock.patch("src.views.force_quit_dialog.messagebox") as MB,
+        ):
+            CO.return_value.choose.return_value = (123, "foo")
+            dialog._kill_by_click()
+            args, kwargs = CO.call_args
+            assert kwargs.get("workers") == 5
+            MB.askyesno.assert_called_once()
+            dialog.force_kill.assert_called_once_with(123)
+
+    def test_kill_by_click_cache_env(self) -> None:
+        dialog = ForceQuitDialog.__new__(ForceQuitDialog)
+        dialog.accent = "#f00"
+        dialog.paused = True
+        dialog._watcher = mock.Mock()
+        dialog._populate = mock.Mock()
+        dialog.withdraw = mock.Mock()
+        dialog.deiconify = mock.Mock()
+        dialog.force_kill = mock.Mock(return_value=True)
+        dialog.after_idle = mock.Mock()
+
+        with (
+            mock.patch.dict(os.environ, {"KILL_BY_CLICK_CACHE": "0"}),
+            mock.patch("src.views.click_overlay.ClickOverlay") as CO,
+            mock.patch("src.views.force_quit_dialog.messagebox") as MB,
+        ):
+            CO.return_value.choose.return_value = (123, "foo")
+            dialog._kill_by_click()
+            args, kwargs = CO.call_args
+            assert kwargs.get("cache") is False
+            MB.askyesno.assert_called_once()
+            dialog.force_kill.assert_called_once_with(123)
+
+    def test_kill_by_click_cache_timeout_env(self) -> None:
+        dialog = ForceQuitDialog.__new__(ForceQuitDialog)
+        dialog.accent = "#f00"
+        dialog.paused = True
+        dialog._watcher = mock.Mock()
+        dialog._populate = mock.Mock()
+        dialog.withdraw = mock.Mock()
+        dialog.deiconify = mock.Mock()
+        dialog.force_kill = mock.Mock(return_value=True)
+        dialog.after_idle = mock.Mock()
+
+        with (
+            mock.patch.dict(os.environ, {"KILL_BY_CLICK_CACHE_TIMEOUT": "0.2"}),
+            mock.patch("src.views.click_overlay.ClickOverlay") as CO,
+            mock.patch("src.views.force_quit_dialog.messagebox") as MB,
+        ):
+            CO.return_value.choose.return_value = (123, "foo")
+            dialog._kill_by_click()
+            args, kwargs = CO.call_args
+            assert kwargs.get("cache_timeout") == 0.2
+            MB.askyesno.assert_called_once()
             dialog.force_kill.assert_called_once_with(123)
 
     @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")

--- a/tests/test_kill_by_click_cli.py
+++ b/tests/test_kill_by_click_cli.py
@@ -14,12 +14,16 @@ def test_main_invokes_overlay(monkeypatch):
             min_interval=None,
             max_interval=None,
             delay_scale=None,
+            background=None,
+            workers=None,
         ):
             called['skip_confirm'] = skip_confirm
             called['interval'] = interval
             called['min_interval'] = min_interval
             called['max_interval'] = max_interval
             called['delay_scale'] = delay_scale
+            called['background'] = background
+            called['workers'] = workers
 
         def choose(self):
             called['choose'] = True
@@ -34,6 +38,8 @@ def test_main_invokes_overlay(monkeypatch):
         '--min-interval', '0.05',
         '--max-interval', '0.3',
         '--delay-scale', '500',
+        '--workers', '3',
+        '--no-background',
     ])
 
     assert called.get('choose')
@@ -42,3 +48,85 @@ def test_main_invokes_overlay(monkeypatch):
     assert called.get('min_interval') == 0.05
     assert called.get('max_interval') == 0.3
     assert called.get('delay_scale') == 500.0
+    assert called.get('background') is False
+    assert called.get('workers') == 3
+
+
+def test_main_background_flag(monkeypatch):
+    called = {}
+
+    class DummyOverlay:
+        def __init__(self, root, *, background=None, **_kwargs):
+            called['background'] = background
+
+        def choose(self):
+            called['choose'] = True
+            return (None, None)
+
+    monkeypatch.setattr(kbc, 'ClickOverlay', DummyOverlay)
+    monkeypatch.setattr(kbc.tk, 'Tk', lambda: type('T', (), {'withdraw': lambda self: None, 'destroy': lambda self: None})())
+
+    kbc.main(['--background'])
+
+    assert called.get('choose')
+    assert called.get('background') is True
+
+
+def test_main_workers_flag(monkeypatch):
+    called = {}
+
+    class DummyOverlay:
+        def __init__(self, root, *, workers=None, **_kwargs):
+            called['workers'] = workers
+
+        def choose(self):
+            called['choose'] = True
+            return (None, None)
+
+    monkeypatch.setattr(kbc, 'ClickOverlay', DummyOverlay)
+    monkeypatch.setattr(kbc.tk, 'Tk', lambda: type('T', (), {'withdraw': lambda self: None, 'destroy': lambda self: None})())
+
+    kbc.main(['--workers', '4'])
+
+    assert called.get('choose')
+    assert called.get('workers') == 4
+
+
+def test_main_cache_flag(monkeypatch):
+    called = {}
+
+    class DummyOverlay:
+        def __init__(self, root, *, cache=None, **_kwargs):
+            called['cache'] = cache
+
+        def choose(self):
+            called['choose'] = True
+            return (None, None)
+
+    monkeypatch.setattr(kbc, 'ClickOverlay', DummyOverlay)
+    monkeypatch.setattr(kbc.tk, 'Tk', lambda: type('T', (), {'withdraw': lambda self: None, 'destroy': lambda self: None})())
+
+    kbc.main(['--cache'])
+
+    assert called.get('choose')
+    assert called.get('cache') is True
+
+
+def test_main_cache_timeout(monkeypatch):
+    called = {}
+
+    class DummyOverlay:
+        def __init__(self, root, *, cache_timeout=None, **_kwargs):
+            called['cache_timeout'] = cache_timeout
+
+        def choose(self):
+            called['choose'] = True
+            return (None, None)
+
+    monkeypatch.setattr(kbc, 'ClickOverlay', DummyOverlay)
+    monkeypatch.setattr(kbc.tk, 'Tk', lambda: type('T', (), {'withdraw': lambda self: None, 'destroy': lambda self: None})())
+
+    kbc.main(['--cache-timeout', '0.2'])
+
+    assert called.get('choose')
+    assert called.get('cache_timeout') == 0.2

--- a/tests/test_kill_utils.py
+++ b/tests/test_kill_utils.py
@@ -29,7 +29,7 @@ class TestKillUtils(unittest.TestCase):
             ),
         ]
         parent = subprocess.Popen(cmd)
-        time.sleep(0.2)
+        time.sleep(0.5)
         children = psutil.Process(parent.pid).children()
         self.assertTrue(children)
         kill_process_tree(parent.pid)

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -5,12 +5,10 @@ import sys
 from types import SimpleNamespace
 import psutil
 import socket
-from src.utils import kill_utils
 import pytest
 
 from src.utils import security
 from src.utils.security import (
-    LocalPort,
     is_firewall_enabled,
     set_firewall_enabled,
     is_defender_enabled,
@@ -166,13 +164,18 @@ def test_kill_process_by_port(monkeypatch):
         SimpleNamespace(status=psutil.CONN_LISTEN, laddr=SimpleNamespace(port=80), pid=1234)
     ]
     monkeypatch.setattr(psutil, "net_connections", lambda kind="inet": fake_conns)
+
     class FakeProc:
+
         def __init__(self, pid):
             called["pid"] = pid
+
         def terminate(self):
             called["term"] = True
+
         def kill(self):
             called["kill"] = True
+
         def wait(self, timeout=None):
             pass
 

--- a/tests/test_tools_view.py
+++ b/tests/test_tools_view.py
@@ -1,6 +1,5 @@
 import os
 import unittest
-from unittest import mock
 from src.app import CoolBoxApp
 from src.views.tools_view import ToolsView
 


### PR DESCRIPTION
## Summary
- run window detection on dedicated worker threads instead of a thread pool
- update docs to describe the new background polling strategy
- adapt unit tests for worker-based implementation
- clean up style issues to satisfy flake8

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`
- `flake8 src setup.py tests | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6863f6275bf0832b844d4e0ed03618e5