### PR TITLE
Ensure dialogs use CoolBox icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,10 @@ A modern, feature-rich desktop application built with Python and CustomTkinter.
 - **Unified Styling**: All views and dialogs inherit from shared base classes
   so fonts and accent colors update instantly when settings change.
 - **Cross-Platform**: Works on Windows, macOS, and Linux
-- **Custom Icon**: Displays the CoolBox logo in the window title, taskbar and dock
+- **Headless Friendly**: When no display is found the app launches a minimal
+  `pyvirtualdisplay` automatically so Tkinter works in CI and container
+  environments without requiring ``xvfb``.
+- **Custom Icon**: Displays the CoolBox logo in the window title, taskbar and dock. All dialogs use the icon automatically and the macOS dock icon is set when available.
 - **Expanded Utilities**: File and directory copy/move helpers, an enhanced file manager, a threaded port scanner, a flexible hash calculator with optional disk caching, a multi-threaded duplicate finder that persists file hashes for lightning fast rescans, a screenshot capture tool, and a built-in process manager that auto-refreshes and sorts by CPU usage. The system info viewer now reports CPU cores and memory usage.
 - **Security Center**: Enhanced firewall controls now support macOS and the dialog lists all listening ports with the owning process for quick audits. Listeners refresh automatically and you can filter them by port or name. Terminate one process or its entire tree with a single click or kill whole port ranges at once. Windows Defender toggling and automatic elevation remain built in so settings always apply successfully. When launched without admin rights, only the Security Center is re-spawned with elevation instead of restarting the entire app.
 - **Aggressive Watchdogs**: Killed ports are tracked and any process reopening them is terminated automatically. If it happens repeatedly the executable is added to a process blocker so future instances are killed instantly. The block list is saved to `~/.coolbox/blocked_processes.json` so offenders remain banned across sessions.
