### PR TITLE
Add GUI-based executable inspector

### DIFF
--- a/src/views/__init__.py
+++ b/src/views/__init__.py
@@ -14,6 +14,7 @@ from .click_overlay import ClickOverlay
 from .system_info_dialog import SystemInfoDialog
 from .recent_files_dialog import RecentFilesDialog
 from .security_dialog import SecurityDialog
+from .exe_inspector_dialog import ExeInspectorDialog
 
 __all__ = [
     "BaseView",
@@ -30,4 +31,5 @@ __all__ = [
     "SystemInfoDialog",
     "RecentFilesDialog",
     "SecurityDialog",
+    "ExeInspectorDialog",
 ]

--- a/src/views/exe_inspector_dialog.py
+++ b/src/views/exe_inspector_dialog.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+"""Dialog showing executable details with a terminal style interface."""
+
+import datetime
+import shlex
+from pathlib import Path
+from typing import List, Dict
+
+import customtkinter as ctk
+
+from .base_dialog import BaseDialog
+from ..utils.process_utils import run_command_ex
+
+# Reuse helpers from the CLI inspector
+from scripts import exe_inspector as inspector
+
+
+class ExeInspectorDialog(BaseDialog):
+    """Display executable information and allow running shell commands."""
+
+    def __init__(self, app, exe_path: str) -> None:
+        super().__init__(app, title="Executable Inspector", geometry="700x500", resizable=(True, True))
+        self.path = Path(exe_path)
+
+        container = self.create_container()
+        self.output = ctk.CTkTextbox(
+            container,
+            fg_color="#000000",
+            text_color="#00ff00",
+        )
+        self.output.configure(font=("Courier", 12))
+        self.output.pack(fill="both", expand=True)
+
+        entry_frame = ctk.CTkFrame(container, fg_color="transparent")
+        entry_frame.pack(fill="x", pady=(10, 0))
+        self.entry = ctk.CTkEntry(entry_frame)
+        self.entry.pack(side="left", fill="x", expand=True)
+        self.entry.bind("<Return>", self._on_enter)
+        refresh = ctk.CTkButton(entry_frame, text="Refresh", width=100, command=self.refresh)
+        refresh.pack(side="right", padx=5)
+
+        self.refresh()
+        self.center_window()
+        self.refresh_fonts()
+        self.refresh_theme()
+
+    # ------------------------------------------------------------------ helpers
+    def _write_lines(self, lines: List[str]) -> None:
+        self.output.configure(state="normal")
+        self.output.delete("1.0", "end")
+        for line in lines:
+            self.output.insert("end", line + "\n")
+        self.output.see("end")
+        self.output.configure(state="disabled")
+
+    # ------------------------------------------------------------------ actions
+    def refresh(self) -> None:
+        """Gather fresh information and render it."""
+        info: Dict[str, str] = inspector.gather_info(self.path)
+        procs = inspector._processes_for(self.path) if self.path.exists() else []
+        ports = inspector._ports_for([p.pid for p in procs]) if procs else {}
+        strings = inspector._extract_strings(self.path, limit=10)
+
+        lines: List[str] = []
+        lines.append("# Executable Info")
+        for k, v in info.items():
+            lines.append(f"{k}: {v}")
+        if procs:
+            lines.append("\n# Running Processes")
+            for p in procs:
+                try:
+                    lines.append(f"{p.pid} {p.name()}")
+                except Exception:
+                    continue
+        if ports:
+            lines.append("\n# Listening Ports")
+            for port, names in ports.items():
+                lines.append(f"{port} {', '.join(names)}")
+        if strings:
+            lines.append("\n# Strings")
+            for s in strings:
+                lines.append(s)
+
+        self._write_lines(lines)
+
+    def _on_enter(self, event=None) -> None:
+        cmd = self.entry.get().strip()
+        if not cmd:
+            return
+        ts = datetime.datetime.now().strftime("[%H:%M:%S] $ ")
+        self.output.configure(state="normal")
+        self.output.insert("end", ts + cmd + "\n")
+        out, rc = run_command_ex(shlex.split(cmd), capture=True, check=False)
+        if out is None:
+            self.output.insert("end", "<error>\n")
+        elif out:
+            self.output.insert("end", out + ("" if out.endswith("\n") else "\n"))
+        else:
+            self.output.insert("end", "<no output>\n")
+        if rc is not None:
+            self.output.insert("end", f"[exit {rc}]\n")
+        self.output.see("end")
+        self.output.configure(state="disabled")
+        self.entry.delete(0, "end")

--- a/src/views/tools_view.py
+++ b/src/views/tools_view.py
@@ -690,13 +690,9 @@ class ToolsView(BaseView):
         if self.app.status_bar is not None:
             self.app.status_bar.set_message("Launching Exe Inspector...", "info")
         try:
-            subprocess.Popen([
-                sys.executable,
-                "-m",
-                "scripts.exe_inspector",
-                exe,
-                "--tui",
-            ])
+            from .exe_inspector_dialog import ExeInspectorDialog
+
+            ExeInspectorDialog(self.app, exe)
         except Exception as exc:
             messagebox.showerror("Executable Inspector", str(exc))
 

--- a/tests/test_tools_view.py
+++ b/tests/test_tools_view.py
@@ -1,6 +1,5 @@
 import os
 import unittest
-import subprocess
 from tkinter import filedialog
 from unittest.mock import patch
 from src.app import CoolBoxApp
@@ -41,19 +40,15 @@ class TestToolsView(unittest.TestCase):
 
         self.assertTrue(called["open"])
 
-    def test_exe_inspector_invokes_popen(self) -> None:
+    def test_exe_inspector_opens_dialog(self) -> None:
         with patch.object(filedialog, "askopenfilename", return_value="app.exe"), \
-             patch.object(subprocess, "Popen") as popen:
+             patch("src.views.exe_inspector_dialog.ExeInspectorDialog") as dlg:
             dummy_app = type("DummyApp", (), {"status_bar": None})()
             dummy = type("Dummy", (), {"app": dummy_app})()
 
             ToolsView._exe_inspector(dummy)
 
-            popen.assert_called_once()
-            args = popen.call_args[0][0]
-            self.assertEqual(
-                args[1:], ["-m", "scripts.exe_inspector", "app.exe", "--tui"]
-            )
+            dlg.assert_called_once_with(dummy_app, "app.exe")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `ExeInspectorDialog` for inspecting executables with a terminal-style UI
- expose the new dialog in `src/views/__init__.py`
- launch the dialog from the Tools view instead of spawning a subprocess
- update tests to expect the dialog invocation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686aa1510d08832ba5ab39b8f95180bb