### PR TITLE
Fix Pillow loading and icon logic

### DIFF
--- a/PIL/__init__.py
+++ b/PIL/__init__.py
@@ -1,6 +1,55 @@
-from .Image import Image
-from .ImageTk import PhotoImage
-from . import ImageGrab
-from .PngImagePlugin import PngInfo
+"""Compatibility loader for the Pillow package.
 
-__all__ = ["Image", "PhotoImage", "ImageGrab", "PngInfo"]
+This module attempts to import the real :mod:`PIL` implementation if it is
+installed.  When the library is unavailable or ``COOLBOX_FORCE_STUB`` is set to
+``1``, the very small fallback stubs bundled with CoolBox are used instead.
+This ensures an installed Pillow is never shadowed by the stubs.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.machinery
+import importlib.util
+import os
+import site
+import sys
+from types import ModuleType
+
+
+def _load_system_pillow() -> ModuleType | None:
+    """Return the installed Pillow package if found."""
+
+    if os.environ.get("COOLBOX_FORCE_STUB") == "1":
+        return None
+
+    search_paths = site.getsitepackages() + [site.getusersitepackages()]
+    for path in search_paths:
+        try:
+            spec = importlib.machinery.PathFinder.find_spec("PIL", [path])
+        except Exception:
+            spec = None
+        if spec and spec.origin and spec.origin != __file__:
+            module = importlib.util.module_from_spec(spec)
+            assert spec.loader
+            # Remove this module entry before executing the real package to avoid
+            # recursion when it performs relative imports.
+            sys.modules.pop(__name__, None)
+            sys.modules["PIL"] = module
+            spec.loader.exec_module(module)
+            return module
+    return None
+
+
+module = _load_system_pillow()
+if module is None:
+    from .Image import Image  # noqa: F401
+    from .ImageTk import PhotoImage  # noqa: F401
+    from . import ImageGrab  # noqa: F401
+    from .PngImagePlugin import PngInfo  # noqa: F401
+
+    __all__ = ["Image", "PhotoImage", "ImageGrab", "PngInfo"]
+else:
+    for name in getattr(module, "__all__", dir(module)):
+        globals()[name] = getattr(module, name)
+    __all__ = getattr(module, "__all__", [n for n in globals() if not n.startswith("_")])

--- a/src/utils/icons.py
+++ b/src/utils/icons.py
@@ -18,9 +18,26 @@ except Exception:  # pragma: no cover - optional runtime dep
 
 try:
     from PIL import Image, ImageTk  # type: ignore
-except Exception:  # pragma: no cover - pillow optional
-    Image = None  # type: ignore
-    ImageTk = None  # type: ignore
+    if not hasattr(Image, "open"):
+        raise ImportError
+except Exception:  # pragma: no cover - pillow optional or stub detected
+    try:
+        from ..ensure_deps import ensure_pillow
+
+        ensure_pillow()
+        import importlib
+
+        for name in list(sys.modules):
+            if name.startswith("PIL"):
+                sys.modules.pop(name)
+        importlib.invalidate_caches()
+        Image = importlib.import_module("PIL.Image")  # type: ignore
+        ImageTk = importlib.import_module("PIL.ImageTk")  # type: ignore
+        if not hasattr(Image, "open"):
+            raise ImportError
+    except Exception:
+        Image = None  # type: ignore
+        ImageTk = None  # type: ignore
 
 __all__ = ["logo_paths", "set_window_icon"]
 


### PR DESCRIPTION
## Summary
- ensure the bundled PIL stubs don't override a real Pillow installation
- reload Pillow in `src/utils/icons` if stubs are detected

## Testing
- `flake8 PIL/__init__.py src/utils/icons.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686993eda840832b9b43d41318eb8025