### PR TITLE
Add shell command tab to exe inspector

### DIFF
--- a/scripts/exe_inspector.tcss
+++ b/scripts/exe_inspector.tcss
@@ -9,3 +9,7 @@ Input#filter-input {
     dock: bottom;
     width: 100%;
 }
+Input#cmd-input {
+    dock: bottom;
+    width: 100%;
+}


### PR DESCRIPTION
## Summary
- allow running shell commands in the TUI exe inspector
- style command input in CSS
- test command submission logic
- cover no-output case for shell commands
- include exit status and error handling for shell commands
- add timestamped command output with `clear` command

## Testing
- `pytest tests/test_exe_inspector.py::test_tui_command tests/test_exe_inspector.py::test_tui_command_no_output tests/test_exe_inspector.py::test_tui_command_error tests/test_exe_inspector.py::test_tui_command_clear -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a9311a820832b8f0cfc1661e631e3