### PR TITLE
Improve security center launching

### DIFF
--- a/src/security_center.py
+++ b/src/security_center.py
@@ -1,0 +1,23 @@
+"""Standalone entry point for the Security Center dialog."""
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from .app import CoolBoxApp
+from .views.security_dialog import SecurityDialog
+
+
+def main() -> None:
+    app = CoolBoxApp()
+    app.window.withdraw()
+    SecurityDialog(app)
+    app.window.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/security_center_hidden.py
+++ b/src/security_center_hidden.py
@@ -1,0 +1,40 @@
+"""Launch the Security Center dialog without showing a console window."""
+from __future__ import annotations
+
+import sys
+import os
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from .utils.win_console import hide_terminal, spawn_detached, silence_stdio
+from .app import CoolBoxApp
+from .views.security_dialog import SecurityDialog
+
+
+def _relaunch_if_needed() -> None:
+    if os.environ.get("COOLBOX_HIDDEN") == "1":
+        return
+    hide_terminal(detach=False)
+    os.environ["COOLBOX_HIDDEN"] = "1"
+    spawn_detached([sys.executable, str(Path(__file__).resolve()), *sys.argv[1:]])
+    sys.exit(0)
+
+
+_relaunch_if_needed()
+detach = os.environ.get("COOLBOX_HIDDEN") != "1"
+hide_terminal(detach=detach)
+silence_stdio()
+
+
+def main() -> None:
+    app = CoolBoxApp()
+    app.window.withdraw()
+    SecurityDialog(app)
+    app.window.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/views/security_dialog.py
+++ b/src/views/security_dialog.py
@@ -64,8 +64,10 @@ class SecurityDialog(BaseDialog):
 
         style = ttk.Style(self)
         style.theme_use("clam")
+        style.layout("PortTreeview.Treeview", style.layout("Treeview"))
+        style.configure("PortTreeview.Treeview")
         style.map(
-            "PortTreeview",
+            "PortTreeview.Treeview",
             background=[("selected", "#2a6cad")],
             foreground=[("selected", "white")],
         )
@@ -75,7 +77,7 @@ class SecurityDialog(BaseDialog):
             columns=columns,
             show="headings",
             selectmode="browse",
-            style="PortTreeview",
+            style="PortTreeview.Treeview",
         )
         vsb = ttk.Scrollbar(tree_frame, orient="vertical", command=self.port_tree.yview)
         hsb = ttk.Scrollbar(tree_frame, orient="horizontal", command=self.port_tree.xview)

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -214,7 +214,16 @@ def test_kill_port_range(monkeypatch):
 
 def test_launch_security_center_missing(monkeypatch):
     monkeypatch.setattr(security.Path, "is_file", lambda self: False, raising=False)
-    assert security.launch_security_center() is False
+    monkeypatch.setattr(security, "is_admin", lambda: True)
+    called = {}
+
+    def fake_bg(args, **kwargs):
+        called["args"] = args
+        return True
+
+    monkeypatch.setattr(security, "run_command_background", fake_bg)
+    assert security.launch_security_center() is True
+    assert called["args"][:2] == [sys.executable, "-m"]
 
 
 def test_launch_security_center_admin(monkeypatch):


### PR DESCRIPTION
## Summary
- add new `src.security_center` and `src.security_center_hidden` modules for launching the Security Center
- update `launch_security_center` to fall back to running modules when the scripts are missing
- update test for launching without scripts
- fix treeview style so standalone Security Center runs under Xvfb

## Testing
- `pytest -q tests/test_security.py::test_launch_security_center_missing`
- `pytest -q tests/test_security.py`
- `xvfb-run -a python -m src.security_center` *(terminated after manual kill)*

------
https://chatgpt.com/codex/tasks/task_e_6867d948fe4c832b938cd24e8bb400a6