### PR TITLE
Fix icon color and disable verbose icon logging

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -111,7 +111,7 @@ class CoolBoxApp:
         try:
             from .utils.icons import set_window_icon
 
-            photo, ctk_image, tmp = set_window_icon(self.window, callback=log)
+            photo, ctk_image, tmp = set_window_icon(self.window)
             self._icon_photo = photo
             self._icon_image = ctk_image
             self._temp_icon = tmp

--- a/src/utils/icons.py
+++ b/src/utils/icons.py
@@ -43,13 +43,13 @@ __all__ = ["logo_paths", "set_window_icon"]
 
 
 def _notify(callback, message: str) -> None:
-    """Dispatch *message* to *callback* and the default logger."""
+    """Dispatch *message* to *callback* and optionally log it."""
     if callback:
         try:
             callback(message)
         except Exception:
             pass
-    log(message)
+        log(message)
 
 
 def _search_logo(filename: str, callback=None) -> Path:
@@ -137,7 +137,9 @@ def set_window_icon(window, *, callback=None) -> tuple[object | None, object | N
 
                 photo = tk.PhotoImage(file=str(png))  # type: ignore
             if ctk and hasattr(ctk, "CTkImage") and image is not None:
-                ctk_image = ctk.CTkImage(light_image=image, size=image.size)
+                ctk_image = ctk.CTkImage(
+                    light_image=image, dark_image=image, size=image.size
+                )
             window.iconphoto(True, photo)
 
         if sys.platform.startswith("win"):


### PR DESCRIPTION
## Summary
- don't spam log when loading icons unless a callback is provided
- use CTkImage for both dark and light themes
- call `set_window_icon` without verbose callback

## Testing
- `pytest tests/test_assets.py::test_logo_paths -q`
- `pytest -q tests/test_app.py::TestCoolBoxApp::test_initial_view`
- `pytest -q tests/test_helpers.py::test_calc_hash`


------
https://chatgpt.com/codex/tasks/task_e_686997500014832bb52629a31497effc