### PR TITLE
Add detach option for VM debugging

### DIFF
--- a/scripts/run_debug.sh
+++ b/scripts/run_debug.sh
@@ -62,13 +62,21 @@ fi
 # can initialize correctly.
 TARGET="${DEBUG_TARGET:-main.py}"
 
+ARGS=(python -Xfrozen_modules=off -m debugpy --listen "$DEBUG_PORT")
+if [ "$DEBUG_NOWAIT" = "1" ]; then
+    :
+else
+    ARGS+=(--wait-for-client)
+fi
+ARGS+=("$TARGET")
+
 if [ -z "$DISPLAY" ]; then
     if command -v xvfb-run >/dev/null 2>&1; then
-        exec xvfb-run -a python -Xfrozen_modules=off -m debugpy --listen "$DEBUG_PORT" --wait-for-client $TARGET
+        exec xvfb-run -a "${ARGS[@]}"
     else
         echo "warning: xvfb-run not found; running without virtual display" >&2
-        exec python -Xfrozen_modules=off -m debugpy --listen "$DEBUG_PORT" --wait-for-client $TARGET
+        exec "${ARGS[@]}"
     fi
 else
-    exec python -Xfrozen_modules=off -m debugpy --listen "$DEBUG_PORT" --wait-for-client $TARGET
+    exec "${ARGS[@]}"
 fi

--- a/scripts/run_devcontainer.sh
+++ b/scripts/run_devcontainer.sh
@@ -16,24 +16,22 @@ fi
 IMAGE_NAME=coolbox-dev
 CONTAINER_NAME=coolbox_dev
 DEBUG_PORT="${DEBUG_PORT:-5678}"
+SKIP_DEPS="${SKIP_DEPS:-}"
+DEBUG_NOWAIT="${DEBUG_NOWAIT:-}"
 
 # Build image
 $ENGINE build -f .devcontainer/Dockerfile -t $IMAGE_NAME .
 
-# Run container and start app under debugpy
+# Run container and launch application using run_debug.sh
 TARGET="${DEBUG_TARGET:-main.py}"
-RUN_CMD="python -Xfrozen_modules=off -m debugpy --listen $DEBUG_PORT --wait-for-client $TARGET"
-if [ -z "$DISPLAY" ]; then
-    if command -v xvfb-run >/dev/null 2>&1; then
-        RUN_CMD="xvfb-run -a $RUN_CMD"
-    else
-        echo "warning: xvfb-run not found; running without virtual display" >&2
-    fi
-fi
+RUN_CMD="./scripts/run_debug.sh"
 exec $ENGINE run --rm \
     --name $CONTAINER_NAME \
     -e DISPLAY=$DISPLAY \
     -e DEBUG_PORT=$DEBUG_PORT \
+    -e DEBUG_TARGET="$TARGET" \
+    -e SKIP_DEPS=$SKIP_DEPS \
+    -e DEBUG_NOWAIT=$DEBUG_NOWAIT \
     -p $DEBUG_PORT:$DEBUG_PORT \
     -v /tmp/.X11-unix:/tmp/.X11-unix \
     -v "$(pwd)":/workspace \

--- a/scripts/run_vagrant.sh
+++ b/scripts/run_vagrant.sh
@@ -6,4 +6,9 @@ if ! command -v vagrant >/dev/null 2>&1; then
 fi
 PORT="${DEBUG_PORT:-5678}"
 DEBUG_PORT="$PORT" vagrant up
-DEBUG_PORT="$PORT" vagrant ssh -c "cd /vagrant && DEBUG_PORT=$PORT DEBUG_TARGET=\"$DEBUG_TARGET\" ./scripts/run_debug.sh"
+DEBUG_PORT="$PORT" vagrant ssh -c "cd /vagrant && \
+    DEBUG_PORT=$PORT \
+    DEBUG_TARGET=\"$DEBUG_TARGET\" \
+    SKIP_DEPS=\"$SKIP_DEPS\" \
+    DEBUG_NOWAIT=\"$DEBUG_NOWAIT\" \
+    ./scripts/run_debug.sh"

