### PR TITLE
Resolve unused helpers and finalize Kill by Click tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,30 @@ A modern, feature-rich desktop application built with Python and CustomTkinter.
   ``KILL_BY_CLICK_MAX_INTERVAL`` (``0.2`` seconds) using an exponential curve
   tied to pointer velocity. ``KILL_BY_CLICK_DELAY_SCALE`` controls how strongly
   speed influences this interval. Fast motion shortens the delay for responsive
-  tracking while slower movement stretches it to conserve CPU. The window's normal interaction state is restored automatically when the overlay closes. The Force Quit dialog uses this overlay when you choose *Kill by Click* and falls back to the window under the cursor if no PID is detected. Set ``FORCE_QUIT_CLICK_SKIP_CONFIRM=1`` to skip the termination prompt. The overlay samples the window
+tracking while slower movement stretches it to conserve CPU. The window's normal interaction state is restored automatically when the overlay closes. The Force Quit dialog uses this overlay when you choose *Kill by Click* and falls back to the window under the cursor if no PID is detected. Set ``FORCE_QUIT_CLICK_SKIP_CONFIRM=1`` to skip the termination prompt. The overlay samples the window
+  information using dedicated worker threads so UI events never block even when
+  window queries are slow. Set ``KILL_BY_CLICK_BACKGROUND=0`` to disable
+  background polling. ``KILL_BY_CLICK_WORKERS`` controls how many threads run
+  these queries concurrently.
+  The overlay also caches the most recent window information while the cursor
+  remains inside that window's bounds, eliminating redundant system queries
+  during slow motions or brief pauses. Set ``KILL_BY_CLICK_CACHE=0`` to disable
+  this optimisation or ``KILL_BY_CLICK_CACHE_TIMEOUT`` to control how long
+  cached results remain valid.
+  Set ``KILL_BY_CLICK_IMMEDIATE=0`` to disable immediate queries when the
+  cursor moves. When enabled, movement wakes the worker threads so results
+  update without waiting for the next polling interval.
+  Set ``KILL_BY_CLICK_HEATMAP=0`` to disable the scoring heatmap entirely.
   The highlight color defaults to ``red`` but can be customized by setting
   ``KILL_BY_CLICK_HIGHLIGHT`` in the environment. The ``scripts/kill_by_click.py``
-  helper launches the overlay directly from the command line. Use `--skip-confirm` to close it instantly without the final check. The overlay samples the window
+  helper launches the overlay directly from the command line. Use `--skip-confirm` to close it instantly without the final check. Pass `--background` or
+  `--no-background` to explicitly enable or disable threaded detection. Use
+  `--workers` to control the number of detection threads. Pass `--cache` or
+  `--no-cache` to override caching and `--cache-timeout` to set the expiration.
+  Use `--heatmap` or `--no-heatmap` to toggle the cursor heatmap which can
+  slightly reduce CPU usage when disabled. Use `--immediate` or
+  `--no-immediate` to enable or disable instant queries when the cursor moves.
+  The overlay samples the window
   repeatedly and mixes those results with a short hover history to choose the
   most stable PID even when windows overlap. ``KILL_BY_CLICK_HISTORY`` sets how
   many hover entries are kept while ``KILL_BY_CLICK_SAMPLE_DECAY`` and

--- a/scripts/kill_by_click.py
+++ b/scripts/kill_by_click.py
@@ -37,6 +37,69 @@ def main(argv: list[str] | None = None) -> None:
         type=float,
         help="Controls how strongly pointer speed shortens the delay",
     )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        help="Number of threads to use for background window detection",