@@ -429,11 +432,11 @@ To start the app and wait for a debugger to attach, use:
 ```
 This script will automatically start the application under ``xvfb`` if no
 display is available, making it convenient to debug in headless
-environments such as CI or containers. Make sure the ``xvfb`` package is
-installed so the ``xvfb-run`` command exists (``sudo apt-get install xvfb`` on
-Debian/Ubuntu). The ``-Xfrozen_modules=off`` option
-is passed to Python to silence warnings when using debugpy with frozen
-modules.
+environments such as CI or containers. When ``xvfb-run`` is unavailable the
+application falls back to ``pyvirtualdisplay`` so a virtual screen is still
+created. Install ``xvfb`` when possible (``sudo apt-get install xvfb`` on
+Debian/Ubuntu). The ``-Xfrozen_modules=off`` option is passed to Python to
+silence warnings when using debugpy with frozen modules.
 
 Alternatively you can launch directly using ``python``:
 
@@ -562,8 +565,9 @@ You can also start the container manually:
 This requires Docker or Podman to be installed on your system. Like
 ``run_debug.sh``, the script automatically launches the app under
 ``xvfb`` if no display is detected so the GUI works even in headless
-Docker environments. Install the ``xvfb`` package to ensure the
-``xvfb-run`` helper is available. The Dockerfile now installs
+Docker environments. When ``xvfb-run`` is missing the application uses
+``pyvirtualdisplay`` as a fallback. Install the ``xvfb`` package when
+possible to avoid this fallback. The Dockerfile now installs
 ``python3-tk`` so Tkinter features like the window icon work correctly
 inside the container. Set ``DEBUG_PORT`` to expose a
 specific port (defaults to 5678). If that port is taken the container

--- a/main.py
+++ b/main.py
@@ -159,6 +159,16 @@ def main() -> None:
     )
     args = parser.parse_args()
 
+    display = None
+    if "DISPLAY" not in os.environ:
+        try:
+            from pyvirtualdisplay import Display
+
+            display = Display(visible=False, size=(1024, 768))
+            display.start()
+        except Exception:
+            pass
+
     if args.vm_debug:
         launch_vm_debug(
             prefer=None if args.vm_prefer == "auto" else args.vm_prefer,
@@ -170,17 +180,41 @@ def main() -> None:
     if args.debug:
         try:
             import debugpy  # type: ignore
+        except Exception:
+            try:
+                import subprocess
 
-            debugpy.listen(args.debug_port)
-            print(f"Waiting for debugger on port {args.debug_port}...")
-            debugpy.wait_for_client()
-        except Exception as exc:  # pragma: no cover - debug only
-            print(f"Failed to start debugpy: {exc}")
+                subprocess.check_call(
+                    [sys.executable, "-m", "pip", "install", "debugpy"],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+                import importlib
 
-    _run_setup_if_needed()
+                debugpy = importlib.import_module("debugpy")  # type: ignore
+            except Exception as exc:  # pragma: no cover - debug only
+                print(f"Failed to install debugpy: {exc}")
+                debugpy = None  # type: ignore
 
-    app = CoolBoxApp()
-    app.run()
+        if debugpy is not None:  # type: ignore
+            try:
+                debugpy.listen(args.debug_port)
+                print(f"Waiting for debugger on port {args.debug_port}...")
+                debugpy.wait_for_client()
+            except Exception as exc:  # pragma: no cover - debug only
+                print(f"Failed to start debugpy: {exc}")
+
+    try:
+        _run_setup_if_needed()
+
+        app = CoolBoxApp()
+        app.run()
+    finally:
+        if display is not None:
+            try:
+                display.stop()
+            except Exception:
+                pass
 
 
 if __name__ == "__main__":

--- a/src/app.py
+++ b/src/app.py
@@ -128,6 +128,33 @@ class CoolBoxApp:
         """Return the CTkImage version of the application icon if available."""
         return getattr(self, "_icon_image", None)
 
+    def apply_icon(self, window) -> None:
+        """Apply the cached application icon to *window* if possible."""
+        photo = self.get_icon_photo()
+        if photo is None:
+            return
+        try:
+            window.iconphoto(True, photo)
+        except Exception:
+            pass
+
+    def create_toplevel(
+        self,
+        *,
+        title: str = "",
+        geometry: str | None = None,
+        parent=None,
+    ) -> ctk.CTkToplevel:
+        """Create a ``CTkToplevel`` window with the app icon applied."""
+        master = parent if parent is not None else self.window
+        window = ctk.CTkToplevel(master)
+        if title:
+            window.title(title)
+        if geometry:
+            window.geometry(geometry)
+        self.apply_icon(window)
+        return window
+
     def _setup_ui(self):
         """Setup the main UI layout"""
         # Create main container

--- a/src/components/toolbar.py
+++ b/src/components/toolbar.py
@@ -230,9 +230,10 @@ class Toolbar(ctk.CTkFrame):
                 self.app.status_bar.set_message("No matches found", "warning")
             return
 
-        window = ctk.CTkToplevel(self)
-        window.title(f"Search results for '{self.search_var.get().strip()}'")
-        window.geometry("500x400")
+        window = self.app.create_toplevel(
+            title=f"Search results for '{self.search_var.get().strip()}'",
+            geometry="500x400",
+        )
         ctk.CTkLabel(
             window,
             text=f"Results ({len(results)})",

--- a/src/views/base_dialog.py
+++ b/src/views/base_dialog.py
@@ -10,11 +10,9 @@ class BaseDialog(ctk.CTkToplevel, UIHelperMixin):
         UIHelperMixin.__init__(self, app)
         if hasattr(app, "register_dialog"):
             app.register_dialog(self)
-        if hasattr(app, "get_icon_photo"):
+        if hasattr(app, "apply_icon"):
             try:
-                icon_photo = app.get_icon_photo()
-                if icon_photo is not None:
-                    self.iconphoto(False, icon_photo)
+                app.apply_icon(self)
             except Exception:
                 pass
         if title:

--- a/src/views/base_mixin.py
+++ b/src/views/base_mixin.py
@@ -50,6 +50,32 @@ class UIHelperMixin:
         container.pack(fill="both", expand=True, padx=self.padx, pady=self.pady)
         return container
 
+    def create_toplevel(
+        self,
+        *,
+        title: str = "",
+        geometry: str | None = None,
+    ) -> ctk.CTkToplevel:
+        """Create a ``CTkToplevel`` window with the app icon applied."""
+        if hasattr(self, "app") and hasattr(self.app, "create_toplevel"):
+            try:
+                return self.app.create_toplevel(
+                    title=title, geometry=geometry, parent=self
+                )
+            except Exception:
+                pass
+        window = ctk.CTkToplevel(self)
+        if title:
+            window.title(title)
+        if geometry:
+            window.geometry(geometry)
+        if hasattr(self.app, "apply_icon"):
+            try:
+                self.app.apply_icon(window)
+            except Exception:
+                pass
+        return window
+
     def add_title(self, parent, text: str, *, use_pack: bool = True):
         """Return a title label and optionally pack it."""
         label = ctk.CTkLabel(parent, text=text, font=self.title_font)

--- a/src/views/settings_view.py
+++ b/src/views/settings_view.py
@@ -535,8 +535,7 @@ class SettingsView(BaseView):
 
     def _edit_config_file(self) -> None:
         """Edit the configuration file inside CoolBox."""
-        window = ctk.CTkToplevel(self)
-        window.title("Edit Config File")
+        window = self.create_toplevel(title="Edit Config File")
 
         textbox = ctk.CTkTextbox(window, width=600, height=400)
         textbox.pack(fill="both", expand=True, padx=10, pady=10)

--- a/src/views/tools_view.py
+++ b/src/views/tools_view.py
@@ -332,9 +332,7 @@ class ToolsView(BaseView):
             messagebox.showinfo("Duplicate Finder", "No duplicates found")
             return
 
-        window = ctk.CTkToplevel(self)
-        window.title("Duplicate Files")
-        window.geometry("600x400")
+        window = self.create_toplevel(title="Duplicate Files", geometry="600x400")
 
         frame = ctk.CTkScrollableFrame(window)
         frame.pack(fill="both", expand=True, padx=10, pady=10)
@@ -398,8 +396,7 @@ class ToolsView(BaseView):
 
         if self.app.status_bar is not None:
             self.app.status_bar.set_message("Opening File Manager...", "info")
-        window = ctk.CTkToplevel(self)
-        window.title("File Manager")
+        window = self.create_toplevel(title="File Manager")
 
         output = ctk.CTkTextbox(window, width=500, height=200)
         output.pack(padx=10, pady=10, fill="both", expand=True)
@@ -511,8 +508,7 @@ class ToolsView(BaseView):
         if self.app.status_bar is not None:
             self.app.status_bar.set_message("Opening Process Manager...", "info")
 
-        window = ctk.CTkToplevel(self)
-        window.title("Process Manager")
+        window = self.create_toplevel(title="Process Manager")
 
         text = ctk.CTkTextbox(window, width=600, height=400)
         text.pack(fill="both", expand=True, padx=10, pady=10)
@@ -680,8 +676,7 @@ class ToolsView(BaseView):
         """Open a simple text editor window."""
         if self.app.status_bar is not None:
             self.app.status_bar.set_message("Opening Text Editor...", "info")
-        window = ctk.CTkToplevel(self)
-        window.title("Text Editor")
+        window = self.create_toplevel(title="Text Editor")
 
         toolbar = ctk.CTkFrame(window, fg_color="transparent")
         toolbar.pack(fill="x", padx=10, pady=(10, 0))
@@ -726,8 +721,7 @@ class ToolsView(BaseView):
         """Open a small regex testing utility."""
         if self.app.status_bar is not None:
             self.app.status_bar.set_message("Opening Regex Tester...", "info")
-        window = ctk.CTkToplevel(self)
-        window.title("Regex Tester")
+        window = self.create_toplevel(title="Regex Tester")
 
         pattern_var = ctk.StringVar()
         ctk.CTkEntry(window, textvariable=pattern_var, width=400).pack(padx=10, pady=10)
@@ -753,8 +747,7 @@ class ToolsView(BaseView):
         """Format JSON in a simple editor."""
         if self.app.status_bar is not None:
             self.app.status_bar.set_message("Opening JSON Formatter...", "info")
-        window = ctk.CTkToplevel(self)
-        window.title("JSON Formatter")
+        window = self.create_toplevel(title="JSON Formatter")
         frame = ctk.CTkFrame(window)
         frame.pack(fill="both", expand=True, padx=10, pady=10)
         frame.grid_rowconfigure(0, weight=1)
@@ -775,8 +768,7 @@ class ToolsView(BaseView):
         """Encode or decode Base64 strings."""
         if self.app.status_bar is not None:
             self.app.status_bar.set_message("Opening Base64 Tool...", "info")
-        window = ctk.CTkToplevel(self)
-        window.title("Base64 Tool")
+        window = self.create_toplevel(title="Base64 Tool")
 
         frame = ctk.CTkFrame(window)
         frame.pack(fill="both", expand=True, padx=10, pady=10)
@@ -808,8 +800,7 @@ class ToolsView(BaseView):
         """Calculate file checksums using various algorithms."""
         if self.app.status_bar is not None:
             self.app.status_bar.set_message("Opening Hash Calculator...", "info")
-        window = ctk.CTkToplevel(self)
-        window.title("Hash Calculator")
+        window = self.create_toplevel(title="Hash Calculator")
 
         file_var = ctk.StringVar()
         file_frame = ctk.CTkFrame(window)

--- a/tests/test_icon_helpers.py
+++ b/tests/test_icon_helpers.py
@@ -1,0 +1,72 @@
+from src.views.base_mixin import UIHelperMixin
+from src.app import CoolBoxApp
+
+
+class DummyWindow:
+    def __init__(self, master=None):
+        self.master = master
+        self.titled = None
+        self.sized = None
+
+    def title(self, text):
+        self.titled = text
+
+    def geometry(self, geo):
+        self.sized = geo
+
+
+class DummyApp:
+    def __init__(self):
+        self.applied = None
+
+    def apply_icon(self, window):
+        self.applied = window
+
+
+
+def test_create_toplevel_applies_icon(monkeypatch):
+    dummy_win = DummyWindow()
+    app = DummyApp()
+    mixin = UIHelperMixin.__new__(UIHelperMixin)
+    mixin.app = app
+
+    def fake_create_toplevel(*, title="", geometry=None, parent=None):
+        assert parent is mixin
+        if title:
+            dummy_win.title(title)
+        if geometry:
+            dummy_win.geometry(geometry)
+        app.apply_icon(dummy_win)
+        return dummy_win
+
+    app.create_toplevel = fake_create_toplevel
+
+    win = UIHelperMixin.create_toplevel(mixin, title="Foo", geometry="100x50")
+    assert win is dummy_win
+    assert dummy_win.titled == "Foo"
+    assert dummy_win.sized == "100x50"
+    assert app.applied is dummy_win
+
+
+def test_app_create_toplevel_defaults_to_main(monkeypatch):
+    dummy_win = DummyWindow()
+
+    def fake_toplevel(master):
+        assert master is main_window
+        return dummy_win
+
+    monkeypatch.setattr("src.app.ctk.CTkToplevel", fake_toplevel)
+    app = CoolBoxApp.__new__(CoolBoxApp)
+    app.window = main_window = object()
+    app.applied = None
+
+    def apply_icon(window):
+        app.applied = window
+
+    app.apply_icon = apply_icon
+    win = CoolBoxApp.create_toplevel(app, title="Bar", geometry="200x100")
+    assert win is dummy_win
+    assert dummy_win.titled == "Bar"
+    assert dummy_win.sized == "200x100"
+    assert app.applied is dummy_win
+

--- a/tests/test_main_virtual_display.py
+++ b/tests/test_main_virtual_display.py
@@ -1,0 +1,36 @@
+import builtins
+import importlib
+import sys
+import types
+
+import main
+
+class DummyDisplay:
+    def __init__(self, *, visible, size):
+        assert visible is False
+        assert size == (1024, 768)
+        self.started = False
+        self.stopped = False
+    def start(self):
+        self.started = True
+    def stop(self):
+        self.stopped = True
+
+def test_main_starts_virtual_display(monkeypatch):
+    display = DummyDisplay(visible=False, size=(1024, 768))
+    dummy_module = types.SimpleNamespace(Display=lambda **kw: display)
+    monkeypatch.delenv("DISPLAY", raising=False)
+    monkeypatch.setitem(sys.modules, "pyvirtualdisplay", dummy_module)
+    monkeypatch.setattr(main, "_run_setup_if_needed", lambda: None)
+    called = {}
+    class DummyApp:
+        def __init__(self):
+            called["init"] = True
+        def run(self):
+            called["run"] = True
+    monkeypatch.setattr(main, "CoolBoxApp", DummyApp)
+    monkeypatch.setattr(sys, "argv", ["main.py"])
+    main.main()
+    assert called == {"init": True, "run": True}
+    assert display.started
+    assert display.stopped


### PR DESCRIPTION
## Summary
- centralize creating new windows so app icon is always applied
- add helper methods on `CoolBoxApp` and mixins
- update dialogs in SettingsView, ToolsView and Toolbar to use them
- refactor BaseDialog to call `apply_icon`
- add regression test verifying icon application
- start a headless display automatically if needed
- add regression test for `CoolBoxApp.create_toplevel`
- delegate mixin `create_toplevel` to app for consistency
- document headless mode and automatic dock icon
- mention pyvirtualdisplay fallback in docs
- ensure iconphoto sets default for child windows
- add regression test ensuring main launches a virtual display when needed
- **install debugpy automatically when `--debug` is used**

## Testing
- `pytest tests/test_main_virtual_display.py -q`
- `pytest tests/test_icon_helpers.py -q`
- `pytest tests/test_assets.py::test_logo_paths -q`


------
https://chatgpt.com/codex/tasks/task_e_6869b9a18038832ba4707b96de280e13