### PR TITLE
Fix icon handling with env overrides

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -39,17 +39,7 @@ import sys
 import tempfile
 import ctypes
 
-
-def _assets_path(*parts: str) -> Path:
-    """Return the absolute path to an asset inside the project."""
-    base_env = os.environ.get("COOLBOX_ASSETS")
-    if base_env:
-        base = Path(base_env)
-    elif getattr(sys, "frozen", False):
-        base = Path(getattr(sys, "_MEIPASS"))  # type: ignore[attr-defined]
-    else:
-        base = Path(__file__).resolve().parents[1]
-    return base.joinpath("assets", *parts)
+from .utils.assets import asset_path
 
 from .config import Config
 from .components.sidebar import Sidebar
@@ -118,57 +108,15 @@ class CoolBoxApp:
 
     def _set_app_icon(self) -> None:
         """Set the window and dock icon to the CoolBox logo."""
-        icon_png = _assets_path("images", "coolbox_logo.png")
-        icon_ico = _assets_path("images", "coolbox_logo.ico")
         try:
-            image = None
-            if icon_png.is_file() and Image and ImageTk:
-                image = Image.open(icon_png)
-                self._icon_photo = ImageTk.PhotoImage(image)
-                if hasattr(ctk, "CTkImage"):
-                    self._icon_image = ctk.CTkImage(light_image=image, size=image.size)
-            elif icon_png.is_file():
-                import tkinter as tk
-                self._icon_photo = tk.PhotoImage(file=str(icon_png))  # type: ignore
-                self._icon_image = None
-            else:
-                self._icon_photo = None
-                self._icon_image = None
+            from .utils.icons import set_window_icon
 
-            if self._icon_photo:
-                self.window.iconphoto(True, self._icon_photo)
-
-            if sys.platform.startswith("win"):
-                ico_path = icon_ico if icon_ico.is_file() else None
-                if ico_path is None and image is not None and Image:
-                    try:
-                        tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".ico")
-                        image.save(tmp, format="ICO")
-                        tmp.close()
-                        ico_path = Path(tmp.name)
-                        self._temp_icon = tmp.name
-                    except Exception as exc:  # pragma: no cover - optional feature
-                        log(f"Failed to create temporary icon: {exc}")
-                        ico_path = None
-                if ico_path is not None:
-                    try:
-                        self.window.iconbitmap(str(ico_path))
-                        ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID("CoolBox")
-                    except Exception as exc:  # pragma: no cover - optional feature
-                        log(f"Failed to set taskbar icon: {exc}")
-            
+            photo, ctk_image, tmp = set_window_icon(self.window)
+            self._icon_photo = photo
+            self._icon_image = ctk_image
+            self._temp_icon = tmp
         except Exception as exc:  # pragma: no cover - best effort
             log(f"Failed to set window icon: {exc}")
