### PR TITLE
Fix CTkLabel warning

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -110,10 +110,13 @@ class CoolBoxApp:
             if Image and ImageTk:
                 image = Image.open(icon_path)
                 self._icon_photo = ImageTk.PhotoImage(image)
+                if hasattr(ctk, "CTkImage"):
+                    self._icon_image = ctk.CTkImage(light_image=image, size=image.size)
             else:
                 import tkinter as tk
 
                 self._icon_photo = tk.PhotoImage(file=str(icon_path))  # type: ignore
+                self._icon_image = None
             self.window.iconphoto(True, self._icon_photo)
 
             if sys.platform.startswith("win") and Image and ImageTk:
@@ -144,6 +147,10 @@ class CoolBoxApp:
     def get_icon_photo(self):
         """Return the cached application icon if available."""
         return getattr(self, "_icon_photo", None)
+
+    def get_icon_image(self):
+        """Return the CTkImage version of the application icon if available."""
+        return getattr(self, "_icon_image", None)
 
     def _setup_ui(self):
         """Setup the main UI layout"""

--- a/src/views/about_view.py
+++ b/src/views/about_view.py
@@ -26,7 +26,9 @@ class AboutView(BaseView):
         container = self.create_container()
 
         # Application logo
-        logo = self.app.get_icon_photo()
+        logo = self.app.get_icon_image()
+        if logo is None:
+            logo = self.app.get_icon_photo()
         if logo is not None:
             ctk.CTkLabel(container, image=logo, text="").pack(pady=(0, 10))
 


### PR DESCRIPTION
## Summary
- load app logo as `CTkImage` when available
- expose `get_icon_image` to retrieve the logo as `CTkImage`
- use `get_icon_image` in `AboutView`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68695e08f0d8832bbf3ff813a98958ff