+    )
+    parser.add_argument(
+        "--cache-timeout",
+        type=float,
+        help="Seconds to keep cached window info valid",
+    )
+    immed = parser.add_mutually_exclusive_group()
+    immed.add_argument(
+        "--immediate",
+        dest="immediate",
+        action="store_true",
+        help="Trigger window queries immediately on cursor move",
+    )
+    immed.add_argument(
+        "--no-immediate",
+        dest="immediate",
+        action="store_false",
+        help="Disable immediate queries on movement",
+    )
+    heat = parser.add_mutually_exclusive_group()
+    heat.add_argument(
+        "--heatmap",
+        dest="heatmap",
+        action="store_true",
+        help="Enable cursor heatmap tracking",
+    )
+    heat.add_argument(
+        "--no-heatmap",
+        dest="heatmap",
+        action="store_false",
+        help="Disable cursor heatmap tracking",
+    )
+    cache = parser.add_mutually_exclusive_group()
+    cache.add_argument(
+        "--cache",
+        dest="cache",
+        action="store_true",
+        help="Enable caching of window info",
+    )
+    cache.add_argument(
+        "--no-cache",
+        dest="cache",
+        action="store_false",
+        help="Disable cached window info",
+    )
+    bg = parser.add_mutually_exclusive_group()
+    bg.add_argument(
+        "--background",
+        dest="background",
+        action="store_true",
+        help="Query the window on a background thread",
+    )
+    bg.add_argument(
+        "--no-background",
+        dest="background",
+        action="store_false",
+        help="Disable threaded window detection",
+    )
+    parser.set_defaults(background=None, cache=None, heatmap=None, immediate=None)
     args = parser.parse_args(argv)
 
     root = tk.Tk()
@@ -50,6 +113,18 @@ def main(argv: list[str] | None = None) -> None:
         kwargs["max_interval"] = args.max_interval
     if args.delay_scale is not None:
         kwargs["delay_scale"] = args.delay_scale
+    if args.workers is not None:
+        kwargs["workers"] = args.workers
+    if args.background is not None:
+        kwargs["background"] = args.background
+    if args.cache_timeout is not None:
+        kwargs["cache_timeout"] = args.cache_timeout
+    if args.cache is not None:
+        kwargs["cache"] = args.cache
+    if args.heatmap is not None:
+        kwargs["heatmap"] = args.heatmap
+    if args.immediate is not None:
+        kwargs["immediate"] = args.immediate
     overlay = ClickOverlay(root, **kwargs)
     pid, title = overlay.choose()
     if pid is None:

--- a/src/utils/network.py
+++ b/src/utils/network.py
@@ -1121,21 +1121,6 @@ async def async_detect_local_hosts(
     )
 
 
-def _ping_host(host: str, timeout: float = 1.0) -> bool:
-    """Return ``True`` if ``host`` responds to ping within ``timeout`` seconds."""
-    system = platform.system().lower()
-    if system == "windows":
-        cmd = ["ping", "-n", "1", "-w", str(int(timeout * 1000)), host]
-    else:
-        cmd = ["ping", "-c", "1", "-W", str(int(timeout)), host]
-    return (
-        subprocess.run(
-            cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
-        ).returncode
-        == 0
-    )
-
-
 async def _async_ping_host(
     host: str,
     timeout: float = 1.0,

--- a/src/utils/rainbow.py
+++ b/src/utils/rainbow.py
@@ -67,7 +67,7 @@ class RainbowBorder:
         self.start()
         return self
 
-    def __exit__(self, exc_type, exc, tb) -> None:
+    def __exit__(self, *exc_info) -> None:
         self.stop()
 
     def start(self) -> None:

--- a/src/utils/security.py
+++ b/src/utils/security.py
@@ -9,6 +9,8 @@ from typing import Optional
 from pathlib import Path
 import sys
 import psutil
+from dataclasses import dataclass
+import socket
 from .kill_utils import kill_process, kill_process_tree
 
 
@@ -211,10 +213,6 @@ def require_admin(prompt: str = "Administrator access is required.") -> None:
 
     if not ensure_admin(prompt):
         raise PermissionError("Administrator privileges are required")
-
-
-from dataclasses import dataclass
-import socket
 
 
 @dataclass(slots=True)

--- a/src/views/force_quit_dialog.py
+++ b/src/views/force_quit_dialog.py
@@ -2078,6 +2078,30 @@ class ForceQuitDialog(BaseDialog):
             "highlight": color,
             "on_hover": self._highlight_pid,
         }
