### PR TITLE
Add VM fallback improvements

### DIFF
--- a/scripts/exe_tester.py
+++ b/scripts/exe_tester.py
@@ -1,0 +1,825 @@
+#!/usr/bin/env python3
+"""Stress test an executable using CoolBox security utilities."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import platform
+import sys
+import time
+from pathlib import Path
+from subprocess import Popen
+import subprocess
+import shutil
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from src.utils import security  # noqa: E402
+from src.utils import security_log, MatrixBorder  # noqa: E402
+from src.utils.win_console import hidden_creation_flags, spawn_detached  # noqa: E402
+from rich.console import Console, Group  # noqa: E402
+from rich.table import Table  # noqa: E402
+from rich.progress import Progress  # noqa: E402
+from rich.live import Live  # noqa: E402
+from rich.text import Text  # noqa: E402
+
+DEFAULT_MESSAGE = "EXECUTABLE  STRESS  TESTER"
+
+MATRIX_ART = [
+    r"    _              _     ",
+    r"   / \\   ___  __ _(_)___ ",
+    r"  / _ \\ / _ \\/ _` | / __|",
+    r" / ___ \\  __/ (_| | \\__ \",",
+    r"/_/   \\_\\___|\\__, |_|___/",
+    r"             |___/       ",
+    r"",
+    r"   {msg}  ",
+]
+
+
+def render_header(console: Console) -> None:
+    """Print the static ASCII header."""
+    msg = os.environ.get("MATRIX_MESSAGE", DEFAULT_MESSAGE)
+    for line in MATRIX_ART:
+        console.print(Text(line.format(msg=msg), style="green"))
+
+
+def run_powershell(command: str, *, capture: bool = False) -> str | None:
+    """Execute ``command`` via PowerShell with numerous fallbacks."""
+    system = platform.system()
+    if system != "Windows":
+        exe = (
+            shutil.which("pwsh")
+            or shutil.which("pwsh-preview")
+            or shutil.which("powershell")
+            or shutil.which("powershell-preview")
+        )
+        if exe:
+            try:
+                cp = subprocess.run(
+                    [exe, "-Command", command],
+                    capture_output=capture,
+                    text=True,
+                    check=False,
+                )
+                if cp.returncode == 0:
+                    return cp.stdout if capture else ""
+            except Exception as exc:  # pragma: no cover - best effort
+                security_log.add_event("exe_test", f"nonwin powershell failed: {exc}")
+        return None
+
+    attempts: list[list[str]] = []
+    attempts.append(["powershell", "-Command", command])
+    attempts.append(["pwsh", "-Command", command])
+
+    cmd_path = Path(command)
+    if cmd_path.is_file() and cmd_path.suffix.lower() == ".ps1":
+        attempts.insert(0, ["pwsh", "-File", command])
+        attempts.insert(
+            0,
+            [
+                "powershell",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+                command,
+            ],
+        )
+    attempts.append(["powershell", "-NoProfile", "-Command", command])
+    attempts.append(["pwsh", "-NoProfile", "-Command", command])
+    attempts.append([
+        "powershell",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-Command",
+        command,
+    ])
+
+    comspec = os.environ.get("COMSPEC")
+    if comspec:
+        attempts.append([comspec, "/c", "powershell", "-Command", command])
+
+    pwsh_env = os.environ.get("PWSH")
+    if pwsh_env:
+        attempts.append([pwsh_env, "-Command", command])
+
+    root_dir = Path(os.environ.get("SystemRoot", r"C:\\Windows"))
+    for sub in ("System32", "Sysnative", "SysWOW64"):
+        ps_exe = root_dir / sub / "WindowsPowerShell" / "v1.0" / "powershell.exe"
+        if ps_exe.is_file():
+            attempts.append([str(ps_exe), "-Command", command])
+
+    for pf_var in (
+        "ProgramFiles",
+        "ProgramFiles(x86)",
+        "ProgramW6432",
+        "ProgramFilesArm",
+    ):
+        pf = os.environ.get(pf_var)
+        if pf:
+            for subdir in ("PowerShell\\7", "PowerShell\\6", "PowerShell\\7-preview"):
+                for exe_name in (
+                    "pwsh.exe",
+                    "pwsh-preview.exe",
+                    "powershell.exe",
+                    "powershell-preview.exe",
+                ):
+                    exe = Path(pf) / subdir / exe_name
+                    if exe.is_file():
+                        attempts.append([str(exe), "-Command", command])
+
+    pshome = os.environ.get("PSHOME")
+    if pshome:
+        exe = Path(pshome) / "powershell.exe"
+        if exe.is_file():
+            attempts.append([str(exe), "-Command", command])
+        exe = Path(pshome) / "pwsh.exe"
+        if exe.is_file():
+            attempts.append([str(exe), "-Command", command])
+
+    env_ps = os.environ.get("POWERSHELL_EXE")
+    if env_ps:
+        exe = Path(env_ps)
+        if exe.is_file():
+            attempts.insert(0, [str(exe), "-Command", command])
+
+    for mod_path in os.environ.get("PSModulePath", "").split(os.pathsep):
+        base = Path(mod_path).parent
+        exe = base / "powershell.exe"
+        if exe.is_file():
+            attempts.append([str(exe), "-Command", command])
+
+    if shutil.which("where"):
+        try:
+            cp = subprocess.run(
+                ["where", "powershell"], capture_output=True, text=True, check=False
+            )
+            if cp.returncode == 0:
+                for line in cp.stdout.splitlines():
+                    exe = Path(line.strip())
+                    if exe.is_file():
+                        attempts.append([str(exe), "-Command", command])
+        except Exception as exc:
+            security_log.add_event("exe_test", f"where powershell failed: {exc}")
+
+    for entry in os.environ.get("PATH", "").split(os.pathsep):
+        for exe in ("powershell.exe", "pwsh.exe"):
+            candidate = Path(entry) / exe
+            if candidate.is_file():
+                attempts.append([str(candidate), "-Command", command])
+
+    if shutil.which("wsl"):
+        attempts.append(["wsl", "powershell.exe", "-Command", command])
+        attempts.append(["wsl", "pwsh", "-Command", command])
+
+    if comspec:
+        attempts.append([comspec, "/k", "powershell", "-Command", command])
+
+    py_launcher = shutil.which("py")
+    if py_launcher:
+        attempts.append([py_launcher, "-3", "-m", "powershell", "-Command", command])
+
+    for cmd in attempts:
+        out = security._run(cmd, capture=capture)
+        if out is not None:
+            return out
+        security_log.add_event("exe_test", f"powershell attempt failed: {cmd}")
+
+    if comspec:
+        out = security._run([comspec, "/c", command], capture=capture)
+        if out is not None:
+            return out
+        security_log.add_event("exe_test", f"cmd shell failed: {command}")
+
+    try:
+        cp = subprocess.run(
+            ["powershell", "-Command", command],
+            capture_output=capture,
+            text=True,
+            check=False,
+        )
+        if cp.returncode == 0:
+            return cp.stdout if capture else ""
+    except Exception as exc:
+        security_log.add_event("exe_test", f"final powershell failed: {exc}")
+
+    if comspec:
+        try:
+            cp = subprocess.run(
+                [comspec, "/c", "start", "/wait", "powershell", "-Command", command],
+                capture_output=capture,
+                text=True,
+                check=False,
+            )
+            if cp.returncode == 0:
+                return cp.stdout if capture else ""
+        except Exception as exc:
+            security_log.add_event("exe_test", f"start fallback failed: {exc}")
+
+    if shutil.which("dotnet"):
+        try:
+            cp = subprocess.run(
+                ["dotnet", "tool", "run", "powershell", "-Command", command],
+                capture_output=capture,
+                text=True,
+                check=False,
+            )
+            if cp.returncode == 0:
+                return cp.stdout if capture else ""
+        except Exception as exc:
+            security_log.add_event("exe_test", f"dotnet tool failed: {exc}")
+
+    try:
+        cp = subprocess.run(
+            f"powershell -Command \"{command}\"",
+            shell=True,
+            capture_output=capture,
+            text=True,
+            check=False,
+        )
+        if cp.returncode == 0:
+            return cp.stdout if capture else ""
+    except Exception as exc:
+        security_log.add_event("exe_test", f"shell powershell failed: {exc}")
+
+    if security.run_command_background(["powershell", "-Command", command]):
+        return ""
+
+    try:
+        spawn_detached(["powershell", "-Command", command])
+        return ""
+    except Exception as exc:  # pragma: no cover - best effort
+        security_log.add_event("exe_test", f"detached powershell failed: {exc}")
+
+    return None
+
+
+def launch_exe(path: Path, *, hidden: bool = False) -> Popen:
+    """Launch *path* and return the process object."""
+    kwargs = {}
+    if hidden:
+        kwargs["creationflags"] = hidden_creation_flags(detach=False)
+    return Popen([str(path)], stdout=None, stderr=None, **kwargs)
+
+
+def smart_terminate(proc: Popen, *, tree: bool = False) -> bool:
+    """Terminate ``proc`` gracefully with fallbacks."""
+    try:
+        proc.terminate()
+        proc.wait(timeout=3)
+        return True
+    except Exception:
+        pass
+    try:
+        return security.kill_process_tree(proc.pid) if tree else security.kill_process(proc.pid)
+    except Exception as exc:
+        security_log.add_event("exe_test", f"terminate failed: {exc}")
+        return False
+
+
+def smart_launch_exe(path: Path, *, hidden: bool = False) -> Popen | None:
+    """Attempt to launch *path* using multiple strategies."""
+    attempts: list[tuple[str, callable[[], Popen]]] = []
+
+    # Extension specific helpers
+    ext = path.suffix.lower()
+    if ext in {".py", ".pyw"}:
+        attempts.append(
+            (
+                "python",
+                lambda: Popen(
+                    [sys.executable, str(path)],
+                    stdout=None,
+                    stderr=None,
+                    **({"creationflags": hidden_creation_flags(detach=False)} if hidden else {}),
+                ),
+            )
+        )
+        py3 = shutil.which("python3")
+        if py3 and py3 != sys.executable:
+            attempts.append(
+                (
+                    "python3",
+                    lambda p=py3: Popen(
+                        [p, str(path)],
+                        stdout=None,
+                        stderr=None,
+                        **({"creationflags": hidden_creation_flags(detach=False)} if hidden else {}),
+                    ),
+                )
+            )
+        py_launcher = shutil.which("py")
+        if platform.system() == "Windows" and py_launcher:
+            attempts.append(
+                (
+                    "py",
+                    lambda pl=py_launcher: Popen(
+                        [pl, str(path)],
+                        stdout=None,
+                        stderr=None,
+                        **({"creationflags": hidden_creation_flags(detach=False)} if hidden else {}),
+                    ),
+                )
+            )
+    elif ext in {".bat", ".cmd"}:
+        attempts.append(
+            (
+                "cmd-file",
+                lambda: Popen(
+                    [os.environ.get("COMSPEC", "cmd"), "/c", str(path)],
+                    stdout=None,
+                    stderr=None,
+                    **({"creationflags": hidden_creation_flags(detach=False)} if hidden else {}),
+                ),
+            )
+        )
+    elif ext == ".ps1":
+        attempts.append(
+            (
+                "ps1",
+                lambda: Popen(
+                    ["powershell", "-ExecutionPolicy", "Bypass", "-File", str(path)],
+                    stdout=None,
+                    stderr=None,
+                    **({"creationflags": hidden_creation_flags(detach=False)} if hidden else {}),
+                ),
+            )
+        )
+    elif ext == ".sh":
+        attempts.append(
+            (
+                "bash",
+                lambda: Popen(
+                    ["bash", str(path)],
+                    stdout=None,
+                    stderr=None,
+                    **({"creationflags": hidden_creation_flags(detach=False)} if hidden else {}),
+                ),
+            )
+        )
+        attempts.append(
+            (
+                "sh-file",
+                lambda: Popen(
+                    ["sh", str(path)],
+                    stdout=None,
+                    stderr=None,
+                    **({"creationflags": hidden_creation_flags(detach=False)} if hidden else {}),
+                ),
+            )
+        )
+    elif ext == ".js":
+        for host in ("wscript", "cscript"):
+            attempts.append(
+                (
+                    host,
+                    lambda h=host: Popen(
+                        [h, str(path)],
+                        stdout=None,
+                        stderr=None,
+                        **({"creationflags": hidden_creation_flags(detach=False)} if hidden else {}),
+                    ),
+                )
+            )
+        node = shutil.which("node") or shutil.which("nodejs")
+        if node:
+            attempts.append(
+                (
+                    "node",
+                    lambda ne=node: Popen(
+                        [ne, str(path)],
+                        stdout=None,
+                        stderr=None,
+                        **({"creationflags": hidden_creation_flags(detach=False)} if hidden else {}),
+                    ),
+                )
+            )
+    elif ext == ".vbs":
+        attempts.append(
+            (
+                "cscript",
+                lambda: Popen(
+                    ["cscript", "//B", str(path)],
+                    stdout=None,
+                    stderr=None,
+                    **({"creationflags": hidden_creation_flags(detach=False)} if hidden else {}),
+                ),
+            )
+        )
+    elif ext == ".wsf":
+        for host in ("wscript", "cscript"):
+            attempts.append(
+                (
+                    host,
+                    lambda h=host: Popen(
+                        [h, str(path)],
+                        stdout=None,
+                        stderr=None,
+                        **({"creationflags": hidden_creation_flags(detach=False)} if hidden else {}),
+                    ),
+                )
+            )
+    elif ext == ".jar":
+        attempts.append(
+            (
+                "java",
+                lambda: Popen(
+                    ["java", "-jar", str(path)],
+                    stdout=None,
+                    stderr=None,
+                    **({"creationflags": hidden_creation_flags(detach=False)} if hidden else {}),
+                ),
+            )
+        )
+        javaw = shutil.which("javaw")
+        if javaw:
+            attempts.append(
+                (
+                    "javaw",
+                    lambda jw=javaw: Popen(
+                        [jw, "-jar", str(path)],
+                        stdout=None,
+                        stderr=None,
+                        **({"creationflags": hidden_creation_flags(detach=False)} if hidden else {}),
+                    ),
+                )
+            )
+    elif ext == ".msi":
+        attempts.append(
+            (
+                "msiexec",
+                lambda: Popen(
+                    ["msiexec", "/i", str(path)],
+                    stdout=None,
+                    stderr=None,
+                    **({"creationflags": hidden_creation_flags(detach=False)} if hidden else {}),
+                ),
+            )
+        )
+        attempts.append(
+            (
+                "msiexec-quiet",
+                lambda: Popen(
+                    ["msiexec", "/qn", "/i", str(path)],
+                    stdout=None,
+                    stderr=None,
+                    **({"creationflags": hidden_creation_flags(detach=False)} if hidden else {}),
+                ),
+            )
+        )
+    elif ext == ".deb":
+        attempts.append(
+            (
+                "dpkg",
+                lambda: Popen(
+                    ["dpkg", "-i", str(path)],
+                    stdout=None,
+                    stderr=None,
+                    **({"creationflags": hidden_creation_flags(detach=False)} if hidden else {}),
+                ),
+            )
+        )
+    elif ext.lower() == ".appimage":
+        attempts.append(
+            (
+                "appimage",
+                lambda: Popen(
+                    [str(path)],
+                    stdout=None,
+                    stderr=None,
+                    **({"creationflags": hidden_creation_flags(detach=False)} if hidden else {}),
+                ),
+            )
+        )
+        attempts.append(
+            (
+                "chmod-appimage",
+                lambda: (security._run(["chmod", "+x", str(path)]), launch_exe(path, hidden=hidden))[1],
+            )
+        )
+    elif ext == ".pkg":
+        attempts.append(
+            (
+                "installer",
+                lambda: Popen(
+                    ["sudo", "installer", "-pkg", str(path), "-target", "/"],
+                    stdout=None,
+                    stderr=None,
+                    **({"creationflags": hidden_creation_flags(detach=False)} if hidden else {}),
+                ),
+            )
+        )
+
+    attempts.append(("direct", lambda: launch_exe(path, hidden=hidden)))
+
+    system = platform.system()
+    if system == "Windows":
+        attempts.append(
+            (
+                "cmd",
+                lambda: Popen(
+                    [os.environ.get("COMSPEC", "cmd"), "/c", str(path)],
+                    stdout=None,
+                    stderr=None,
+                ),
+            )
+        )
+        attempts.append(
+            (
+                "powershell",
+                lambda: Popen(
+                    ["powershell", "-Command", f"Start-Process -FilePath '{path}'"],
+                    stdout=None,
+                    stderr=None,
+                ),
+            )
+        )
+        attempts.append(
+            (
+                "start",
+                lambda: Popen([os.environ.get("COMSPEC", "cmd"), "/c", "start", "", str(path)], stdout=None, stderr=None),
+            )
+        )
+        attempts.append(
+            (
+                "shell",
+                lambda: Popen(str(path), shell=True),
+            )
+        )
+    elif system == "Darwin":
+        attempts.append(
+            (
+                "open",
+                lambda: Popen(["open", str(path)], stdout=None, stderr=None),
+            )
+        )
+        if path.suffix == ".app" and path.is_dir():
+            attempts.append(
+                (
+                    "open-app",
+                    lambda: Popen(["open", "-a", str(path)], stdout=None, stderr=None),
+                )
+            )
+            attempts.append(
+                (
+                    "open-new",
+                    lambda: Popen(["open", "-n", str(path)], stdout=None, stderr=None),
+                )
+            )
+            mac_exec = path / "Contents" / "MacOS" / path.stem
+            if mac_exec.is_file():
+                attempts.append(
+                    (
+                        "mac-direct",
+                        lambda me=mac_exec: Popen([str(me)], stdout=None, stderr=None),
+                    )
+                )
+    else:
+        attempts.append(
+            (
+                "sh",
+                lambda: Popen(["sh", str(path)], stdout=None, stderr=None),
+            )
+        )
+        attempts.append(
+            (
+                "sh-c",
+                lambda: Popen(["sh", "-c", str(path)], stdout=None, stderr=None),
+            )
+        )
+        if ext == ".exe" and shutil.which("wine"):
+            attempts.append(("wine", lambda: Popen(["wine", str(path)], stdout=None, stderr=None)))
+        attempts.append(
+            (
+                "nohup",
+                lambda: Popen(["nohup", str(path)], stdout=None, stderr=None),
+            )
+        )
+        if shutil.which("xdg-open"):
+            attempts.append(("xdg-open", lambda: Popen(["xdg-open", str(path)], stdout=None, stderr=None)))
+        attempts.append(("shell", lambda: Popen(str(path), shell=True)))
+        if shutil.which("wsl"):
+            attempts.append(("wsl", lambda: Popen(["wsl", str(path)], stdout=None, stderr=None)))
+            try:
+                cp = subprocess.run(["wsl", "wslpath", "-a", str(path)], capture_output=True, text=True, check=False)
+                if cp.returncode == 0:
+                    wpath = cp.stdout.strip()
+                    attempts.append(("wsl-conv", lambda: Popen(["wsl", wpath], stdout=None, stderr=None)))
+            except Exception:
+                pass
+
+    if system == "Windows" and hasattr(os, "startfile"):
+        def startfile_proc() -> Popen:
+            os.startfile(str(path))
+            class Dummy:
+                def poll(self) -> None:
+                    return None
+
+            return Dummy()
+
+        attempts.append(("startfile", startfile_proc))
+
+    for name, func in attempts:
+        try:
+            return func()
+        except PermissionError as exc:
+            security_log.add_event("exe_test", f"permission for {name}: {exc}")
+            if security.ensure_admin("Launching requires admin rights"):
+                try:
+                    return func()
+                except Exception as exc2:
+                    security_log.add_event(
+                        "exe_test", f"admin launch {name} failed: {exc2}"
+                    )
+            continue
+        except Exception as exc:
+            security_log.add_event("exe_test", f"launch {name} failed: {exc}")
+            continue
+
+    if system != "Windows" and not os.access(path, os.X_OK):
+        if security._run(["chmod", "+x", str(path)]):
+            try:
+                return launch_exe(path, hidden=hidden)
+            except Exception as exc:
+                security_log.add_event("exe_test", f"chmod retry failed: {exc}")
+
+    if security.run_command_background([str(path)]):
+        class Dummy:
+            def poll(self) -> None:
+                return None
+
+        return Dummy()
+
+    if security._run([str(path)]):
+        class Dummy:
+            def poll(self) -> None:
+                return None
+
+        return Dummy()
+
+    try:
+        spawn_detached([str(path)])
+        class Dummy:
+            def poll(self) -> None:
+                return None
+
+        return Dummy()
+    except Exception as exc:
+        security_log.add_event("exe_test", f"spawn_detached failed: {exc}")
+
+    return None
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Stress test an executable")
+    parser.add_argument("exe", help="Path to the executable to test")
+    parser.add_argument(
+        "-n",
+        "--iterations",
+        type=int,
+        default=5,
+        help="Number of times to run",
+    )
+    parser.add_argument("--ps-before", help="PowerShell command to run before each launch")
+    parser.add_argument("--ps-after", help="PowerShell command to run after each launch")
+    parser.add_argument(
+        "-t",
+        "--runtime",
+        type=float,
+        default=2.0,
+        help="Seconds to keep running",
+    )
+    parser.add_argument("--hidden", action="store_true", help="Hide the executable window")
+    parser.add_argument("--admin", action="store_true", help="Request admin rights first")
+    return parser.parse_args(argv)
+
+
+def run_cli(args: argparse.Namespace, *, console: Console | None = None) -> None:
+    exe_path = Path(args.exe)
+    if not exe_path.is_file():
+        raise SystemExit(f"Executable not found: {exe_path}")
+
+    if args.admin:
+        try:
+            security.require_admin("Administrator privileges are required")
+        except PermissionError:
+            return
+
+    console = console or Console()
+    console.clear()
+    render_header(console)
+
+    progress = Progress(transient=True)
+    table = Table(title="Open Ports", expand=True)
+    table.add_column("Iteration", justify="right")
+    table.add_column("Ports")
+    cpu_table = Table(title="CPU %", expand=True)
+    cpu_table.add_column("Iteration", justify="right")
+    cpu_table.add_column("Usage")
+    mem_table = Table(title="Mem MB", expand=True)
+    mem_table.add_column("Iteration", justify="right")
+    mem_table.add_column("Usage")
+    fail_table = Table(title="Failures", expand=True)
+    fail_table.add_column("Iteration", justify="right")
+    fail_table.add_column("Reason")
+    event_history: list[str] = []
+
+    baseline_ports = set(security.list_open_ports().keys())
+
+    with MatrixBorder(console=console), Live(console=console, refresh_per_second=4) as live:
+        task = progress.add_task("testing", total=args.iterations)
+        for i in range(1, args.iterations + 1):
+            security_log.add_event("exe_test", f"Starting iteration {i} for {exe_path}")
+            event_history.append(f"start {i}")
+            if args.ps_before:
+                try:
+                    run_powershell(args.ps_before)
+                except Exception as exc:
+                    security_log.add_event("exe_test", f"ps-before failed: {exc}")
+            proc = smart_launch_exe(exe_path, hidden=args.hidden)
+            if proc is None:
+                security_log.add_event("exe_test", "all launch methods failed")
+                fail_table.add_row(str(i), "launch")
+                continue
+            pmon = None
+            try:
+                import psutil
+                pmon = psutil.Process(proc.pid)
+                pmon.cpu_percent(interval=None)
+            except Exception:
+                pmon = None
+            time.sleep(args.runtime)
+            if proc.poll() is None:
+                ok = smart_terminate(proc)
+                if not ok:
+                    security_log.add_event("exe_test", "terminate via smart_terminate failed")
+                    fail_table.add_row(str(i), "terminate")
+                    try:
+                        security.kill_process_tree(proc.pid)
+                    except Exception as exc:
+                        security_log.add_event("exe_test", f"kill tree failed: {exc}")
+            if args.ps_after:
+                try:
+                    run_powershell(args.ps_after)
+                except Exception as exc:
+                    security_log.add_event("exe_test", f"ps-after failed: {exc}")
+            ports = security.list_open_ports()
+            new_ports = set(ports.keys()) - baseline_ports
+            cpu_val = "-"
+            mem_val = "-"
+            if pmon is not None:
+                try:
+                    cpu_val = f"{pmon.cpu_percent(interval=None):.1f}"
+                    mem_val = f"{pmon.memory_info().rss / (1024*1024):.1f}"
+                except Exception:
+                    cpu_val = "err"
+                    mem_val = "err"
+            security_log.add_event(
+                "exe_test",
+                f"Finished iteration {i}; open ports: {list(ports.keys())}",
+            )
+            event_history.append(f"end {i}")
+            table.add_row(
+                str(i),
+                ", ".join(map(str, sorted(new_ports))) or "-",
+            )
+            cpu_table.add_row(str(i), cpu_val)
+            mem_table.add_row(str(i), mem_val)
+            while len(event_history) > 5:
+                event_history.pop(0)
+            log_table = Table(title="Events", expand=True)
+            log_table.add_column("Event")
+            for ev in event_history:
+                log_table.add_row(ev)
+            progress.update(task, advance=1)
+            live.update(
+                Group(progress, table, cpu_table, mem_table, fail_table, log_table)
+            )
+
+    console.print(table)
+    console.print(cpu_table)
+    log_table = Table(title="Events", expand=True)
+    log_table.add_column("Event")
+    for ev in event_history:
+        log_table.add_row(ev)
+    console.print(mem_table)
+    console.print(fail_table)
+    console.print(log_table)
+
+    counts = security_log.event_counts()
+    count_table = Table(title="Log Counts", expand=True)
+    count_table.add_column("Category")
+    count_table.add_column("Total", justify="right")
+    for cat, cnt in sorted(counts.items()):
+        count_table.add_row(cat, str(cnt))
+    console.print(count_table)
+
+
+def main(argv: list[str] | None = None) -> None:
+    run_cli(parse_args(argv))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/exe_tester_vm_debug.py
+++ b/scripts/exe_tester_vm_debug.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Launch the executable tester inside a VM debug environment."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+from pathlib import Path
+
+from src.utils import launch_vm_debug
+import socket
+
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run exe tester in VM debug mode")
+    parser.add_argument("exe", help="Target executable path")
+    parser.add_argument("tester_args", nargs=argparse.REMAINDER, help="Additional arguments for exe_tester.py")
+    parser.add_argument("--prefer", choices=["docker", "vagrant", "auto"], default="auto", help="Preferred backend")
+    parser.add_argument("--code", action="store_true", help="Open VS Code once the VM starts")
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=5678,
+        help="Debug port to use when launching the environment",
+    )
+    parser.add_argument("--skip-deps", action="store_true", help="Skip installing dependencies in the VM")
+    return parser.parse_args(argv)
+
+
+def pick_port(start: int = 5678, count: int = 10) -> int:
+    """Return a free TCP port starting at *start* within *count* attempts."""
+
+    for port in range(start, start + count + 1):
+        with socket.socket() as s:
+            try:
+                s.bind(("", port))
+            except OSError:
+                continue
+            return port
+    return start
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = parse_args(argv)
+    tester = Path(__file__).with_name("exe_tester.py")
+    target = shlex.quote(str(tester)) + " " + " ".join(shlex.quote(a) for a in [args.exe] + args.tester_args)
+    port = pick_port(args.port)
+    if port != args.port:
+        print(f"Debug port {args.port} in use; using {port}")
+    launch_vm_debug(
+        prefer=None if args.prefer == "auto" else args.prefer,
+        open_code=args.code,
+        port=port,
+        skip_deps=args.skip_deps,
+        target=target,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_debug.sh
+++ b/scripts/run_debug.sh
@@ -60,13 +60,15 @@ fi
 # Launch the application waiting for debugger to attach.  If no display
 # is available, ``xvfb-run`` provides a virtual framebuffer so Tkinter
 # can initialize correctly.
+TARGET="${DEBUG_TARGET:-main.py}"
+
 if [ -z "$DISPLAY" ]; then
     if command -v xvfb-run >/dev/null 2>&1; then
-        exec xvfb-run -a python -Xfrozen_modules=off -m debugpy --listen $DEBUG_PORT --wait-for-client main.py
+        exec xvfb-run -a python -Xfrozen_modules=off -m debugpy --listen "$DEBUG_PORT" --wait-for-client $TARGET
     else
         echo "warning: xvfb-run not found; running without virtual display" >&2
-        exec python -Xfrozen_modules=off -m debugpy --listen $DEBUG_PORT --wait-for-client main.py
+        exec python -Xfrozen_modules=off -m debugpy --listen "$DEBUG_PORT" --wait-for-client $TARGET
     fi
 else
-    exec python -Xfrozen_modules=off -m debugpy --listen $DEBUG_PORT --wait-for-client main.py
+    exec python -Xfrozen_modules=off -m debugpy --listen "$DEBUG_PORT" --wait-for-client $TARGET
 fi

--- a/scripts/run_devcontainer.sh
+++ b/scripts/run_devcontainer.sh
@@ -21,7 +21,8 @@ DEBUG_PORT="${DEBUG_PORT:-5678}"
 $ENGINE build -f .devcontainer/Dockerfile -t $IMAGE_NAME .
 
 # Run container and start app under debugpy
-RUN_CMD="python -Xfrozen_modules=off -m debugpy --listen $DEBUG_PORT --wait-for-client main.py"
+TARGET="${DEBUG_TARGET:-main.py}"
+RUN_CMD="python -Xfrozen_modules=off -m debugpy --listen $DEBUG_PORT --wait-for-client $TARGET"
 if [ -z "$DISPLAY" ]; then
     if command -v xvfb-run >/dev/null 2>&1; then
         RUN_CMD="xvfb-run -a $RUN_CMD"

--- a/scripts/run_vagrant.sh
+++ b/scripts/run_vagrant.sh
@@ -6,4 +6,4 @@ if ! command -v vagrant >/dev/null 2>&1; then
 fi
 PORT="${DEBUG_PORT:-5678}"
 DEBUG_PORT="$PORT" vagrant up
-DEBUG_PORT="$PORT" vagrant ssh -c "cd /vagrant && DEBUG_PORT=$PORT ./scripts/run_debug.sh"
+DEBUG_PORT="$PORT" vagrant ssh -c "cd /vagrant && DEBUG_PORT=$PORT DEBUG_TARGET=\"$DEBUG_TARGET\" ./scripts/run_debug.sh"

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -31,9 +31,11 @@ _ATTR_MODULES = {
     # rainbow
     "RainbowBorder": "rainbow",
     "NeonPulseBorder": "rainbow",
+    "MatrixBorder": "rainbow",
     # vm
     "launch_vm_debug": "vm",
     "async_launch_vm_debug": "vm",
+    "available_backends": "vm",
     # file manager
     "read_text": "file_manager",
     "write_text": "file_manager",

--- a/src/utils/rainbow.py
+++ b/src/utils/rainbow.py
@@ -190,3 +190,41 @@ class NeonPulseBorder(RainbowBorder):
             time.sleep(self.speed)
             self._phase += 0.05
             offset += 1
+
+
+class MatrixBorder(RainbowBorder):
+    """Render a classic green "matrix" style border around the terminal."""
+
+    def __init__(
+        self,
+        speed: float = 0.1,
+        *,
+        style: str = "single",
+        console: Console | None = None,
+    ) -> None:
+        super().__init__(speed, colors=["#00ff00"], style=style, console=console)
+        self._counter = 0
+        self._chars = "01"
+
+    def _draw(self, offset: int) -> None:  # type: ignore[override]
+        width, height = shutil.get_terminal_size(fallback=(80, 24))
+        self.console.file.write("\x1b7")  # save cursor
+        tl, tr, bl, br, h, v = self.border
+        seq = self._chars
+        top = tl + "".join(seq[(self._counter + i) % len(seq)] for i in range(width - 2)) + tr
+        bottom = bl + "".join(seq[(self._counter + width + i) % len(seq)] for i in range(width - 2)) + br
+        self.console.control(Control.home())
+        self.console.print(Text(top, style="green"), end="")
+        self.console.control(Control.move_to(0, height - 1))
+        self.console.print(Text(bottom, style="green"), end="")
+        for row in range(1, height - 1):
+            l = seq[(self._counter + row) % len(seq)]
+            r = seq[(self._counter + height + row) % len(seq)]
+            self.console.control(Control.move_to(0, row))
+            self.console.print(Text(l, style="green"), end="")
+            self.console.control(Control.move_to(width - 1, row))
+            self.console.print(Text(r, style="green"), end="")
+        self.console.file.write("\x1b8")  # restore cursor
+        self.console.file.flush()
+        self._counter += 1
+

--- a/src/utils/vm.py
+++ b/src/utils/vm.py
@@ -1,5 +1,7 @@
 import os
 import shutil
+import platform
+import subprocess
 from pathlib import Path
 from typing import Iterable, List
 import asyncio
@@ -21,14 +23,16 @@ except ImportError:  # pragma: no cover - fallback when run as a script
 def _pick_backend(prefer: str) -> Iterable[str]:
     """Return an ordered list of VM backends to try."""
 
+    if prefer == "wsl":
+        return ("wsl", "docker", "podman", "vagrant")
     if prefer == "vagrant":
-        return ("vagrant", "docker", "podman")
+        return ("vagrant", "docker", "podman", "wsl")
     if prefer == "docker":
-        return ("docker", "podman", "vagrant")
+        return ("docker", "podman", "vagrant", "wsl")
     if prefer == "podman":
-        return ("podman", "docker", "vagrant")
+        return ("podman", "docker", "vagrant", "wsl")
     # auto / unknown
-    return ("docker", "podman", "vagrant")
+    return ("docker", "podman", "vagrant", "wsl")
 
 
 def available_backends() -> List[str]:
@@ -37,6 +41,8 @@ def available_backends() -> List[str]:
     for name in ("docker", "podman", "vagrant"):
         if shutil.which(name):
             backends.append(name)
+    if platform.system() == "Windows" and shutil.which("wsl"):
+        backends.append("wsl")
     return backends
 
 
@@ -46,6 +52,7 @@ def launch_vm_debug(
     open_code: bool = False,
     port: int = 5678,
     skip_deps: bool = False,
+    target: str | None = None,
 ) -> None:
     """Launch CoolBox inside a VM or fall back to local debugging.
 
