### PR TITLE
Enhance exe inspector handling of stubborn executables

### DIFF
--- a/scripts/exe_inspector.py
+++ b/scripts/exe_inspector.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Interactive CLI for inspecting executable files."""
+from __future__ import annotations
+
+import argparse
+import datetime
+import platform
+import sys
+from pathlib import Path
+from typing import Dict, List
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from rich.console import Console  # noqa: E402
+from rich.table import Table  # noqa: E402
+from rich.prompt import Prompt  # noqa: E402
+import psutil  # noqa: E402
+
+from src.utils.helpers import calc_hash  # noqa: E402
+from src.utils.process_utils import run_command  # noqa: E402
+from src.utils.security import ensure_admin, is_admin, list_open_ports  # noqa: E402
+import pwd  # noqa: E402
+import grp  # noqa: E402
+import shutil  # noqa: E402
+
+
+def _calc_hash_smart(path: Path) -> str:
+    """Return SHA256 hash of *path* using fallbacks if direct reading fails."""
+    try:
+        return calc_hash(str(path), "sha256")
+    except Exception as exc:
+        if platform.system() == "Windows":
+            out = run_command(["certutil", "-hashfile", str(path), "SHA256"], capture=True)
+            if out:
+                return out.split()[0]
+        else:
+            tool = shutil.which("sha256sum") or shutil.which("shasum")
+            if tool:
+                cmd = [tool]
+                if Path(tool).name == "shasum":
+                    cmd += ["-a", "256"]
+                cmd.append(str(path))
+                out = run_command(cmd, capture=True)
+                if out:
+                    return out.split()[0]
+        return f"<unavailable: {exc}>"
+
+
+def _powershell(cmd: str) -> str | None:
+    """Run a PowerShell command and return its output."""
+    return run_command([
+        "powershell",
+        "-NoProfile",
+        "-Command",
+        f"{cmd} -ErrorAction SilentlyContinue",
+    ], capture=True)
+
+
+def _windows_details(path: Path) -> Dict[str, str]:
+    details: Dict[str, str] = {}
+    details["SHA256"] = _calc_hash_smart(path)
+    version = _powershell(f'(Get-Item \"{path}\").VersionInfo.ProductVersion')
+    if version:
+        details["Version"] = version.strip()
+    desc = _powershell(f'(Get-Item \"{path}\").VersionInfo.FileDescription')
+    if desc:
+        details["Description"] = desc.strip()
+    company = _powershell(f'(Get-Item \"{path}\").VersionInfo.CompanyName')
+    if company:
+        details["Company"] = company.strip()
+    sig = _powershell(f'$(Get-AuthenticodeSignature \"{path}\").Status')
+    if sig:
+        details["Signature"] = sig.strip()
+    return details
+
+
+def _unix_details(path: Path) -> Dict[str, str]:
+    details: Dict[str, str] = {}
+    details["SHA256"] = _calc_hash_smart(path)
+    file_type = run_command(["file", "-b", str(path)], capture=True)
+    if file_type:
+        details["Type"] = file_type.strip()
+    return details
+
+
+def _file_owner(path: Path) -> str | None:
+    """Return owner of *path*."""
+    try:
+        if platform.system() == "Windows":
+            owner = _powershell(f'(Get-Acl \"{path}\").Owner')
+            return owner.strip() if owner else None
+        stat = path.stat()
+        user = pwd.getpwuid(stat.st_uid).pw_name
+        group = grp.getgrgid(stat.st_gid).gr_name
+        return f"{user}:{group}"
+    except Exception:
+        return None
+
+
+def _extract_strings(path: Path, *, limit: int = 10, min_len: int = 4) -> List[str]:
+    """Return a list of printable strings found in *path*."""
+    try:
+        data = path.read_bytes()
+    except Exception:
+        return []
+    import re
+    pattern = re.compile(rb"[ -~]{%d,}" % min_len)
+    found = []
+    for match in pattern.finditer(data):
+        s = match.group().decode("ascii", "replace")
+        if s not in found:
+            found.append(s)
+        if len(found) >= limit:
+            break
+    return found
+
+
+def gather_info(path: Path) -> Dict[str, str]:
+    info: Dict[str, str] = {
+        "Path": str(path),
+        "Exists": str(path.exists()),
+    }
+    if path.exists():
+        try:
+            stat = path.stat()
+        except PermissionError:
+            info["Access"] = "Denied"
+            return info
+
+        info.update(
+            {
+                "Size": f"{stat.st_size} bytes",
+                "Modified": datetime.datetime.fromtimestamp(stat.st_mtime).isoformat(),
+                "Created": datetime.datetime.fromtimestamp(stat.st_ctime).isoformat(),
+                "Owner": _file_owner(path) or "unknown",
+            }
+        )
+
+        if platform.system() == "Windows":
+            info.update(_windows_details(path))
+        else:
+            info.update(_unix_details(path))
+    return info
+
+
+def _processes_for(path: Path) -> List[psutil.Process]:
+    result: List[psutil.Process] = []
+    for proc in psutil.process_iter(["pid", "name", "exe"]):
+        try:
+            exe = proc.info.get("exe") or ""
+            if exe and Path(exe).resolve() == path.resolve():
+                result.append(proc)
+        except Exception:
+            continue
+    return result
+
+
+def _ports_for(pids: List[int]) -> Dict[int, List[str]]:
+    ports = list_open_ports()
+    result: Dict[int, List[str]] = {}
+    for port, items in ports.items():
+        for entry in items:
+            if entry.pid in pids:
+                result.setdefault(port, []).append(entry.process)
+    return result
+
+
+def display(info: Dict[str, str], procs: List[psutil.Process], ports: Dict[int, List[str]], strings: List[str] | None = None) -> None:
+    console = Console()
+    table = Table(title="Executable Info", show_lines=True)
+    table.add_column("Property", style="bold")
+    table.add_column("Value")
+    for k, v in info.items():
+        table.add_row(k, v)
+    console.print(table)
+
+    if procs:
+        pt = Table(title="Running Processes", show_lines=True)
+        pt.add_column("PID", justify="right")
+        pt.add_column("Name")
+        for p in procs:
+            try:
+                pt.add_row(str(p.pid), p.name())
+            except Exception:
+                continue
+        console.print(pt)
+
+    if ports:
+        port_table = Table(title="Listening Ports", show_lines=True)
+        port_table.add_column("Port", justify="right")
+        port_table.add_column("Process")
+        for port, names in ports.items():
+            port_table.add_row(str(port), ", ".join(names))
+        console.print(port_table)
+
+    if strings:
+        st = Table(title="Strings", show_lines=True)
+        st.add_column("Text")
+        for s in strings:
+            st.add_row(s)
+        console.print(st)
+
+
+def main(argv: List[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Inspect an executable file")
+    parser.add_argument("exe", nargs="?", help="Path to executable")
+    parser.add_argument(
+        "--admin",
+        action="store_true",
+        help="Request administrator rights for process and port info",
+    )
+    parser.add_argument(
+        "--strings",
+        type=int,
+        metavar="N",
+        help="Display up to N printable strings from the file",
+    )
+    args = parser.parse_args(argv)
+
+    exe_arg = args.exe or Prompt.ask("Path to executable")
+    exe_path = Path(exe_arg).expanduser()
+
+    if args.admin and not is_admin():
+        if not ensure_admin("Administrator access is required for process and port information."):
+            sys.exit(1)
+
+    info = gather_info(exe_path)
+    procs = _processes_for(exe_path) if exe_path.exists() else []
+    ports = _ports_for([p.pid for p in procs]) if procs else {}
+
+    strings = _extract_strings(exe_path, limit=args.strings) if args.strings else None
+
+    display(info, procs, ports, strings)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_exe_inspector.py
+++ b/tests/test_exe_inspector.py
@@ -1,0 +1,91 @@
+import platform
+from pathlib import Path
+from types import SimpleNamespace
+
+import scripts.exe_inspector as inspector
+
+
+def test_gather_info_windows(monkeypatch, tmp_path):
+    exe = tmp_path / "app.exe"
+    exe.write_text("hello")
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+
+    called = []
+
+    def fake_ps(cmd):
+        called.append(cmd)
+        return "val"
+
+    monkeypatch.setattr(inspector, "_powershell", fake_ps)
+    monkeypatch.setattr(inspector, "calc_hash", lambda p, algo="sha256": "hash")
+
+    info = inspector.gather_info(exe)
+    assert info["SHA256"] == "hash"
+    assert info["Version"] == "val"
+    assert called
+
+
+def test_processes_for(monkeypatch, tmp_path):
+    exe = tmp_path / "a.exe"
+    exe.write_text("x")
+
+    proc = SimpleNamespace(info={"pid": 1, "name": "a", "exe": str(exe)})
+
+    monkeypatch.setattr(
+        inspector.psutil,
+        "process_iter",
+        lambda attrs=None: [proc],
+    )
+
+    procs = inspector._processes_for(exe)
+    assert len(procs) == 1
+
+
+def test_hash_fallback(monkeypatch, tmp_path):
+    exe = tmp_path / "stub.exe"
+    exe.write_text("x")
+
+    def fail_hash(path, algo="sha256"):
+        raise PermissionError("denied")
+
+    monkeypatch.setattr(inspector, "calc_hash", fail_hash)
+    monkeypatch.setattr(
+        inspector,
+        "run_command",
+        lambda cmd, capture=False: "abcd1234 efgh" if capture else "",
+    )
+
+    digest = inspector._calc_hash_smart(exe)
+    assert digest == "abcd1234"
+
+
+def test_gather_info_denied(monkeypatch, tmp_path):
+    exe = tmp_path / "bad.exe"
+    exe.write_text("x")
+
+    orig_stat = Path.stat
+    orig_exists = Path.exists
+
+    def fake_stat(self, *a, **kw):
+        if self == exe:
+            raise PermissionError()
+        return orig_stat(self, *a, **kw)
+
+    def fake_exists(self):
+        if self == exe:
+            return True
+        return orig_exists(self)
+
+    monkeypatch.setattr(Path, "stat", fake_stat)
+    monkeypatch.setattr(Path, "exists", fake_exists)
+
+    info = inspector.gather_info(exe)
+    assert info.get("Access") == "Denied"
+
+
+def test_extract_strings(tmp_path):
+    exe = tmp_path / "bin"
+    exe.write_bytes(b"\x00hello\x00world1234\x00")
+    strings = inspector._extract_strings(exe, limit=5, min_len=4)
+    assert "hello" in strings
+    assert "world1234" in strings


### PR DESCRIPTION
## Summary
- add `_calc_hash_smart` with cross-platform fallbacks
- silence PowerShell errors and record access denied state in `gather_info`
- extend tests to cover hash fallback and permission errors
- add owner detection and printable strings extraction for executables
- interactive CLI improvements and option to display embedded strings

## Testing
- `pytest tests/test_exe_inspector.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a746642d0832b98fd8f229b5debdc