+        bg_env = os.getenv("KILL_BY_CLICK_BACKGROUND")
+        if bg_env is not None:
+            kwargs["background"] = bg_env.lower() not in ("0", "false", "no")
+        workers_env = os.getenv("KILL_BY_CLICK_WORKERS")
+        if workers_env is not None:
+            try:
+                kwargs["workers"] = int(workers_env)
+            except ValueError:
+                pass
+        cache_env = os.getenv("KILL_BY_CLICK_CACHE")
+        if cache_env is not None:
+            kwargs["cache"] = cache_env.lower() not in ("0", "false", "no")
+        cache_to_env = os.getenv("KILL_BY_CLICK_CACHE_TIMEOUT")
+        if cache_to_env is not None:
+            try:
+                kwargs["cache_timeout"] = float(cache_to_env)
+            except ValueError:
+                pass
+        heat_env = os.getenv("KILL_BY_CLICK_HEATMAP")
+        if heat_env is not None:
+            kwargs["heatmap"] = heat_env.lower() not in ("0", "false", "no")
+        immed_env = os.getenv("KILL_BY_CLICK_IMMEDIATE")
+        if immed_env is not None:
+            kwargs["immediate"] = immed_env.lower() not in ("0", "false", "no")
         if interval_env is not None:
             try:
                 kwargs["interval"] = float(interval_env)

--- a/tests/test_auto_setup.py
+++ b/tests/test_auto_setup.py
@@ -1,7 +1,5 @@
 import importlib
 import os
-import sys
-from types import ModuleType
 from importlib import metadata
 
 import main

--- a/tests/test_click_overlay.py
+++ b/tests/test_click_overlay.py
@@ -8,6 +8,13 @@ from src.views.click_overlay import ClickOverlay, WindowInfo
 
 
 class TestClickOverlay(unittest.TestCase):
+    def setUp(self) -> None:
+        self._bg_patch = patch.dict(os.environ, {"KILL_BY_CLICK_BACKGROUND": "0"})
+        self._bg_patch.start()
+
+    def tearDown(self) -> None:
+        self._bg_patch.stop()
+
     @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
     def test_overlay_creation(self) -> None:
         root = tk.Tk()
@@ -31,6 +38,37 @@ class TestClickOverlay(unittest.TestCase):
                 overlay = ClickOverlay(root)
             color = overlay.canvas.itemcget(overlay.rect, "outline")
             self.assertEqual(color, "green")
+            overlay.destroy()
+            root.destroy()
+
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_workers_env_creates_threads(self) -> None:
+        with patch.dict(os.environ, {"KILL_BY_CLICK_BACKGROUND": "1", "KILL_BY_CLICK_WORKERS": "3"}):
+            root = tk.Tk()
+            started = []
+
+            class DummyThread:
+                def __init__(self, *_, **__):
+                    pass
+
+                def start(self):
+                    started.append(True)
+
+            with patch("src.views.click_overlay.threading.Thread", DummyThread), patch(
+                "src.views.click_overlay.is_supported", return_value=False
+            ):
+                overlay = ClickOverlay(root)
+                assert len(started) == 3
+            overlay.destroy()
+            root.destroy()
+
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_immediate_env_disables_trigger(self) -> None:
+        with patch.dict(os.environ, {"KILL_BY_CLICK_BACKGROUND": "1", "KILL_BY_CLICK_IMMEDIATE": "0"}):
+            root = tk.Tk()
+            with patch("src.views.click_overlay.is_supported", return_value=False):
+                overlay = ClickOverlay(root)
+            self.assertFalse(overlay.immediate)
             overlay.destroy()
             root.destroy()
 
@@ -158,6 +196,83 @@ class TestClickOverlay(unittest.TestCase):
             result = overlay._query_window()
 
         self.assertEqual(result.pid, 321)