-
-        if sys.platform == "darwin":
-            try:
-                from AppKit import NSApplication, NSImage
-
-                path = str(icon_ico if icon_ico.is_file() else icon_png)
-                ns_image = NSImage.alloc().initByReferencingFile_(path)
-                NSApplication.sharedApplication().setApplicationIconImage_(ns_image)
-            except Exception as exc:  # pragma: no cover - optional feature
-                log(f"Failed to set dock icon: {exc}")
 
     def get_icon_photo(self):
         """Return the cached application icon if available."""

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -23,6 +23,11 @@ _ATTR_MODULES = {
     "hex_brightness": "helpers",
     "run_with_spinner": "helpers",
     "console": "helpers",
+    # asset helpers
+    "asset_path": "assets",
+    "assets_base": "assets",
+    "logo_paths": "icons",
+    "set_window_icon": "icons",
     # rainbow
     "RainbowBorder": "rainbow",
     "NeonPulseBorder": "rainbow",

--- a/src/utils/assets.py
+++ b/src/utils/assets.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+"""Asset path helpers used throughout CoolBox."""
+
+from pathlib import Path
+import os
+import sys
+
+
+def assets_base() -> Path:
+    """Return the base directory containing bundled assets."""
+    base_env = os.environ.get("COOLBOX_ASSETS")
+    if base_env:
+        return Path(base_env)
+    if getattr(sys, "frozen", False):  # Support PyInstaller
+        return Path(getattr(sys, "_MEIPASS"))  # type: ignore[attr-defined]
+    return Path(__file__).resolve().parents[2]
+
+
+def asset_path(*parts: str) -> Path:
+    """Return the absolute path to a file in the ``assets`` directory."""
+    return assets_base().joinpath("assets", *parts)

--- a/src/utils/icons.py
+++ b/src/utils/icons.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+"""Helpers for loading and applying application icons."""
+
+from pathlib import Path
+import os
+import sys
+import tempfile
+import ctypes
+
+from .assets import asset_path
+
+try:
+    import customtkinter as ctk
+except Exception:  # pragma: no cover - optional runtime dep
+    ctk = None  # type: ignore
+
+try:
+    from PIL import Image, ImageTk  # type: ignore
+except Exception:  # pragma: no cover - pillow optional
+    Image = None  # type: ignore
+    ImageTk = None  # type: ignore
+
+__all__ = ["logo_paths", "set_window_icon"]
+
+
+def logo_paths() -> tuple[Path, Path]:
+    """Return paths to the CoolBox logo image and icon.
+
+    The locations can be overridden using the environment variables
+    ``COOLBOX_LOGO_PNG`` and ``COOLBOX_LOGO_ICO``. If not set, the files are
+    resolved from :func:`asset_path`.
+    """
+
+    png = os.environ.get("COOLBOX_LOGO_PNG")
+    ico = os.environ.get("COOLBOX_LOGO_ICO")
+    return (
+        Path(png) if png else asset_path("images", "coolbox_logo.png"),
+        Path(ico) if ico else asset_path("images", "coolbox_logo.ico"),
+    )
+
+
+def _load_image(path: Path) -> "Image.Image | None":
+    if Image is None:
+        return None
+    try:
+        return Image.open(path)
+    except Exception:  # pragma: no cover - best effort
+        return None
+
+
+def set_window_icon(window) -> tuple[object | None, object | None, str | None]:
+    """Set the application icon on *window* and return icon objects.
+
+    Returns a tuple ``(photo, ctk_image, tmp_icon)`` where ``photo`` is the
+    ``tk.PhotoImage`` used for ``iconphoto``, ``ctk_image`` is a ``CTkImage``
+    if available and ``tmp_icon`` is the path of any temporary ``.ico`` file
+    created on Windows.
+    """
+
+    png, ico = logo_paths()
+    photo = None
+    ctk_image = None
+    tmp_path: str | None = None
+
+    image = _load_image(png) if png.is_file() else None
+
+    try:
+        if png.is_file():
+            if ImageTk and image is not None:
+                photo = ImageTk.PhotoImage(image)
+            else:
+                import tkinter as tk
+
+                photo = tk.PhotoImage(file=str(png))  # type: ignore
+            if ctk and hasattr(ctk, "CTkImage") and image is not None:
+                ctk_image = ctk.CTkImage(light_image=image, size=image.size)
+            window.iconphoto(True, photo)
+
+        if sys.platform.startswith("win"):
+            ico_path = ico if ico.is_file() else None
+            if ico_path is None and image is not None and Image:
+                try:
+                    with tempfile.NamedTemporaryFile(delete=False, suffix=".ico") as tmp:
+                        image.save(tmp, format="ICO")
+                    ico_path = Path(tmp.name)
+                    tmp_path = tmp.name
+                except Exception:  # pragma: no cover - optional feature
+                    ico_path = None
+            if ico_path is not None:
+                try:
+                    window.iconbitmap(str(ico_path))
+                    ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID("CoolBox")
+                except Exception:  # pragma: no cover - optional feature
+                    pass
+
+    except Exception:  # pragma: no cover - best effort
+        pass
+
+    if sys.platform == "darwin":
+        try:  # pragma: no cover - optional feature
+            from AppKit import NSApplication, NSImage
+
+            path = str(ico if ico.is_file() else png)
+            ns_image = NSImage.alloc().initByReferencingFile_(path)
+            NSApplication.sharedApplication().setApplicationIconImage_(ns_image)
+        except Exception:
+            pass
+
+    return photo, ctk_image, tmp_path

--- a/src/utils/network.py
+++ b/src/utils/network.py
@@ -11,6 +11,7 @@ import shutil
 import ssl
 import re
 from pathlib import Path
+from .assets import asset_path
 from typing import (
     Callable,
     List,
@@ -48,9 +49,11 @@ _DEFAULT_PING_CONCURRENCY = int(
 _PING_CACHE_TTL = float(os.environ.get("PING_CACHE_TTL", 30.0))
 
 # Optional OUI database used for MAC vendor lookups
+
 _OUI_FILE = Path(
     os.environ.get(
-        "OUI_FILE", str(Path(__file__).resolve().parent.parent / "assets" / "oui.txt")
+        "OUI_FILE",
+        str(asset_path("oui.txt")),
     )
 )
 

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -1,0 +1,36 @@
+from src.utils.assets import asset_path, assets_base
+from src.utils import logo_paths
+
+
+def test_asset_path_default(monkeypatch):
+    monkeypatch.delenv("COOLBOX_ASSETS", raising=False)
+    p = asset_path("images", "coolbox_logo.png")
+    assert p.is_absolute()
+    assert p.name == "coolbox_logo.png"
+    assert assets_base() in p.parents
+
+
+def test_asset_path_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("COOLBOX_ASSETS", str(tmp_path))
+    p = asset_path("foo", "bar.txt")
+    assert p == tmp_path / "assets" / "foo" / "bar.txt"
+
+
+def test_logo_paths():
+    png, ico = logo_paths()
+    assert png.name == 'coolbox_logo.png'
+    assert ico.name == 'coolbox_logo.ico'
+    assert png.exists()
+    assert ico.exists()
+
+
+def test_logo_env(monkeypatch, tmp_path):
+    png = tmp_path / "my_logo.png"
+    ico = tmp_path / "my_logo.ico"
+    png.write_text("x")
+    ico.write_text("y")
+    monkeypatch.setenv("COOLBOX_LOGO_PNG", str(png))
+    monkeypatch.setenv("COOLBOX_LOGO_ICO", str(ico))
+    paths = logo_paths()
+    assert paths == (png, ico)
+


### PR DESCRIPTION
## Summary
- allow overriding logo paths with `COOLBOX_LOGO_PNG` and `COOLBOX_LOGO_ICO`
- test the new environment variable behaviour for logo paths

## Testing
- `pytest tests/test_assets.py tests/test_network.py::test_scan_ports -q`
- `pytest -q` *(fails: KeyboardInterrupt after tests complete)*

------
https://chatgpt.com/codex/tasks/task_e_686988659f54832bb90dd15ae8f7e210