### PR TITLE
Improve icon handling with callbacks

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -39,17 +39,7 @@ import sys
 import tempfile
 import ctypes
 
-
-def _assets_path(*parts: str) -> Path:
-    """Return the absolute path to an asset inside the project."""
-    base_env = os.environ.get("COOLBOX_ASSETS")
-    if base_env:
-        base = Path(base_env)
-    elif getattr(sys, "frozen", False):
-        base = Path(getattr(sys, "_MEIPASS"))  # type: ignore[attr-defined]
-    else:
-        base = Path(__file__).resolve().parents[1]
-    return base.joinpath("assets", *parts)
+from .utils.assets import asset_path
 
 from .config import Config
 from .components.sidebar import Sidebar
@@ -89,6 +79,7 @@ class CoolBoxApp:
         self.window.geometry(f"{self.config.get('window_width', 1200)}x{self.config.get('window_height', 800)}")
 
         # Set application icon
+        self.icon_callbacks: list[callable] = []
         self._set_app_icon()
 
         # Set minimum window size
@@ -118,57 +109,28 @@ class CoolBoxApp:
 
     def _set_app_icon(self) -> None:
         """Set the window and dock icon to the CoolBox logo."""
-        icon_png = _assets_path("images", "coolbox_logo.png")
-        icon_ico = _assets_path("images", "coolbox_logo.ico")
         try:
-            image = None
-            if icon_png.is_file() and Image and ImageTk:
-                image = Image.open(icon_png)
-                self._icon_photo = ImageTk.PhotoImage(image)
-                if hasattr(ctk, "CTkImage"):
-                    self._icon_image = ctk.CTkImage(light_image=image, size=image.size)
-            elif icon_png.is_file():
-                import tkinter as tk
-                self._icon_photo = tk.PhotoImage(file=str(icon_png))  # type: ignore
-                self._icon_image = None
-            else:
-                self._icon_photo = None
-                self._icon_image = None
+            from .utils.icons import set_window_icon
 
-            if self._icon_photo:
-                self.window.iconphoto(True, self._icon_photo)
-
-            if sys.platform.startswith("win"):
-                ico_path = icon_ico if icon_ico.is_file() else None
-                if ico_path is None and image is not None and Image:
-                    try:
-                        tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".ico")
-                        image.save(tmp, format="ICO")
-                        tmp.close()
-                        ico_path = Path(tmp.name)
-                        self._temp_icon = tmp.name
-                    except Exception as exc:  # pragma: no cover - optional feature
-                        log(f"Failed to create temporary icon: {exc}")
-                        ico_path = None
-                if ico_path is not None:
-                    try:
-                        self.window.iconbitmap(str(ico_path))
-                        ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID("CoolBox")
-                    except Exception as exc:  # pragma: no cover - optional feature
-                        log(f"Failed to set taskbar icon: {exc}")
-            
+            photo, ctk_image, tmp = set_window_icon(self.window, self._on_icon_event)
+            self._icon_photo = photo
+            self._icon_image = ctk_image
+            self._temp_icon = tmp
         except Exception as exc:  # pragma: no cover - best effort
             log(f"Failed to set window icon: {exc}")
 
-        if sys.platform == "darwin":
-            try:
-                from AppKit import NSApplication, NSImage
+    def add_icon_callback(self, callback: callable) -> None:
+        """Register a callback for icon load events."""
+        if callback not in self.icon_callbacks:
+            self.icon_callbacks.append(callback)
 
