### PR TITLE
Fix Docker icon issue

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Install Tk for CustomTkinter
 RUN apt-get update && \
-    apt-get install -y tk git && \
+    apt-get install -y tk python3-tk git && \
     rm -rf /var/lib/apt/lists/*
 
 # Install Python dependencies

--- a/README.md
+++ b/README.md
@@ -563,7 +563,9 @@ This requires Docker or Podman to be installed on your system. Like
 ``run_debug.sh``, the script automatically launches the app under
 ``xvfb`` if no display is detected so the GUI works even in headless
 Docker environments. Install the ``xvfb`` package to ensure the
-``xvfb-run`` helper is available. Set ``DEBUG_PORT`` to expose a
+``xvfb-run`` helper is available. The Dockerfile now installs
+``python3-tk`` so Tkinter features like the window icon work correctly
+inside the container. Set ``DEBUG_PORT`` to expose a
 specific port (defaults to 5678). If that port is taken the container
 uses the next free one. You may also use ``./scripts/run_vm_debug.sh`` or
 ``python scripts/run_vm_debug.py`` (``.\scripts\run_vm_debug.ps1`` on Windows) which choose Docker/Podman or Vagrant

--- a/src/app.py
+++ b/src/app.py
@@ -111,10 +111,12 @@ class CoolBoxApp:
         try:
             from .utils.icons import set_window_icon
 
-            photo, ctk_image, tmp = set_window_icon(self.window)
+            photo, ctk_image, tmp = set_window_icon(self.window, callback=log)
             self._icon_photo = photo
             self._icon_image = ctk_image
             self._temp_icon = tmp
+            if photo is None:
+                log("Window icon not applied; check logs for details")
         except Exception as exc:  # pragma: no cover - best effort
             log(f"Failed to set window icon: {exc}")
 

--- a/src/utils/icons.py
+++ b/src/utils/icons.py
@@ -140,7 +140,10 @@ def set_window_icon(window, *, callback=None) -> tuple[object | None, object | N
                 ctk_image = ctk.CTkImage(
                     light_image=image, dark_image=image, size=image.size
                 )
-            window.iconphoto(True, photo)
+            try:
+                window.iconphoto(True, photo)
+            except Exception as exc:  # pragma: no cover - best effort
+                _notify(callback, f"iconphoto failed: {exc}")
 
         if sys.platform.startswith("win"):
             _notify(callback, "Detected Windows platform")


### PR DESCRIPTION
## Summary
- install python3-tk in devcontainer for Tkinter support
- document python3-tk requirement
- log window icon failures and add diagnostic callback
- warn when iconphoto fails

## Testing
- `flake8 src setup.py tests`
- `pytest tests/test_assets.py tests/test_helpers.py -q`


------
https://chatgpt.com/codex/tasks/task_e_686999d603a8832b9772127bfbe8ba4d