@@ -59,6 +66,9 @@ def launch_vm_debug(
         If true and the ``code`` command is available, Visual Studio Code will
         be opened with the project folder once the VM starts. This makes it easy
         to attach the debugger using the ``Python: Attach`` configuration.
+    target:
+        Optional Python script path and arguments to launch instead of
+        ``main.py`` inside the VM.
     """
 
     root = Path(__file__).resolve().parents[2]
@@ -77,11 +87,25 @@ def launch_vm_debug(
             print(f"Launching CoolBox in {name} for debugging...")
             env = os.environ.copy()
             env["DEBUG_PORT"] = str(port)
+            if target:
+                env["DEBUG_TARGET"] = target
             if skip_deps:
                 env["SKIP_DEPS"] = "1"
             if name in {"docker", "podman"}:
                 script = root / "scripts" / "run_devcontainer.sh"
                 cmd = [str(script), name]
+            elif name == "wsl":
+                script = root / "scripts" / "run_debug.sh"
+                try:
+                    wsl_script = subprocess.check_output(
+                        ["wsl", "wslpath", "-a", str(script)], text=True
+                    ).strip()
+                except Exception:
+                    wsl_script = str(script).replace("\\", "/")
+                    if ":" in wsl_script:
+                        drive, rest = wsl_script.split(":", 1)
+                        wsl_script = f"/mnt/{drive.lower()}{rest}"
+                cmd = ["wsl", "bash", wsl_script]
             else:
                 script = root / "scripts" / "run_vagrant.sh"
                 cmd = [str(script)]
@@ -94,6 +118,8 @@ def launch_vm_debug(
     print("No VM backend available; detected none. Launching locally under debugpy.")
     env = os.environ.copy()
     env["DEBUG_PORT"] = str(port)
+    if target:
+        env["DEBUG_TARGET"] = target
     if skip_deps:
         env["SKIP_DEPS"] = "1"
     run_command([str(root / "scripts" / "run_debug.sh")], timeout=None, env=env)
@@ -105,6 +131,7 @@ async def async_launch_vm_debug(
     open_code: bool = False,
     port: int = 5678,
     skip_deps: bool = False,
+    target: str | None = None,
 ) -> None:
     """Asynchronous wrapper for :func:`launch_vm_debug`."""
     loop = asyncio.get_running_loop()
@@ -115,4 +142,5 @@ async def async_launch_vm_debug(
         open_code,
         port,
         skip_deps,
+        target,
     )

--- a/tests/test_exe_tester.py
+++ b/tests/test_exe_tester.py
@@ -1,0 +1,350 @@
+from io import StringIO
+import sys
+from pathlib import Path
+import argparse
+
+import scripts.exe_tester as et
+from rich.console import Console
+
+
+class DummyBorder:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+
+def test_exe_tester_run_cli(monkeypatch):
+    monkeypatch.setattr(et, "MatrixBorder", lambda console=None: DummyBorder())
+    args = et.parse_args([sys.executable, "--iterations", "1", "--runtime", "0.1"])
+    buf = StringIO()
+    console = Console(file=buf)
+    et.run_cli(args, console=console)
+    out = buf.getvalue()
+    assert "Iteration | Ports" in out
+    assert "EXECUTABLE  STRESS  TESTER" in out
+    assert "___  __" in out
+    assert out.count("Iteration | Usage") >= 2
+
+
+def test_smart_launch_exe_fallback(monkeypatch):
+    monkeypatch.setattr(et, "launch_exe", lambda *a, **k: (_ for _ in ()).throw(OSError("fail")))
+
+    created = {}
+
+    def dummy_popen(args, **kwargs):
+        created["args"] = args
+        class Dummy:
+            def poll(self):
+                return None
+        return Dummy()
+
+    monkeypatch.setattr(et, "Popen", dummy_popen)
+    monkeypatch.setattr(et.platform, "system", lambda: "Windows")
+
+    proc = et.smart_launch_exe(Path(sys.executable))
+    assert proc is not None
+    assert created["args"][0] != str(Path(sys.executable))
+
+
+def test_run_powershell_fallback(monkeypatch):
+    calls = []
+    def fake_run(cmd, capture=False):
+        calls.append(cmd)
+        if len(calls) < 3:
+            return None
+        return "ok"
+
+    monkeypatch.setattr(et.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(et.security, "_run", fake_run)
+    monkeypatch.setattr(et.Path, "is_file", lambda self: True)
+    out = et.run_powershell("echo 1", capture=True)
+    assert out == "ok"
+    assert len(calls) >= 3
+
+
+def test_smart_terminate(monkeypatch):
+    killed = {}
+    monkeypatch.setattr(et.security, "kill_process", lambda pid: killed.setdefault("kill", []).append(pid) or True)
+    monkeypatch.setattr(et.security, "kill_process_tree", lambda pid: killed.setdefault("tree", []).append(pid) or True)
+
+    class Dummy:
+        def __init__(self):
+            self.pid = 123
+        def terminate(self):
+            raise OSError("nope")
+        def wait(self, timeout=None):
+            raise OSError
+
+    proc = Dummy()
+    assert et.smart_terminate(proc) is True
+    assert killed["kill"] == [123]
+
+
+def test_smart_launch_exe_background(monkeypatch):
+    monkeypatch.setattr(et, "launch_exe", lambda *a, **k: (_ for _ in ()).throw(OSError("fail")))
+    monkeypatch.setattr(et, "Popen", lambda *a, **k: (_ for _ in ()).throw(OSError("fail")))
+
+    called = []
+    monkeypatch.setattr(et.security, "run_command_background", lambda cmd: called.append(cmd) or True)
+
+    proc = et.smart_launch_exe(Path(sys.executable))
+    assert proc is not None
+    assert called
+
+
+def test_run_powershell_wsl(monkeypatch):
+    calls = []
+
+    def fake_run(cmd, capture=False):
+        calls.append(cmd)
+        if cmd and cmd[0] == "wsl":
+            return "ok"
+        return None
+
+    monkeypatch.setattr(et.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(et.security, "_run", fake_run)
+    monkeypatch.setattr(et.Path, "is_file", lambda self: False)
+    monkeypatch.setenv("PATH", "")
+    monkeypatch.setattr(et.shutil, "which", lambda name: "/bin/wsl" if name == "wsl" else None)
+    out = et.run_powershell("echo 1", capture=True)
+    assert out == "ok"
+    assert any(call[0] == "wsl" for call in calls)
+
+
+def test_run_powershell_pshome(monkeypatch, tmp_path):
+    exe = tmp_path / "powershell.exe"
+    exe.write_text("")
+
+    calls = []
+
+    def fake_run(cmd, capture=False):
+        calls.append(cmd)
+        if exe in map(Path, cmd):
+            return "ok"
+        return None
+
+    monkeypatch.setattr(et.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(et.security, "_run", fake_run)
+    monkeypatch.setenv("PSHOME", str(tmp_path))
+    out = et.run_powershell("echo 1", capture=True)
+    assert out == "ok"
+    assert any(str(exe) in cmd for cmd in calls)
+
+
+def test_run_powershell_env(monkeypatch, tmp_path):
+    exe = tmp_path / "pwsh.exe"
+    exe.write_text("")
+
+    calls = []
+
+    def fake_run(cmd, capture=False):
+        calls.append(cmd)
+        if exe in map(Path, cmd):
+            return "ok"
+        return None
+
+    monkeypatch.setattr(et.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(et.security, "_run", fake_run)
+    monkeypatch.setenv("POWERSHELL_EXE", str(exe))
+    out = et.run_powershell("echo 1", capture=True)
+    assert out == "ok"
+    assert calls[0][0] == str(exe)
+
+
+def test_js_fallback(monkeypatch, tmp_path):
+    script = tmp_path / "test.js"
+    script.write_text("")
+    called = []
+
+    def fake_popen(args, **kwargs):
+        called.append(args)
+        if args[0] in {"wscript", "cscript"}:
+            raise OSError("fail")
+        class Dummy:
+            def poll(self):
+                return None
+        return Dummy()
+
+    monkeypatch.setattr(et, "launch_exe", lambda *a, **k: (_ for _ in ()).throw(OSError("fail")))
+    monkeypatch.setattr(et, "Popen", fake_popen)
+    monkeypatch.setattr(et.platform, "system", lambda: "Windows")
+
+    proc = et.smart_launch_exe(script)
+    assert proc is not None
+    assert any(args[0] in {"wscript", "cscript"} for args in called)
+
+
+def test_js_node_fallback(monkeypatch, tmp_path):
+    script = tmp_path / "node_test.js"
+    script.write_text("")
+    called = []
+
+    def fake_popen(args, **kwargs):
+        called.append(args)
+        if args[0] in {"wscript", "cscript"}:
+            raise OSError("fail")
+        class Dummy:
+            def poll(self):
+                return None
+        return Dummy()
+
+    monkeypatch.setattr(et, "launch_exe", lambda *a, **k: (_ for _ in ()).throw(OSError("fail")))
+    monkeypatch.setattr(et, "Popen", fake_popen)
+    monkeypatch.setattr(et.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(et.shutil, "which", lambda name: "/usr/bin/node" if name in {"node", "nodejs"} else None)
+
+    proc = et.smart_launch_exe(script)
+    assert proc is not None
+    assert any(args[0] == "/usr/bin/node" for args in called)
+
+
+def test_startfile_fallback(monkeypatch):
+    monkeypatch.setattr(et, "launch_exe", lambda *a, **k: (_ for _ in ()).throw(OSError("fail")))
+    monkeypatch.setattr(et, "Popen", lambda *a, **k: (_ for _ in ()).throw(OSError("fail")))
+    monkeypatch.setattr(et.platform, "system", lambda: "Windows")
+
+    started = {}
+
+    def fake_startfile(p):
+        started["path"] = p
+
+    monkeypatch.setattr(et.os, "startfile", fake_startfile, raising=False)
+
+    proc = et.smart_launch_exe(Path(sys.executable))
+    assert proc is not None
+    assert started["path"]
+
+
+def test_spawn_detached_fallback(monkeypatch):
+    monkeypatch.setattr(et, "launch_exe", lambda *a, **k: (_ for _ in ()).throw(OSError("fail")))
+    monkeypatch.setattr(et, "Popen", lambda *a, **k: (_ for _ in ()).throw(OSError("fail")))
+    monkeypatch.setattr(et.security, "run_command_background", lambda *_a, **_k: False)
+
+    spawned = []
+
+    def fake_spawn(args):
+        spawned.append(args)
+
+    monkeypatch.setattr(et, "spawn_detached", fake_spawn)
+
+    proc = et.smart_launch_exe(Path(sys.executable))
+    assert proc is not None
+    assert spawned
+
+
+def test_chmod_retry(monkeypatch):
+    monkeypatch.setattr(et, "launch_exe", lambda *a, **k: (_ for _ in ()).throw(PermissionError("denied")))
+
+    calls = []
+
+    def fake_run(cmd, capture=False):
+        calls.append(cmd)
+        return True
+
+    monkeypatch.setattr(et.security, "_run", fake_run)
+    monkeypatch.setattr(et.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(et.os, "access", lambda *a, **k: False)
+
+    monkeypatch.setattr(et, "Popen", lambda *a, **k: (_ for _ in ()).throw(OSError("fail")))
+
+    proc = et.smart_launch_exe(Path("/tmp/foo"))
+    assert proc is not None
+    assert any(c[0] == "chmod" for c in calls)
+
+
+def test_run_powershell_non_windows(monkeypatch):
+    ran = {}
+
+    def fake_run(cmd, capture=False):
+        ran["cmd"] = cmd
+        return "ok"
+
+    monkeypatch.setattr(et.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(et.shutil, "which", lambda name: "/bin/pwsh" if name == "pwsh" else None)
+    monkeypatch.setattr(et.subprocess, "run", lambda *a, **k: argparse.Namespace(returncode=0, stdout="ok"))
+    out = et.run_powershell("echo 1", capture=True)
+    assert out == "ok"
+
+
+def test_msi_fallback(monkeypatch, tmp_path):
+    msi = tmp_path / "test.msi"
+    msi.write_text("")
+
+    monkeypatch.setattr(et, "launch_exe", lambda *a, **k: (_ for _ in ()).throw(OSError("fail")))
+
+    called = {}
+
+    def fake_popen(args, **kwargs):
+        called["args"] = args
+        class Dummy:
+            def poll(self):
+                return None
+        return Dummy()
+
+    monkeypatch.setattr(et, "Popen", fake_popen)
+    monkeypatch.setattr(et.platform, "system", lambda: "Windows")
+
+    proc = et.smart_launch_exe(msi)
+    assert proc is not None
+    assert called["args"][0] == "msiexec"
+
+
+def test_wsf_fallback(monkeypatch, tmp_path):
+    script = tmp_path / "test.wsf"
+    script.write_text("")
+
+    called = []
+
+    popen_calls = 0
+
+    def fake_popen(args, **kwargs):
+        nonlocal popen_calls
+        called.append(args)
+        popen_calls += 1
+        if popen_calls == 1:
+            raise OSError("fail")
+        class Dummy:
+            def poll(self):
+                return None
+        return Dummy()
+
+    monkeypatch.setattr(et, "launch_exe", lambda *a, **k: (_ for _ in ()).throw(OSError("fail")))
+    monkeypatch.setattr(et, "Popen", fake_popen)
+    monkeypatch.setattr(et.platform, "system", lambda: "Windows")
+
+    proc = et.smart_launch_exe(script)
+    assert proc is not None
+    assert any(args[0] in {"wscript", "cscript"} for args in called)
+
+
+def test_appimage_fallback(monkeypatch, tmp_path):
+    exe = tmp_path / "app.AppImage"
+    exe.write_text("")
+
+    called = []
+
+    popen_calls = 0
+
+    def fake_popen(args, **kwargs):
+        nonlocal popen_calls
+        called.append(args)
+        popen_calls += 1
+        if popen_calls == 1:
+            raise OSError("fail")
+        class Dummy:
+            def poll(self):
+                return None
+        return Dummy()
+
+    run_calls = []
+    monkeypatch.setattr(et, "launch_exe", lambda *a, **k: (_ for _ in ()).throw(OSError("fail")))
+    monkeypatch.setattr(et, "Popen", fake_popen)
+    monkeypatch.setattr(et.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(et.security, "_run", lambda cmd, capture=False: run_calls.append(cmd) or True)
+
+    proc = et.smart_launch_exe(exe)
+    assert proc is not None
+    assert any(args[0] == str(exe) for args in called)
+    assert any(c[0] == "chmod" for c in run_calls)

--- a/tests/test_exe_tester_vm_debug.py
+++ b/tests/test_exe_tester_vm_debug.py
@@ -1,0 +1,30 @@
+import builtins
+import scripts.exe_tester_vm_debug as evd
+
+
+def test_parse_defaults():
+    args = evd.parse_args(['foo.exe'])
+    assert args.prefer == 'auto'
+    assert args.code is False
+    assert args.port == 5678
+    assert args.skip_deps is False
+
+
+def test_main_passes_args(monkeypatch):
+    called = {}
+
+    def fake_launch(prefer=None, open_code=False, port=5678, skip_deps=False, target=None):
+        called['prefer'] = prefer
+        called['open_code'] = open_code
+        called['port'] = port
+        called['skip_deps'] = skip_deps
+        called['target'] = target
+
+    monkeypatch.setattr(evd, 'launch_vm_debug', fake_launch)
+    monkeypatch.setattr(evd, 'pick_port', lambda p: 6000)
+    evd.main(['--prefer', 'docker', '--code', '--port', '5000', '--skip-deps', 'test.exe', '--', '--iterations', '2'])
+    assert called['prefer'] == 'docker'
+    assert called['open_code'] is True
+    assert called['port'] == 6000
+    assert called['skip_deps'] is True
+    assert 'test.exe' in called['target']

--- a/tests/test_vm.py
+++ b/tests/test_vm.py
@@ -7,6 +7,15 @@ import pytest
 import scripts.run_vm_debug as vmcli
 
 
+def test_available_backends_wsl(monkeypatch):
+    def which(cmd):
+        return "/usr/bin/wsl" if cmd == "wsl" else None
+
+    monkeypatch.setattr(shutil, "which", which)
+    monkeypatch.setattr(vm.platform, "system", lambda: "Windows")
+    assert vm.available_backends() == ["wsl"]
+
+
 def test_launch_vm_debug_vagrant(monkeypatch):
     called = []
     monkeypatch.setattr(shutil, "which", lambda x: "/usr/bin/vagrant" if x == "vagrant" else None)
@@ -59,6 +68,21 @@ def test_launch_vm_debug_podman(monkeypatch):
     launch_vm_debug()
     assert Path(called[0][0]).name == "run_devcontainer.sh"
     assert called[0][1] == "podman"
+
+
+def test_launch_vm_debug_wsl(monkeypatch):
+    called = []
+
+    def which(cmd):
+        return "/usr/bin/wsl" if cmd == "wsl" else None
+
+    monkeypatch.setattr(shutil, "which", which)
+    monkeypatch.setattr(vm.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(vm.subprocess, "check_output", lambda cmd, text=True: "/mnt/c/run_debug.sh")
+    monkeypatch.setattr(vm, "run_command_ex", lambda args, **kw: (called.append(args) or ("", 0)))
+    launch_vm_debug(prefer="wsl")
+    assert called
+    assert called[0][0] == "wsl"
 
 
 def test_launch_vm_debug_missing(monkeypatch):


### PR DESCRIPTION
## Summary
- improve exe tester VM launcher with port selection
- export `available_backends` helper
- support WSL backend in VM utilities
- add tests for new launcher and WSL path

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686996392d94832b98f523c5e296768c