--- a/scripts/run_vm_debug.ps1
+++ b/scripts/run_vm_debug.ps1
@@ -4,7 +4,10 @@ param(
     [switch]$Code,
     [int]$Port = 5678,
     [switch]$List,
-    [switch]$SkipDeps
+    [switch]$SkipDeps,
+    [switch]$Quiet,
+    [switch]$NoWait,
+    [switch]$Detach
 )
 
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
@@ -16,5 +19,8 @@ if ($Code) { $ArgsList += '--code' }
 if ($Port -ne 5678) { $ArgsList += '--port'; $ArgsList += $Port }
 if ($List) { $ArgsList += '--list' }
 if ($SkipDeps) { $ArgsList += '--skip-deps' }
+if ($Quiet) { $ArgsList += '--quiet' }
+if ($NoWait) { $ArgsList += '--no-wait' }
+if ($Detach) { $ArgsList += '--detach' }
 
 python $PythonScript @ArgsList

--- a/src/views/exe_tester_dialog.py
+++ b/src/views/exe_tester_dialog.py
@@ -40,7 +40,28 @@ class ExeTesterDialog(BaseDialog):
         self.hidden_var = ctk.BooleanVar()
         self.grid_checkbox(left, "Hide Window", self.hidden_var, 3)
 
-        self.grid_button(left, "Run Test", self._run_test, 4)
+        self.no_ports_var = ctk.BooleanVar()
+        self.grid_checkbox(left, "Skip Port Scan", self.no_ports_var, 4)
+
+        self.refresh_var = ctk.StringVar(value="4")
+        self.grid_entry(left, "Refresh/s:", self.refresh_var, 5, width=80)
+
+        self.cooldown_var = ctk.StringVar(value="0.0")
+        self.grid_entry(left, "Cooldown (s):", self.cooldown_var, 6, width=80)
+
+        self.max_fails_var = ctk.IntVar(value=0)
+        self.grid_entry(left, "Max Fails:", self.max_fails_var, 7, width=80)
+
+        self.ps_before_var = ctk.StringVar()
+        self.grid_entry(left, "Pre-PS:", self.ps_before_var, 8, width=120)
+
+        self.ps_after_var = ctk.StringVar()
+        self.grid_entry(left, "Post-PS:", self.ps_after_var, 9, width=120)
+
+        self.admin_var = ctk.BooleanVar()
+        self.grid_checkbox(left, "Admin Rights", self.admin_var, 10)
+
+        self.grid_button(left, "Run Test", self._run_test, 11)
 
         right = ctk.CTkFrame(self)
         right.grid(row=1, column=1, sticky="nsew", padx=(0, self.padx), pady=self.pady)
@@ -75,16 +96,69 @@ class ExeTesterDialog(BaseDialog):
         self.output_box.configure(state="normal")
         self.output_box.delete("1.0", "end")
         self.output_box.configure(state="disabled")
+        try:
+            refresh = int(self.refresh_var.get())
+        except Exception:
+            messagebox.showerror("Executable Tester", "Invalid refresh rate", parent=self)
+            return
+        try:
+            cooldown = float(self.cooldown_var.get())
+        except Exception:
+            messagebox.showerror("Executable Tester", "Invalid cooldown", parent=self)
+            return
+        try:
+            max_fails = int(self.max_fails_var.get())
+        except Exception:
+            messagebox.showerror("Executable Tester", "Invalid max fails", parent=self)
+            return
+        ps_before = self.ps_before_var.get()
+        ps_after = self.ps_after_var.get()
+        admin = self.admin_var.get()
         thread = threading.Thread(
             target=self._run_process,
-            args=(exe, iterations, runtime, self.hidden_var.get()),
+            args=(exe, iterations, runtime, self.hidden_var.get(), self.no_ports_var.get(), refresh, cooldown, max_fails, ps_before, ps_after, admin),
             daemon=True,
         )
         thread.start()
 