+
+        overlay.destroy()
+        root.destroy()
+
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_query_uses_cached_result(self) -> None:
+        root = tk.Tk()
+        with patch("src.views.click_overlay.is_supported", return_value=False):
+            overlay = ClickOverlay(root)
+
+        info = WindowInfo(123, (0, 0, 20, 20), "cached")
+        with patch("src.views.click_overlay.get_window_at", return_value=info) as gwa:
+            overlay._update_rect()  # first query
+            calls_after_first = gwa.call_count
+            overlay._cursor_x = 10
+            overlay._cursor_y = 10
+            overlay._update_rect()  # inside same rect, should use cache
+
+        self.assertEqual(gwa.call_count, calls_after_first)
+
+        overlay.destroy()
+        root.destroy()
+
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_cache_timeout_expires(self) -> None:
+        root = tk.Tk()
+        with patch("src.views.click_overlay.is_supported", return_value=False):
+            overlay = ClickOverlay(root, cache_timeout=0.05)
+
+        info = WindowInfo(123, (0, 0, 20, 20), "cached")
+        times = iter([0.0, 0.0, 0.04, 0.1])
+        with patch(
+            "src.views.click_overlay.time.monotonic",
+            side_effect=lambda: next(times),
+        ), patch("src.views.click_overlay.get_window_at", return_value=info) as gwa:
+            overlay._update_rect()  # first query at t=0
+            calls_after_first = gwa.call_count
+            overlay._cursor_x = 10
+            overlay._cursor_y = 10
+            overlay._update_rect()  # within timeout
+            overlay._cursor_x = 15
+            overlay._cursor_y = 15
+            overlay._update_rect()  # after timeout
+
+        self.assertEqual(gwa.call_count, calls_after_first + 1)
+
+        overlay.destroy()
+        root.destroy()
+
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_cache_env_disables_caching(self) -> None:
+        with patch.dict(os.environ, {"KILL_BY_CLICK_CACHE": "0"}):
+            root = tk.Tk()
+            with patch("src.views.click_overlay.is_supported", return_value=False):
+                overlay = ClickOverlay(root)
+
+            info = WindowInfo(123, (0, 0, 20, 20), "cached")
+            with patch("src.views.click_overlay.get_window_at", return_value=info) as gwa:
+                overlay._update_rect()
+                calls_after_first = gwa.call_count
+                overlay._cursor_x = 5
+                overlay._cursor_y = 5
+                overlay._update_rect()
+
+            self.assertGreater(gwa.call_count, calls_after_first)
+
+            overlay.destroy()
+            root.destroy()
+
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_heatmap_env_disables_heatmap(self) -> None:
+        with patch.dict(os.environ, {"KILL_BY_CLICK_HEATMAP": "0"}):
+            root = tk.Tk()
+            with patch("src.views.click_overlay.is_supported", return_value=False):
+                overlay = ClickOverlay(root)
+
+        self.assertFalse(overlay.heatmap_enabled)
 
         overlay.destroy()
         root.destroy()
@@ -388,7 +503,7 @@ class TestClickOverlay(unittest.TestCase):
 
         overlay.after_idle = lambda cb: cb()
         overlay._process_update = unittest.mock.Mock()
-        overlay._heatmap.update = unittest.mock.Mock()
+        overlay.engine.heatmap.update = unittest.mock.Mock()
         overlay._last_move_pos = (0, 0)
         overlay._last_move_time = time.time() - 0.1
 
@@ -399,7 +514,7 @@ class TestClickOverlay(unittest.TestCase):
 
         self.assertEqual(overlay._path_history[-1], (20, 10))
         self.assertGreater(overlay._velocity, 0)
-        overlay._heatmap.update.assert_called_once_with(20, 10)
+        overlay.engine.heatmap.update.assert_called_once_with(20, 10)
         overlay._process_update.assert_called_once()
 
         overlay.destroy()