-                path = str(icon_ico if icon_ico.is_file() else icon_png)
-                ns_image = NSImage.alloc().initByReferencingFile_(path)
-                NSApplication.sharedApplication().setApplicationIconImage_(ns_image)
-            except Exception as exc:  # pragma: no cover - optional feature
-                log(f"Failed to set dock icon: {exc}")
+    def _on_icon_event(self, event: str, detail: str) -> None:
+        for cb in self.icon_callbacks:
+            try:
+                cb(event, detail)
+            except Exception as exc:  # pragma: no cover - user callback
+                log(f"Icon event callback failed: {exc}")
+        log(f"icon:{event} - {detail}")
 
     def get_icon_photo(self):
         """Return the cached application icon if available."""

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -23,6 +23,11 @@ _ATTR_MODULES = {
     "hex_brightness": "helpers",
     "run_with_spinner": "helpers",
     "console": "helpers",
+    # asset helpers
+    "asset_path": "assets",
+    "assets_base": "assets",
+    "logo_paths": "icons",
+    "set_window_icon": "icons",
     # rainbow
     "RainbowBorder": "rainbow",
     "NeonPulseBorder": "rainbow",

--- a/src/utils/assets.py
+++ b/src/utils/assets.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+"""Asset path helpers used throughout CoolBox."""
+
+from pathlib import Path
+import os
+import sys
+
+
+def assets_base() -> Path:
+    """Return the base directory containing bundled assets."""
+    base_env = os.environ.get("COOLBOX_ASSETS")
+    if base_env:
+        return Path(base_env)
+    if getattr(sys, "frozen", False):  # Support PyInstaller
+        return Path(getattr(sys, "_MEIPASS"))  # type: ignore[attr-defined]
+    return Path(__file__).resolve().parents[2]
+
+
+def asset_path(*parts: str) -> Path:
+    """Return the absolute path to a file in the ``assets`` directory."""
+    return assets_base().joinpath("assets", *parts)

--- a/src/utils/icons.py
+++ b/src/utils/icons.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+"""Helpers for loading and applying application icons."""
+
+from pathlib import Path
+import os
+import sys
+import tempfile
+import ctypes
+
+from .assets import asset_path, assets_base
+from .helpers import log
+
+try:
+    import customtkinter as ctk
+except Exception:  # pragma: no cover - optional runtime dep
+    ctk = None  # type: ignore
+
+try:
+    from PIL import Image, ImageTk  # type: ignore
+except Exception:  # pragma: no cover - pillow optional
+    Image = None  # type: ignore
+    ImageTk = None  # type: ignore
+
+__all__ = ["logo_paths", "set_window_icon"]
+
+# Default filenames searched when locating logo images if custom paths are not
+# provided via environment variables. This allows flexibility in where assets
+# are stored while still providing sensible fallbacks.
+_PNG_NAMES = [
+    "coolbox_logo.png",
+    "coolbox.png",
+    "logo.png",
+]
+
+_ICO_NAMES = [
+    "coolbox_logo.ico",
+    "coolbox.ico",
+    "logo.ico",
+]
+
+
+def _find_logo(names: list[str]) -> Path | None:
+    """Search ``assets`` directories for the first existing file in *names*."""
+
+    base = assets_base() / "assets"
+    for sub in ("images", "icons", ""):
+        folder = base / sub if sub else base
+        for name in names:
+            path = folder / name
+            if path.is_file():
+                return path
+    return None
+
+
+def logo_paths() -> tuple[Path, Path]:
+    """Return paths to the CoolBox logo image (PNG) and icon (ICO).
+
+    This function first checks the ``COOLBOX_LOGO_PNG`` and
+    ``COOLBOX_LOGO_ICO`` environment variables. If those variables are not set
+    or the files do not exist, several common filenames are searched for within
+    the bundled ``assets`` directories. The search stops at the first existing
+    file found for each format, providing flexibility for custom packaging or
+    overrides without sacrificing sensible defaults.
+    """
+
+    env_png = os.environ.get("COOLBOX_LOGO_PNG")
+    env_ico = os.environ.get("COOLBOX_LOGO_ICO")
+
+    png = Path(env_png) if env_png and Path(env_png).is_file() else _find_logo(_PNG_NAMES)
+    if png is None:
+        png = asset_path("images", "coolbox_logo.png")
+
+    ico = Path(env_ico) if env_ico and Path(env_ico).is_file() else _find_logo(_ICO_NAMES)
+    if ico is None:
+        ico = asset_path("images", "coolbox_logo.ico")
+
+    return png, ico
+
+
+def _load_image(path: Path) -> "Image.Image | None":
+    if Image is None:
+        return None
+    try:
+        return Image.open(path)
+    except Exception:  # pragma: no cover - best effort
+        return None
+
+
+def set_window_icon(
+    window,
+    callback: "Callable[[str, str], None] | None" = None,
+) -> tuple[object | None, object | None, str | None]:
+    """Set the application icon on *window* and return icon objects.
+
+    Parameters
+    ----------
+    window:
+        The Tk-compatible window on which to set the icon.
+    callback:
+        Optional callable ``callback(event, detail)`` invoked for debugging
+        during each step of the icon setup process. If omitted, :func:`log`
+        is used.
+
+    Returns
+    -------
+    tuple
+        ``(photo, ctk_image, tmp_icon)`` where ``photo`` is the ``tk.PhotoImage``
+        used for ``iconphoto``, ``ctk_image`` is a ``CTkImage`` if available, and
+        ``tmp_icon`` is the path to any temporary ``.ico`` file created on
+        Windows.
+    """
+
+    def emit(event: str, detail: str) -> None:
+        if callback is not None:
+            try:
+                callback(event, detail)
+            except Exception as exc:  # pragma: no cover - user callback
+                log(f"Icon callback error: {exc}")
+        else:
+            log(f"icon:{event} - {detail}")
+
+    png, ico = logo_paths()
+    emit("resolved_png", str(png))
+    emit("resolved_ico", str(ico))
+
+    photo = None
+    ctk_image = None
+    tmp_path: str | None = None
+
+    image = _load_image(png) if png.is_file() else None
+    if image is not None:
+        emit("load_image", str(png))
+
+    try:
+        if png.is_file():
+            if ImageTk and image is not None:
+                photo = ImageTk.PhotoImage(image)
+            else:
+                import tkinter as tk
+
+                photo = tk.PhotoImage(file=str(png))  # type: ignore
+            if ctk and hasattr(ctk, "CTkImage") and image is not None:
+                ctk_image = ctk.CTkImage(light_image=image, size=image.size)
+            window.iconphoto(True, photo)
+            emit("iconphoto", str(png))
+
+        if sys.platform.startswith("win"):
+            ico_path = ico if ico.is_file() else None
+            if ico_path is None and image is not None and Image:
+                try:
+                    with tempfile.NamedTemporaryFile(delete=False, suffix=".ico") as tmp:
+                        image.save(tmp, format="ICO")
+                    ico_path = Path(tmp.name)
+                    tmp_path = tmp.name
+                    emit("convert_ico", tmp_path)
+                except Exception:  # pragma: no cover - optional feature
+                    emit("error", "failed_temp_ico")
+                    ico_path = None
+            if ico_path is not None:
+                try:
+                    window.iconbitmap(str(ico_path))
+                    ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID("CoolBox")
+                    emit("iconbitmap", str(ico_path))
+                except Exception:  # pragma: no cover - optional feature
+                    emit("error", "iconbitmap")
+
+    except Exception as exc:  # pragma: no cover - best effort
+        emit("error", str(exc))
+
+    if sys.platform == "darwin":
+        try:  # pragma: no cover - optional feature
+            from AppKit import NSApplication, NSImage
+
+            path = str(ico if ico.is_file() else png)
+            ns_image = NSImage.alloc().initByReferencingFile_(path)
+            NSApplication.sharedApplication().setApplicationIconImage_(ns_image)
+            emit("dock_icon", path)
+        except Exception:
+            emit("error", "dock_icon")
+
+    return photo, ctk_image, tmp_path
+

--- a/src/utils/network.py
+++ b/src/utils/network.py
@@ -11,6 +11,7 @@ import shutil
 import ssl
 import re
 from pathlib import Path
+from .assets import asset_path
 from typing import (
     Callable,
     List,
@@ -48,9 +49,11 @@ _DEFAULT_PING_CONCURRENCY = int(
 _PING_CACHE_TTL = float(os.environ.get("PING_CACHE_TTL", 30.0))
 
 # Optional OUI database used for MAC vendor lookups
+
 _OUI_FILE = Path(
     os.environ.get(
-        "OUI_FILE", str(Path(__file__).resolve().parent.parent / "assets" / "oui.txt")
+        "OUI_FILE",
+        str(asset_path("oui.txt")),
     )
 )
 

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -1,0 +1,36 @@
+from src.utils.assets import asset_path, assets_base
+from src.utils import logo_paths
+
+
+def test_asset_path_default(monkeypatch):
+    monkeypatch.delenv("COOLBOX_ASSETS", raising=False)
+    p = asset_path("images", "coolbox_logo.png")
+    assert p.is_absolute()
+    assert p.name == "coolbox_logo.png"
+    assert assets_base() in p.parents
+
+
+def test_asset_path_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("COOLBOX_ASSETS", str(tmp_path))
+    p = asset_path("foo", "bar.txt")
+    assert p == tmp_path / "assets" / "foo" / "bar.txt"
+
+
+def test_logo_paths():
+    png, ico = logo_paths()
+    assert png.name == 'coolbox_logo.png'
+    assert ico.name == 'coolbox_logo.ico'
+    assert png.exists()
+    assert ico.exists()
+
+
+def test_logo_env(monkeypatch, tmp_path):
+    png = tmp_path / "my_logo.png"
+    ico = tmp_path / "my_logo.ico"
+    png.write_text("x")
+    ico.write_text("y")
+    monkeypatch.setenv("COOLBOX_LOGO_PNG", str(png))
+    monkeypatch.setenv("COOLBOX_LOGO_ICO", str(ico))
+    paths = logo_paths()
+    assert paths == (png, ico)
+

--- a/tests/test_icons.py
+++ b/tests/test_icons.py
@@ -1,0 +1,40 @@
+import types
+import sys
+from src.utils.icons import set_window_icon, logo_paths
+
+
+class DummyWindow:
+    def __init__(self):
+        self.iconphoto_calls = []
+        self.iconbitmap_calls = []
+
+    def iconphoto(self, *args):
+        self.iconphoto_calls.append(args)
+
+    def iconbitmap(self, path):
+        self.iconbitmap_calls.append(path)
+
+
+def test_set_window_icon_callback(monkeypatch, tmp_path):
+    png = tmp_path / "logo.png"
+    ico = tmp_path / "logo.ico"
+    png.write_text("x")
+    ico.write_text("y")
+    monkeypatch.setenv("COOLBOX_LOGO_PNG", str(png))
+    monkeypatch.setenv("COOLBOX_LOGO_ICO", str(ico))
+
+    events = []
+    def cb(event, detail):
+        events.append(event)
+
+    dummy_tk = types.SimpleNamespace(PhotoImage=lambda file=None: object())
+    monkeypatch.setitem(sys.modules, "tkinter", dummy_tk)
+    monkeypatch.setattr("src.utils.icons.Image", None)
+    monkeypatch.setattr("src.utils.icons.ImageTk", None)
+    monkeypatch.setattr("src.utils.icons.ctk", None)
+
+    win = DummyWindow()
+    set_window_icon(win, callback=cb)
+    assert "iconphoto" in events
+    assert win.iconphoto_calls
+


### PR DESCRIPTION
## Summary
- refine logo path resolution with automatic search
- add callback-driven set_window_icon for better debugging
- expose icon events in CoolBoxApp
- test new icon helper features

## Testing
- `pytest tests/test_assets.py tests/test_icons.py tests/test_network.py::test_scan_ports -q`
- `pytest -q` *(tests complete, interrupted afterward)*

------
https://chatgpt.com/codex/tasks/task_e_686988659f54832bb90dd15ae8f7e210