-    def _run_process(self, exe: str, iterations: int, runtime: float, hidden: bool) -> None:
+    def _run_process(
+        self,
+        exe: str,
+        iterations: int,
+        runtime: float,
+        hidden: bool,
+        no_ports: bool,
+        refresh: int,
+        cooldown: float,
+        max_fails: int,
+        ps_before: str,
+        ps_after: str,
+        admin: bool,
+    ) -> None:
         script = Path(__file__).resolve().parents[2] / "scripts" / "exe_tester.py"
-        cmd = [sys.executable, str(script), exe, "--iterations", str(iterations), "--runtime", str(runtime)]
+        cmd = [
+            sys.executable,
+            str(script),
+            exe,
+            "--iterations",
+            str(iterations),
+            "--runtime",
+            str(runtime),
+            "--refresh",
+            str(refresh),
+            "--cooldown",
+            str(cooldown),
+            "--max-fails",
+            str(max_fails),
+        ]
+        if ps_before:
+            cmd.extend(["--ps-before", ps_before])
+        if ps_after:
+            cmd.extend(["--ps-after", ps_after])
+        if admin:
+            cmd.append("--admin")
+        if no_ports:
+            cmd.append("--no-port-scan")
         if hidden:
             cmd.append("--hidden")
         try:

--- a/tests/test_exe_tester_vm_debug.py
+++ b/tests/test_exe_tester_vm_debug.py
@@ -8,23 +8,33 @@ def test_parse_defaults():
     assert args.code is False
     assert args.port == 5678
     assert args.skip_deps is False
+    assert args.quiet is False
+    assert args.no_wait is False
+    assert args.detach is False
 
 
 def test_main_passes_args(monkeypatch):
     called = {}
 
-    def fake_launch(prefer=None, open_code=False, port=5678, skip_deps=False, target=None):
+    def fake_launch(prefer=None, open_code=False, port=5678, skip_deps=False, target=None, print_output=True, nowait=False, detach=False):
         called['prefer'] = prefer
         called['open_code'] = open_code
         called['port'] = port
         called['skip_deps'] = skip_deps
         called['target'] = target
+        called['print_output'] = print_output
+        called['nowait'] = nowait
+        called['detach'] = detach
+        return True
 
     monkeypatch.setattr(evd, 'launch_vm_debug', fake_launch)
     monkeypatch.setattr(evd, 'pick_port', lambda p: 6000)
-    evd.main(['--prefer', 'docker', '--code', '--port', '5000', '--skip-deps', 'test.exe', '--', '--iterations', '2'])
+    evd.main(['--prefer', 'docker', '--code', '--port', '5000', '--skip-deps', '--no-wait', '--quiet', '--detach', 'test.exe', '--', '--iterations', '2'])
     assert called['prefer'] == 'docker'
     assert called['open_code'] is True
     assert called['port'] == 6000
     assert called['skip_deps'] is True
+    assert called['print_output'] is False
+    assert called['nowait'] is True
+    assert called['detach'] is True
     assert 'test.exe' in called['target']

--- a/tests/test_run_vm_debug.py
+++ b/tests/test_run_vm_debug.py
@@ -24,6 +24,18 @@ def test_available_backends(monkeypatch):
     assert backends == ["docker"]
 
 
+def test_parse_defaults():
+    args = rvd.parse_args([])
+    assert args.prefer == "auto"
+    assert args.code is False
+    assert args.port == 5678
+    assert args.list is False
+    assert args.skip_deps is False
+    assert args.quiet is False
+    assert args.no_wait is False
+    assert args.detach is False
+
+
 def test_main_list_backends(monkeypatch, capsys):
     monkeypatch.setattr(rvd, "available_backends", lambda: ["docker", "vagrant"])
     monkeypatch.setattr(rvd, "_load_launch", lambda: lambda prefer=None, open_code=False: None)
@@ -36,28 +48,55 @@ def test_main_list_backends(monkeypatch, capsys):
 def test_main_passes_port(monkeypatch):
     called = {}
 
-    def fake_launch(prefer=None, open_code=False, port=5678, skip_deps=False):
+    def fake_launch(prefer=None, open_code=False, port=5678, skip_deps=False, print_output=True, nowait=False, detach=False):
         called["prefer"] = prefer
         called["open_code"] = open_code
         called["port"] = port