@@ -680,7 +795,7 @@ class TestClickOverlay(unittest.TestCase):
         with patch("src.views.click_overlay.is_supported", return_value=False):
             overlay = ClickOverlay(root)
 
-        overlay._heatmap.region_score = lambda r: 5.0 if r and r[0] == 0 else 0.1
+        overlay.engine.heatmap.region_score = lambda r: 5.0 if r and r[0] == 0 else 0.1
         samples = [
             WindowInfo(1, (0, 0, 10, 10), "one"),
             WindowInfo(2, (20, 20, 10, 10), "two"),

--- a/tests/test_force_quit.py
+++ b/tests/test_force_quit.py
@@ -274,7 +274,7 @@ class TestForceQuit(unittest.TestCase):
             "time.sleep(30)"
         )
         proc = subprocess.Popen([sys.executable, "-c", script])
-        time.sleep(0.2)
+        time.sleep(0.5)
         self.assertTrue(psutil.pid_exists(proc.pid))
         count = ForceQuitDialog.force_kill_above_threads(5)
         time.sleep(0.1)
@@ -1215,6 +1215,7 @@ class TestForceQuit(unittest.TestCase):
         dialog.deiconify = mock.Mock()
 
         with (
+            mock.patch.dict(os.environ, {"KILL_BY_CLICK_BACKGROUND": "0"}),
             mock.patch("src.views.click_overlay.ClickOverlay") as CO,
             mock.patch("src.views.force_quit_dialog.messagebox") as MB,
         ):
@@ -1228,6 +1229,7 @@ class TestForceQuit(unittest.TestCase):
             assert args[0] is dialog
             assert kwargs.get("highlight") == dialog.accent
             assert kwargs.get("on_hover") == dialog._highlight_pid
+            assert kwargs.get("background") is False
             MB.showerror.assert_called_once()
             dialog.after_idle.assert_called_with(dialog._update_hover)
 
@@ -1251,6 +1253,144 @@ class TestForceQuit(unittest.TestCase):
             dialog._kill_by_click()
             MB.askyesno.assert_not_called()
             MB.showinfo.assert_called_once()
