### PR TITLE
Fix console clear attribute

### DIFF
--- a/psutil.py
+++ b/psutil.py
@@ -1,19 +1,19 @@
+from importlib import import_module, machinery, util
 import sys
-from importlib import import_module, util
+from pathlib import Path
 
 module = None
-try:
-    sys.modules.pop('psutil', None)
-    path0 = sys.path.pop(0)
-    module = import_module('psutil')
-    sys.path.insert(0, path0)
-    if getattr(module, '__file__', '') == __file__:
-        module = None
-except Exception:
-    sys.path.insert(0, path0)
-    module = None
-
-if module is None:
+root = str(Path(__file__).resolve().parent)
+paths = [p for p in sys.path if Path(p).resolve() != Path(root).resolve()]
+previous = sys.modules.pop('psutil', None)
+spec = machinery.PathFinder().find_spec('psutil', paths)
+if spec and getattr(spec, 'origin', None) != __file__:
+    module = util.module_from_spec(spec)
+    sys.modules['psutil'] = module
+    spec.loader.exec_module(module)
+else:
+    if previous is not None:
+        sys.modules['psutil'] = previous
     module = import_module('src.psutil')
 
 for name in getattr(module, '__all__', dir(module)):

--- a/rich/console.py
+++ b/rich/console.py
@@ -3,6 +3,9 @@ class Console:
         pass
     def log(self, *a, **k):
         pass
+    def clear(self):
+        import os
+        os.system('cls' if os.name == 'nt' else 'clear')
 
 class Control:
     def __init__(self, *a, **k):

--- a/rich/progress.py
+++ b/rich/progress.py
@@ -1,6 +1,6 @@
 class Progress:
-    def __init__(self, *a, **k):
-        pass
+    def __init__(self, *a, console=None, **k):
+        self.console = console
     def __enter__(self):
         return self
     def __exit__(self, exc_type, exc, tb):


### PR DESCRIPTION
## Summary
- implement `clear()` method in our bundled `rich` stub
- keep console reference in bundled progress stub
- load real `psutil` when available instead of minimal stub

## Testing
- `pytest tests/test_setup.py -q`
- `pytest tests/test_helpers.py::test_run_with_spinner -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68685c9284fc832bb040cabfea48ca76