+        called["print_output"] = print_output
+        called["nowait"] = nowait
+        called["detach"] = detach
+        return True
 
     monkeypatch.setattr(rvd, "_load_launch", lambda: fake_launch)
-    monkeypatch.setattr(rvd.sys, "argv", ["run_vm_debug.py", "--port", "9999"])
+    monkeypatch.setattr(rvd.sys, "argv", ["run_vm_debug.py", "--port", "9999", "--no-wait", "--quiet"])
     rvd.main()
     assert called["port"] == 9999
+    assert called["nowait"] is True
+    assert called["print_output"] is False
+    assert called["detach"] is False
 
 
 def test_main_skip_deps(monkeypatch):
     called = {}
 
-    def fake_launch(prefer=None, open_code=False, port=5678, skip_deps=False):
+    def fake_launch(prefer=None, open_code=False, port=5678, skip_deps=False, print_output=True, nowait=False, detach=False):
         called["skip_deps"] = skip_deps
+        called["nowait"] = nowait
+        called["print_output"] = print_output
+        called["detach"] = detach
+        return True
 
     monkeypatch.setattr(rvd, "_load_launch", lambda: fake_launch)
     monkeypatch.setattr(
         rvd.sys,
         "argv",
-        ["run_vm_debug.py", "--skip-deps"],
+        ["run_vm_debug.py", "--skip-deps", "--no-wait", "--quiet"],
     )
     rvd.main()
     assert called["skip_deps"] is True
+    assert called["nowait"] is True
+    assert called["print_output"] is False
+    assert called["detach"] is False
+
+
+def test_main_detach(monkeypatch):
+    called = {}
+
+    def fake_launch(prefer=None, open_code=False, port=5678, skip_deps=False, print_output=True, nowait=False, detach=False):
+        called["detach"] = detach
+        return True
+
+    monkeypatch.setattr(rvd, "_load_launch", lambda: fake_launch)
+    monkeypatch.setattr(rvd.sys, "argv", ["run_vm_debug.py", "--detach"])
+    rvd.main()
+    assert called["detach"] is True

--- a/tests/test_vm.py
+++ b/tests/test_vm.py
@@ -1,5 +1,6 @@
 import shutil
 from pathlib import Path
+import asyncio
 
 import src.utils.vm as vm
 from src.utils.vm import launch_vm_debug
@@ -20,7 +21,7 @@ def test_launch_vm_debug_vagrant(monkeypatch):
     called = []
     monkeypatch.setattr(shutil, "which", lambda x: "/usr/bin/vagrant" if x == "vagrant" else None)
     monkeypatch.setattr(vm, "run_command_ex", lambda args, **kw: (called.append(args) or ("", 0)))
-    launch_vm_debug()
+    assert launch_vm_debug(nowait=True, detach=False) is True
     assert Path(called[0][0]).name == "run_vagrant.sh"
 
 
@@ -32,7 +33,7 @@ def test_launch_vm_debug_docker(monkeypatch):
 
     monkeypatch.setattr(shutil, "which", which)
     monkeypatch.setattr(vm, "run_command_ex", lambda args, **kw: (called.append(args) or ("", 0)))
-    launch_vm_debug()
+    assert launch_vm_debug(nowait=True, detach=False) is True
     assert Path(called[0][0]).name == "run_devcontainer.sh"
     assert called[0][1] == "docker"
 
@@ -51,7 +52,7 @@ def test_launch_vm_debug_fallback(monkeypatch):
 
     monkeypatch.setattr(shutil, "which", which)
     monkeypatch.setattr(vm, "run_command_ex", fail_call)
-    launch_vm_debug()
+    assert launch_vm_debug(nowait=True, detach=False) is True
     # first attempt with docker should fail then fall back to local
     assert Path(calls[0][0]).name == "run_devcontainer.sh"
     assert Path(calls[1][0]).name == "run_debug.sh"