+            dialog.force_kill.assert_called_once_with(123)
+
+    def test_kill_by_click_background_env(self) -> None:
+        dialog = ForceQuitDialog.__new__(ForceQuitDialog)
+        dialog.accent = "#f00"
+        dialog.paused = True
+        dialog._watcher = mock.Mock()
+        dialog._populate = mock.Mock()
+        dialog.withdraw = mock.Mock()
+        dialog.deiconify = mock.Mock()
+        dialog.force_kill = mock.Mock(return_value=True)
+        dialog.after_idle = mock.Mock()
+
+        with (
+            mock.patch.dict(os.environ, {"KILL_BY_CLICK_BACKGROUND": "0"}),
+            mock.patch("src.views.click_overlay.ClickOverlay") as CO,
+            mock.patch("src.views.force_quit_dialog.messagebox") as MB,
+        ):
+            CO.return_value.choose.return_value = (123, "foo")
+            dialog._kill_by_click()
+            args, kwargs = CO.call_args
+            assert kwargs.get("background") is False
+            MB.askyesno.assert_called_once()
+            dialog.force_kill.assert_called_once_with(123)
+
+    def test_kill_by_click_workers_env(self) -> None:
+        dialog = ForceQuitDialog.__new__(ForceQuitDialog)
+        dialog.accent = "#f00"
+        dialog.paused = True
+        dialog._watcher = mock.Mock()
+        dialog._populate = mock.Mock()
+        dialog.withdraw = mock.Mock()
+        dialog.deiconify = mock.Mock()
+        dialog.force_kill = mock.Mock(return_value=True)
+        dialog.after_idle = mock.Mock()
+
+        with (
+            mock.patch.dict(os.environ, {"KILL_BY_CLICK_WORKERS": "5"}),
+            mock.patch("src.views.click_overlay.ClickOverlay") as CO,
+            mock.patch("src.views.force_quit_dialog.messagebox") as MB,
+        ):
+            CO.return_value.choose.return_value = (123, "foo")
+            dialog._kill_by_click()
+            args, kwargs = CO.call_args
+            assert kwargs.get("workers") == 5
+            MB.askyesno.assert_called_once()
+            dialog.force_kill.assert_called_once_with(123)
+
+    def test_kill_by_click_cache_env(self) -> None:
+        dialog = ForceQuitDialog.__new__(ForceQuitDialog)
+        dialog.accent = "#f00"
+        dialog.paused = True
+        dialog._watcher = mock.Mock()
+        dialog._populate = mock.Mock()
+        dialog.withdraw = mock.Mock()
+        dialog.deiconify = mock.Mock()
+        dialog.force_kill = mock.Mock(return_value=True)
+        dialog.after_idle = mock.Mock()
+
+        with (
+            mock.patch.dict(os.environ, {"KILL_BY_CLICK_CACHE": "0"}),
+            mock.patch("src.views.click_overlay.ClickOverlay") as CO,
+            mock.patch("src.views.force_quit_dialog.messagebox") as MB,
+        ):
+            CO.return_value.choose.return_value = (123, "foo")
+            dialog._kill_by_click()
+            args, kwargs = CO.call_args
+            assert kwargs.get("cache") is False
+            MB.askyesno.assert_called_once()
+            dialog.force_kill.assert_called_once_with(123)
+
+    def test_kill_by_click_cache_timeout_env(self) -> None:
+        dialog = ForceQuitDialog.__new__(ForceQuitDialog)
+        dialog.accent = "#f00"
+        dialog.paused = True
+        dialog._watcher = mock.Mock()
+        dialog._populate = mock.Mock()
+        dialog.withdraw = mock.Mock()
+        dialog.deiconify = mock.Mock()
+        dialog.force_kill = mock.Mock(return_value=True)
+        dialog.after_idle = mock.Mock()
+
+        with (
+            mock.patch.dict(os.environ, {"KILL_BY_CLICK_CACHE_TIMEOUT": "0.2"}),
+            mock.patch("src.views.click_overlay.ClickOverlay") as CO,
+            mock.patch("src.views.force_quit_dialog.messagebox") as MB,
+        ):
+            CO.return_value.choose.return_value = (123, "foo")
+            dialog._kill_by_click()
+            args, kwargs = CO.call_args
+            assert kwargs.get("cache_timeout") == 0.2
+            MB.askyesno.assert_called_once()
+            dialog.force_kill.assert_called_once_with(123)
+
+    def test_kill_by_click_heatmap_env(self) -> None:
+        dialog = ForceQuitDialog.__new__(ForceQuitDialog)
+        dialog.accent = "#f00"
+        dialog.paused = True
+        dialog._watcher = mock.Mock()
+        dialog._populate = mock.Mock()
+        dialog.withdraw = mock.Mock()
+        dialog.deiconify = mock.Mock()
+        dialog.force_kill = mock.Mock(return_value=True)
+        dialog.after_idle = mock.Mock()
+
+        with (
+            mock.patch.dict(os.environ, {"KILL_BY_CLICK_HEATMAP": "0"}),
+            mock.patch("src.views.click_overlay.ClickOverlay") as CO,
+            mock.patch("src.views.force_quit_dialog.messagebox") as MB,
+        ):
+            CO.return_value.choose.return_value = (123, "foo")
+            dialog._kill_by_click()
+            args, kwargs = CO.call_args
+            assert kwargs.get("heatmap") is False
+            MB.askyesno.assert_called_once()
+            dialog.force_kill.assert_called_once_with(123)
+
+    def test_kill_by_click_immediate_env(self) -> None:
+        dialog = ForceQuitDialog.__new__(ForceQuitDialog)
+        dialog.accent = "#f00"
+        dialog.paused = True
+        dialog._watcher = mock.Mock()
+        dialog._populate = mock.Mock()
+        dialog.withdraw = mock.Mock()
+        dialog.deiconify = mock.Mock()
+        dialog.force_kill = mock.Mock(return_value=True)
+        dialog.after_idle = mock.Mock()
+
+        with (
+            mock.patch.dict(os.environ, {"KILL_BY_CLICK_IMMEDIATE": "0"}),
+            mock.patch("src.views.click_overlay.ClickOverlay") as CO,
+            mock.patch("src.views.force_quit_dialog.messagebox") as MB,
+        ):
+            CO.return_value.choose.return_value = (123, "foo")
+            dialog._kill_by_click()
+            args, kwargs = CO.call_args
+            assert kwargs.get("immediate") is False
+            MB.askyesno.assert_called_once()
             dialog.force_kill.assert_called_once_with(123)
 
     @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")

