### PR TITLE
Improve hidden security relaunch

### DIFF
--- a/main.py
+++ b/main.py
@@ -65,8 +65,6 @@ def _check_single(req: str) -> str | None:
             return req
     r = Requirement(req)
     try:
-        from importlib import metadata as importlib_metadata
-
         version = importlib_metadata.version(r.name)
     except importlib_metadata.PackageNotFoundError:
         return req

--- a/scripts/kill_by_click.py
+++ b/scripts/kill_by_click.py
@@ -2,7 +2,6 @@
 """Select a window by clicking it and print the PID and title."""
 
 import argparse
-import os
 import tkinter as tk
 from src.views.click_overlay import ClickOverlay, KILL_BY_CLICK_INTERVAL
 
@@ -17,6 +16,7 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument(
         "--interval",
         type=float,
+        default=KILL_BY_CLICK_INTERVAL,
         help=(
             "Refresh rate in seconds for the overlay. Overrides "
             "KILL_BY_CLICK_INTERVAL if provided."
@@ -41,9 +41,7 @@ def main(argv: list[str] | None = None) -> None:
 
     root = tk.Tk()
     root.withdraw()
-    kwargs = {"skip_confirm": args.skip_confirm}
-    if args.interval is not None:
-        kwargs["interval"] = args.interval
+    kwargs = {"skip_confirm": args.skip_confirm, "interval": args.interval}
     if args.min_interval is not None:
         kwargs["min_interval"] = args.min_interval
     if args.max_interval is not None:

--- a/scripts/security_center_hidden.py
+++ b/scripts/security_center_hidden.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import sys
 import os
-import subprocess
-import platform
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -13,7 +11,7 @@ sys.path.insert(0, str(ROOT))
 
 from src.utils.win_console import (  # noqa: E402
     hide_terminal,
-    hidden_creation_flags,
+    spawn_detached,
     silence_stdio,
 )
 from src.app import CoolBoxApp  # noqa: E402
@@ -26,31 +24,11 @@ def _relaunch_if_needed() -> None:
     if os.environ.get("COOLBOX_HIDDEN") == "1":
         return
 
-    exe = Path(sys.executable)
+    # Hide any visible terminal window before respawning
+    hide_terminal(detach=False)
 
-    if platform.system() == "Windows":
-        if exe.name.lower() == "python.exe":
-            pythonw = exe.with_name("pythonw.exe")
-            if pythonw.is_file():
-                exe = pythonw
-        flags = hidden_creation_flags()
-        os.environ["COOLBOX_HIDDEN"] = "1"
-        subprocess.Popen(
-            [str(exe), str(Path(__file__).resolve()), *sys.argv[1:]],
-            creationflags=flags,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
-        sys.exit(0)
-
-    # POSIX: spawn a detached copy in a new session
     os.environ["COOLBOX_HIDDEN"] = "1"
-    subprocess.Popen(
-        [str(exe), str(Path(__file__).resolve()), *sys.argv[1:]],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        start_new_session=True,
-    )
+    spawn_detached([sys.executable, str(Path(__file__).resolve()), *sys.argv[1:]])
     sys.exit(0)
 
 

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -185,7 +185,7 @@ __all__ = [
     "hide_terminal",
     "silence_stdio",
     "hidden_creation_flags",
-    "is_firewall_enabled", 
+    "is_firewall_enabled",
     "set_firewall_enabled",
     "is_defender_enabled",
     "set_defender_enabled",

--- a/tests/test_auto_setup.py
+++ b/tests/test_auto_setup.py
@@ -1,7 +1,5 @@
 import importlib
 import os
-import sys
-from types import ModuleType
 from importlib import metadata
 
 import main

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -164,13 +164,17 @@ def test_kill_process_by_port(monkeypatch):
         SimpleNamespace(status=psutil.CONN_LISTEN, laddr=SimpleNamespace(port=80), pid=1234)
     ]
     monkeypatch.setattr(psutil, "net_connections", lambda kind="inet": fake_conns)
+
     class FakeProc:
         def __init__(self, pid):
             called["pid"] = pid
+
         def terminate(self):
             called["term"] = True
+
         def kill(self):
             called["kill"] = True
+
         def wait(self, timeout=None):
             pass
 

--- a/tests/test_tools_view.py
+++ b/tests/test_tools_view.py
@@ -1,6 +1,5 @@
 import os
 import unittest
-from unittest import mock
 from src.app import CoolBoxApp
 from src.views.tools_view import ToolsView
 


### PR DESCRIPTION
## Summary
- refine security_center_hidden relaunch logic
- add generic spawn_detached helper for hidden processes
- fix lint errors and tighten Kill by Click CLI defaults

## Testing
- `pytest tests/test_security.py::test_launch_security_center_hidden -q`
- `pytest -q`
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_68640a750824832ba4586c1665e05fe9