@@ -65,7 +66,7 @@ def test_launch_vm_debug_podman(monkeypatch):
 
     monkeypatch.setattr(shutil, "which", which)
     monkeypatch.setattr(vm, "run_command_ex", lambda args, **kw: (called.append(args) or ("", 0)))
-    launch_vm_debug()
+    assert launch_vm_debug(nowait=True, detach=False) is True
     assert Path(called[0][0]).name == "run_devcontainer.sh"
     assert called[0][1] == "podman"
 
@@ -80,7 +81,7 @@ def test_launch_vm_debug_wsl(monkeypatch):
     monkeypatch.setattr(vm.platform, "system", lambda: "Windows")
     monkeypatch.setattr(vm.subprocess, "check_output", lambda cmd, text=True: "/mnt/c/run_debug.sh")
     monkeypatch.setattr(vm, "run_command_ex", lambda args, **kw: (called.append(args) or ("", 0)))
-    launch_vm_debug(prefer="wsl")
+    assert launch_vm_debug(prefer="wsl", nowait=True, detach=False) is True
     assert called
     assert called[0][0] == "wsl"
 
@@ -89,7 +90,7 @@ def test_launch_vm_debug_missing(monkeypatch):
     called = []
     monkeypatch.setattr(shutil, "which", lambda x: None)
     monkeypatch.setattr(vm, "run_command_ex", lambda args, **kw: (called.append(args) or ("", 0)))
-    launch_vm_debug()
+    assert launch_vm_debug(nowait=True) is True
     assert Path(called[0][0]).name == "run_debug.sh"
 
 
@@ -102,7 +103,7 @@ def test_launch_vm_prefer_env(monkeypatch):
     monkeypatch.setattr(shutil, "which", which)
     monkeypatch.setenv("PREFER_VM", "vagrant")
     monkeypatch.setattr(vm, "run_command_ex", lambda args, **kw: (called.append(args) or ("", 0)))
-    launch_vm_debug()
+    assert launch_vm_debug(nowait=True) is True
     assert Path(called[0][0]).name == "run_vagrant.sh"
 
 
@@ -114,7 +115,7 @@ def test_launch_vm_prefer_arg(monkeypatch):
 
     monkeypatch.setattr(shutil, "which", which)
     monkeypatch.setattr(vm, "run_command_ex", lambda args, **kw: (called.append(args) or ("", 0)))
-    launch_vm_debug(prefer="docker")
+    assert launch_vm_debug(prefer="docker", nowait=True) is True
     assert Path(called[0][0]).name == "run_devcontainer.sh"
 
 
@@ -141,7 +142,7 @@ def test_launch_vm_open_code(monkeypatch):
             (Path(args[0]).name, args[1] if len(args) > 1 else None)
         ) or ("", 0))
     )
-    launch_vm_debug(open_code=True)
+    assert launch_vm_debug(open_code=True, nowait=True) is True
     assert calls[0] == "code"
     assert calls[1][0] == "run_vagrant.sh"
 
@@ -154,9 +155,17 @@ def test_launch_vm_open_code_missing(monkeypatch, capsys):
     monkeypatch.setattr(shutil, "which", which)
     monkeypatch.setattr(vm, "run_command_background", lambda *a, **k: None)
     monkeypatch.setattr(vm, "run_command_ex", lambda *a, **k: ("", 0))
-    launch_vm_debug(open_code=True)
+    assert launch_vm_debug(open_code=True, nowait=True) is True
     out = capsys.readouterr().out
     assert "code' command not found" in out
+
+
+def test_launch_vm_detach(monkeypatch):
+    called = []
+    monkeypatch.setattr(shutil, "which", lambda c: "/usr/bin/vagrant" if c == "vagrant" else None)
+    monkeypatch.setattr(vm, "run_command_background", lambda args, **kw: (called.append(args) or True))
+    assert launch_vm_debug(detach=True) is True
+    assert Path(called[0][0]).name == "run_vagrant.sh"
 
 
 def test_launch_vm_debug_env(monkeypatch):