--- a/tests/test_kill_by_click_cli.py
+++ b/tests/test_kill_by_click_cli.py
@@ -14,12 +14,16 @@ def test_main_invokes_overlay(monkeypatch):
             min_interval=None,
             max_interval=None,
             delay_scale=None,
+            background=None,
+            workers=None,
         ):
             called['skip_confirm'] = skip_confirm
             called['interval'] = interval
             called['min_interval'] = min_interval
             called['max_interval'] = max_interval
             called['delay_scale'] = delay_scale
+            called['background'] = background
+            called['workers'] = workers
 
         def choose(self):
             called['choose'] = True
@@ -34,6 +38,8 @@ def test_main_invokes_overlay(monkeypatch):
         '--min-interval', '0.05',
         '--max-interval', '0.3',
         '--delay-scale', '500',
+        '--workers', '3',
+        '--no-background',
     ])
 
     assert called.get('choose')
@@ -42,3 +48,125 @@ def test_main_invokes_overlay(monkeypatch):
     assert called.get('min_interval') == 0.05
     assert called.get('max_interval') == 0.3
     assert called.get('delay_scale') == 500.0
+    assert called.get('background') is False
+    assert called.get('workers') == 3
+
+
+def test_main_background_flag(monkeypatch):
+    called = {}
+
+    class DummyOverlay:
+        def __init__(self, root, *, background=None, **_kwargs):
+            called['background'] = background
+
+        def choose(self):
+            called['choose'] = True
+            return (None, None)
+
+    monkeypatch.setattr(kbc, 'ClickOverlay', DummyOverlay)
+    monkeypatch.setattr(kbc.tk, 'Tk', lambda: type('T', (), {'withdraw': lambda self: None, 'destroy': lambda self: None})())
+
+    kbc.main(['--background'])
+
+    assert called.get('choose')
+    assert called.get('background') is True
+
+
+def test_main_workers_flag(monkeypatch):
+    called = {}
+
+    class DummyOverlay:
+        def __init__(self, root, *, workers=None, **_kwargs):
+            called['workers'] = workers
+
+        def choose(self):
+            called['choose'] = True
+            return (None, None)
+
+    monkeypatch.setattr(kbc, 'ClickOverlay', DummyOverlay)
+    monkeypatch.setattr(kbc.tk, 'Tk', lambda: type('T', (), {'withdraw': lambda self: None, 'destroy': lambda self: None})())
+
+    kbc.main(['--workers', '4'])
+
+    assert called.get('choose')
+    assert called.get('workers') == 4
+
+
+def test_main_cache_flag(monkeypatch):
+    called = {}
+
+    class DummyOverlay:
+        def __init__(self, root, *, cache=None, **_kwargs):
+            called['cache'] = cache
+
+        def choose(self):
+            called['choose'] = True
+            return (None, None)
+
+    monkeypatch.setattr(kbc, 'ClickOverlay', DummyOverlay)
+    monkeypatch.setattr(kbc.tk, 'Tk', lambda: type('T', (), {'withdraw': lambda self: None, 'destroy': lambda self: None})())
+
+    kbc.main(['--cache'])
+
+    assert called.get('choose')
+    assert called.get('cache') is True
+
+
+def test_main_cache_timeout(monkeypatch):
+    called = {}
+
+    class DummyOverlay:
+        def __init__(self, root, *, cache_timeout=None, **_kwargs):
+            called['cache_timeout'] = cache_timeout
+
+        def choose(self):
+            called['choose'] = True
+            return (None, None)
+
+    monkeypatch.setattr(kbc, 'ClickOverlay', DummyOverlay)
+    monkeypatch.setattr(kbc.tk, 'Tk', lambda: type('T', (), {'withdraw': lambda self: None, 'destroy': lambda self: None})())
+
+    kbc.main(['--cache-timeout', '0.2'])
+
+    assert called.get('choose')
+    assert called.get('cache_timeout') == 0.2
+
+
+def test_main_heatmap_flag(monkeypatch):
+    called = {}
+
+    class DummyOverlay:
+        def __init__(self, root, *, heatmap=None, **_kwargs):
+            called['heatmap'] = heatmap
+
+        def choose(self):
+            called['choose'] = True
+            return (None, None)
+
+    monkeypatch.setattr(kbc, 'ClickOverlay', DummyOverlay)
+    monkeypatch.setattr(kbc.tk, 'Tk', lambda: type('T', (), {'withdraw': lambda self: None, 'destroy': lambda self: None})())
+
+    kbc.main(['--no-heatmap'])
+
+    assert called.get('choose')
+    assert called.get('heatmap') is False
+
+
+def test_main_immediate_flag(monkeypatch):
+    called = {}
+
+    class DummyOverlay:
+        def __init__(self, root, *, immediate=None, **_kwargs):
+            called['immediate'] = immediate
+
+        def choose(self):
+            called['choose'] = True
+            return (None, None)
+
+    monkeypatch.setattr(kbc, 'ClickOverlay', DummyOverlay)
+    monkeypatch.setattr(kbc.tk, 'Tk', lambda: type('T', (), {'withdraw': lambda self: None, 'destroy': lambda self: None})())
+
+    kbc.main(['--no-immediate'])
+
+    assert called.get('choose')
+    assert called.get('immediate') is False

