### PR TITLE
Fix CTkLabel image handling

### DIFF
--- a/PIL/Image.py
+++ b/PIL/Image.py
@@ -4,4 +4,3 @@ class Image:
 
     def resize(self, *args, **kwargs):
         return self
-

--- a/src/views/about_view.py
+++ b/src/views/about_view.py
@@ -2,6 +2,7 @@
 About view - Application info
 """
 import customtkinter as ctk
+import tkinter as tk
 from ..components.widgets import info_label
 from ..utils import open_path
 from .base_view import BaseView
@@ -26,11 +27,13 @@ class AboutView(BaseView):
         container = self.create_container()
 
         # Application logo
-        logo = self.app.get_icon_image()
-        if logo is None:
-            logo = self.app.get_icon_photo()
-        if logo is not None:
-            ctk.CTkLabel(container, image=logo, text="").pack(pady=(0, 10))
+        logo_img = self.app.get_icon_image()
+        if logo_img is not None:
+            ctk.CTkLabel(container, image=logo_img, text="").pack(pady=(0, 10))
+        else:
+            photo = self.app.get_icon_photo()
+            if photo is not None:
+                tk.Label(container, image=photo).pack(pady=(0, 10))
 
         self.add_title(container, "About CoolBox")
 


### PR DESCRIPTION
## Summary
- use a regular Tk label if CTkImage isn't available
- remove trailing blank line in PIL/Image.py for flake8

## Testing
- `pytest -q`
- `flake8 src setup.py tests`


------
https://chatgpt.com/codex/tasks/task_e_6869602890c4832baa3db4e80a6350d5