### PR TITLE
Improve icon loading

### DIFF
--- a/src/utils/icons.py
+++ b/src/utils/icons.py
@@ -103,7 +103,12 @@ def _load_image(path: Path, callback=None) -> "Image.Image | None":
         return None
     try:
         _notify(callback, f"Loading image from {path}")
-        return Image.open(path)
+        img = Image.open(path)
+        if max(img.size) > 256:
+            orig = img.size
+            img = img.resize((256, 256), Image.LANCZOS)
+            _notify(callback, f"Resized icon from {orig} to {img.size}")
+        return img
     except Exception as exc:  # pragma: no cover - best effort
         _notify(callback, f"Failed to load image {path}: {exc}")
         return None


### PR DESCRIPTION
## Summary
- resize oversized logo images when setting window icon

## Testing
- `pytest tests/test_assets.py::test_logo_paths -q`
- `pytest tests/test_app.py::TestCoolBoxApp::test_initial_view -q`

------
https://chatgpt.com/codex/tasks/task_e_68699e6764b4832b920a454380b514c5