--- a/tests/test_kill_utils.py
+++ b/tests/test_kill_utils.py
@@ -29,7 +29,7 @@ class TestKillUtils(unittest.TestCase):
             ),
         ]
         parent = subprocess.Popen(cmd)
-        time.sleep(0.2)
+        time.sleep(0.5)
         children = psutil.Process(parent.pid).children()
         self.assertTrue(children)
         kill_process_tree(parent.pid)

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -5,12 +5,10 @@ import sys
 from types import SimpleNamespace
 import psutil
 import socket
-from src.utils import kill_utils
 import pytest
 
 from src.utils import security
 from src.utils.security import (
-    LocalPort,
     is_firewall_enabled,
     set_firewall_enabled,
     is_defender_enabled,
@@ -166,13 +164,18 @@ def test_kill_process_by_port(monkeypatch):
         SimpleNamespace(status=psutil.CONN_LISTEN, laddr=SimpleNamespace(port=80), pid=1234)
     ]
     monkeypatch.setattr(psutil, "net_connections", lambda kind="inet": fake_conns)
+
     class FakeProc:
+
         def __init__(self, pid):
             called["pid"] = pid
+
         def terminate(self):
             called["term"] = True
+
         def kill(self):
             called["kill"] = True
+
         def wait(self, timeout=None):
             pass
 

--- a/tests/test_tools_view.py
+++ b/tests/test_tools_view.py
@@ -1,6 +1,5 @@
 import os
 import unittest
-from unittest import mock
 from src.app import CoolBoxApp
 from src.views.tools_view import ToolsView
 


### PR DESCRIPTION
## Summary
- remove obsolete `_ping_host` helper
- drop unused `confirm_delay` tuning field
- tighten scoring engine logic
- clean up RainbowBorder exit handler

## Testing
- `pip install -q -r requirements.txt`
- `flake8 src setup.py tests | head -n 20`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6863f6275bf0832b844d4e0ed03618e5