@@ -171,7 +180,7 @@ def test_launch_vm_debug_env(monkeypatch):
 
     monkeypatch.setattr(shutil, "which", which)
     monkeypatch.setattr(vm, "run_command_ex", fake_run)
-    launch_vm_debug(port=9999, skip_deps=True)
+    assert launch_vm_debug(port=9999, skip_deps=True, nowait=True) is True
     env = captured[0]
     assert env["DEBUG_PORT"] == "9999"
     assert env["SKIP_DEPS"] == "1"
@@ -183,29 +192,39 @@ def test_vm_cli_parse_defaults():
     assert args.code is False
     assert args.port == 5678
     assert args.list is False
+    assert args.no_wait is False
+    assert args.detach is False
 
 
 def test_vm_cli_main_launch(monkeypatch):
     calls = []
 
-    def fake_launch(prefer=None, open_code=False, port=5678, skip_deps=False):
-        calls.append((prefer, open_code, port, skip_deps))
+    def fake_launch(
+        prefer=None, open_code=False, port=5678, skip_deps=False,
+        print_output=True, nowait=False, detach=False
+    ):
+        calls.append((prefer, open_code, port, skip_deps, print_output, nowait, detach))
+        return True
 
     monkeypatch.setattr(vmcli, "_load_launch", lambda: fake_launch)
-    vmcli.main(["--prefer", "docker", "--code", "--port", "1234"])
-    assert calls == [("docker", True, 1234, False)]
+    vmcli.main(["--prefer", "docker", "--code", "--port", "1234", "--no-wait", "--detach"])
+    assert calls == [("docker", True, 1234, False, True, True, True)]
 
 
 def test_vm_cli_main_auto_port(monkeypatch):
     calls = []
 
-    def fake_launch(prefer=None, open_code=False, port=5678, skip_deps=False):
-        calls.append(port)
+    def fake_launch(
+        prefer=None, open_code=False, port=5678, skip_deps=False,
+        print_output=True, nowait=False, detach=False
+    ):
+        calls.append((port, detach))
+        return True
 
     monkeypatch.setattr(vmcli, "_load_launch", lambda: fake_launch)
     monkeypatch.setattr(vmcli, "pick_port", lambda p: 6000)
-    vmcli.main([])
-    assert calls == [6000]
+    vmcli.main(["--no-wait", "--detach"])
+    assert calls == [(6000, True)]
 
 
 def test_vm_cli_main_list(monkeypatch, capsys):
@@ -219,15 +238,22 @@ def test_vm_cli_main_list(monkeypatch, capsys):
 async def test_async_launch_vm_debug(monkeypatch):
     called = []
 
-    async def run_in_executor(executor, func, *args):
-        func(*args)
+    def run_in_executor(executor, func, *args):
+        return func(*args)
 
     class FakeLoop:
         def run_in_executor(self, executor, func, *args):
-            return run_in_executor(executor, func, *args)
+            fut = asyncio.Future()
+            fut.set_result(run_in_executor(executor, func, *args))
+            return fut
 
     monkeypatch.setattr(vm.asyncio, "get_running_loop", lambda: FakeLoop())
 
-    monkeypatch.setattr(vm, "launch_vm_debug", lambda *a, **k: called.append(True))
-    await vm.async_launch_vm_debug()
-    assert called == [True]
+    def fake_launch(*a, **k):
+        called.append(k.get("detach", False))
+        return True
+
+    monkeypatch.setattr(vm, "launch_vm_debug", fake_launch)
+    ret = await vm.async_launch_vm_debug()
+    assert called == [False]
+    assert ret is True


### PR DESCRIPTION
## Summary
- allow background launching with a new `--detach` flag for VM debug scripts
- propagate the option through `launch_vm_debug` and `async_launch_vm_debug`
- update PowerShell wrapper and documentation
- test the new behaviour across the CLI helpers

## Testing
- `pytest tests/test_run_vm_debug.py tests/test_exe_tester_vm_debug.py tests/test_vm.py -q`
- `pytest -q` *(interrupted after completion summary)*

------
https://chatgpt.com/codex/tasks/task_e_6869cc8cca2c832b9a0f014122ad9fef