### PR TITLE
Improve executable inspector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ __pycache__/
 __pycache__/
 .pytest_cache/
 io_test.tmp
+scripts/hash_calc
+scripts/hash_calc.*

--- a/scripts/hash_calc.cpp
+++ b/scripts/hash_calc.cpp
@@ -1,0 +1,50 @@
+#include <openssl/evp.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+
+extern "C" int hash_file(const char* algo_name, const char* file_path, char* out, size_t out_len) {
+    OpenSSL_add_all_digests();
+    const EVP_MD* md = EVP_get_digestbyname(algo_name);
+    if (!md) {
+        return 1;
+    }
+    EVP_MD_CTX* ctx = EVP_MD_CTX_new();
+    if (!ctx) return 1;
+    std::ifstream file(file_path, std::ios::binary);
+    if (!file) {
+        EVP_MD_CTX_free(ctx);
+        return 1;
+    }
+    EVP_DigestInit_ex(ctx, md, nullptr);
+    char buf[4096];
+    while (file.read(buf, sizeof(buf)) || file.gcount()) {
+        EVP_DigestUpdate(ctx, buf, file.gcount());
+    }
+    unsigned char hash[EVP_MAX_MD_SIZE];
+    unsigned int len;
+    EVP_DigestFinal_ex(ctx, hash, &len);
+    EVP_MD_CTX_free(ctx);
+    if (out_len < len * 2 + 1) return 1;
+    for (unsigned int i = 0; i < len; ++i)
+        std::sprintf(out + i * 2, "%02x", hash[i]);
+    out[len * 2] = '\0';
+    return 0;
+}
+
+#ifdef BUILD_CLI
+int main(int argc, char* argv[]) {
+    if (argc != 3) {
+        std::cerr << "usage: " << argv[0] << " <algo> <file>\n";
+        return 1;
+    }
+    char out[EVP_MAX_MD_SIZE * 2 + 1];
+    if (hash_file(argv[1], argv[2], out, sizeof(out)) != 0) {
+        return 1;
+    }
+    std::cout << out << "\n";
+    return 0;
+}
+#endif

--- a/tests/test_exe_inspector.py
+++ b/tests/test_exe_inspector.py
@@ -1,6 +1,31 @@
 import platform
 from pathlib import Path
 from types import SimpleNamespace
+import hashlib
+import pytest
+import sys
+import types
+
+src = types.ModuleType("src")
+utils = types.ModuleType("src.utils")
+helpers = types.ModuleType("src.utils.helpers")
+process_utils = types.ModuleType("src.utils.process_utils")
+security = types.ModuleType("src.utils.security")
+helpers.calc_hash = lambda p, algo="sha256": hashlib.sha256(Path(p).read_bytes()).hexdigest()
+process_utils.run_command = lambda *a, **kw: ""
+process_utils.run_command_ex = lambda *a, **kw: ("", 0)
+security.ensure_admin = lambda *a, **kw: True
+security.is_admin = lambda: True
+security.list_open_ports = lambda: {}
+utils.helpers = helpers
+utils.process_utils = process_utils
+utils.security = security
+src.utils = utils
+sys.modules.setdefault("src", src)
+sys.modules.setdefault("src.utils", utils)
+sys.modules.setdefault("src.utils.helpers", helpers)
+sys.modules.setdefault("src.utils.process_utils", process_utils)
+sys.modules.setdefault("src.utils.security", security)
 
 import scripts.exe_inspector as inspector
 
@@ -18,6 +43,7 @@ def test_gather_info_windows(monkeypatch, tmp_path):
 
     monkeypatch.setattr(inspector, "_powershell", fake_ps)
     monkeypatch.setattr(inspector, "calc_hash", lambda p, algo="sha256": "hash")
+    monkeypatch.setattr(inspector, "_calc_hash_cpp", lambda p, a: None)
 
     info = inspector.gather_info(exe)
     assert info["SHA256"] == "hash"
@@ -54,9 +80,196 @@ def test_hash_fallback(monkeypatch, tmp_path):
         "run_command",
         lambda cmd, capture=False: "abcd1234 efgh" if capture else "",
     )
+    monkeypatch.setattr(inspector, "_calc_hash_cpp", lambda p, a: None)
 
-    digest = inspector._calc_hash_smart(exe)
+    digest = inspector._calc_hash_smart(exe, "sha256")
     assert digest == "abcd1234"
+
+
+def test_cpp_hash(tmp_path):
+    exe = tmp_path / "bin"
+    exe.write_bytes(b"data")
+    if not inspector._compile_hash_calc():
+        pytest.skip("compiler unavailable")
+    inspector._load_hash_lib()
+    digest = inspector._calc_hash_cpp(exe, "sha256")
+    assert digest == hashlib.sha256(b"data").hexdigest()
+
+
+def test_cpp_used(monkeypatch, tmp_path):
+    exe = tmp_path / "bin"
+    exe.write_text("x")
+    called = []
+    monkeypatch.setattr(inspector, "_calc_hash_cpp", lambda p, a: called.append(a) or "ok")
+    digest = inspector._calc_hash_smart(exe, "sha256")
+    assert digest == "ok"
+    assert called == ["sha256"]
+
+
+def test_compile_uses_pkgconfig(monkeypatch, tmp_path):
+    src = tmp_path / "hash_calc.cpp"
+    src.write_text("int x;")
+    bin_path = tmp_path / "hash_calc"
+    lib_path = tmp_path / "hash_calc.so"
+    calls = []
+
+    def fake_run(cmd, capture=False, check=True):
+        calls.append(cmd)
+        if cmd[0] == "pkg-config":
+            return "-I/ssl/include" if "--cflags" in cmd else "-L/ssl/lib -lcrypto"
+        if Path(cmd[0]).name == "g++":
+            out = lib_path if "-shared" in cmd else bin_path
+            out.touch()
+            return ""
+        return ""
+
+    monkeypatch.setattr(inspector, "run_command", fake_run)
+    monkeypatch.setattr(inspector, "HASHCALC_SRC", src)
+    monkeypatch.setenv("EXE_HASH_BIN", str(bin_path))
+    monkeypatch.setenv("EXE_HASH_LIB", str(lib_path))
+    monkeypatch.setattr(inspector.shutil, "which", lambda x: "/usr/bin/g++" if x == "g++" else None)
+
+    assert inspector._compile_hash_calc()
+    assert any(cmd[0] == "pkg-config" for cmd in calls)
+    assert any("-I/ssl/include" in cmd for cmd in calls if Path(cmd[0]).name == "g++")
+
+
+def test_compile_respects_cxx_env(monkeypatch, tmp_path):
+    src = tmp_path / "hash_calc.cpp"
+    src.write_text("int x;")
+    bin_path = tmp_path / "hash_calc"
+    lib_path = tmp_path / "hash_calc.so"
+    calls = []
+
+    def fake_run(cmd, capture=False, check=True):
+        calls.append(cmd)
+        if cmd[0] == "pkg-config":
+            return ""
+        if cmd[0] == "mycxx":
+            out = lib_path if "-shared" in cmd else bin_path
+            out.touch()
+            return ""
+        return ""
+
+    monkeypatch.setattr(inspector, "run_command", fake_run)
+    monkeypatch.setattr(inspector, "HASHCALC_SRC", src)
+    monkeypatch.setenv("EXE_HASH_BIN", str(bin_path))
+    monkeypatch.setenv("EXE_HASH_LIB", str(lib_path))
+    monkeypatch.setenv("CXX", "mycxx")
+    monkeypatch.setattr(inspector.shutil, "which", lambda x: None)
+
+    assert inspector._compile_hash_calc()
+    assert any(cmd[0] == "mycxx" for cmd in calls)
+
+
+def test_compile_extra_flags(monkeypatch, tmp_path):
+    src = tmp_path / "hash_calc.cpp"
+    src.write_text("int x;")
+    bin_path = tmp_path / "hash_calc"
+    lib_path = tmp_path / "hash_calc.so"
+    calls = []
+
+    def fake_run(cmd, capture=False, check=True):
+        calls.append(cmd)
+        if cmd[0] == "pkg-config":
+            return ""
+        if Path(cmd[0]).name == "g++":
+            out = lib_path if "-shared" in cmd else bin_path
+            out.touch()
+            return ""
+        return ""
+
+    monkeypatch.setattr(inspector, "run_command", fake_run)
+    monkeypatch.setattr(inspector, "HASHCALC_SRC", src)
+    monkeypatch.setenv("EXE_HASH_BIN", str(bin_path))
+    monkeypatch.setenv("EXE_HASH_LIB", str(lib_path))
+    monkeypatch.setenv("EXE_HASH_CXXFLAGS", "-O3 -march=native")
+    monkeypatch.setattr(inspector.shutil, "which", lambda x: "/usr/bin/g++" if x == "g++" else None)
+
+    assert inspector._compile_hash_calc()
+    gxx_calls = [c for c in calls if Path(c[0]).name == "g++"]
+    assert any("-O3" in c for c in gxx_calls)
+    assert any("-march=native" in c for c in gxx_calls)
+
+
+def test_openssl_flags_fallback(monkeypatch):
+    calls = []
+
+    def fake_run(cmd, capture=True, check=False):
+        calls.append(cmd)
+        if cmd[0] == "pkg-config":
+            return ""
+        if cmd[0] == "openssl":
+            return 'OPENSSLDIR: "/opt/ssl"'
+        return ""
+
+    monkeypatch.setattr(inspector, "run_command", fake_run)
+    monkeypatch.setattr(inspector.ctypes.util, "find_library", lambda x: "/opt/ssl/lib/libcrypto.so")
+
+    flags = inspector._openssl_flags()
+    assert "-I/opt/ssl/include" in flags
+    assert "-L/opt/ssl/lib" in flags
+    assert "-lcrypto" in flags
+
+
+def test_load_hash_lib_env(monkeypatch, tmp_path):
+    lib = tmp_path / "libhash.so"
+    lib.touch()
+    monkeypatch.setenv("EXE_HASH_LIB", str(lib))
+    called = []
+
+    class Dummy:
+        def __init__(self):
+            self.hash_file = lambda *a: 0
+
+    def fake_cdll(path):
+        called.append(path)
+        return Dummy()
+
+    monkeypatch.setattr(inspector.ctypes, "CDLL", fake_cdll)
+    monkeypatch.setattr(inspector, "_HASH_LIB", None)
+    monkeypatch.setattr(inspector, "_compile_hash_calc", lambda: False)
+
+    lib_obj = inspector._load_hash_lib()
+    assert isinstance(lib_obj, Dummy)
+    assert called[0] == str(lib)
+
+
+def test_load_hash_lib_find(monkeypatch, tmp_path):
+    lib = tmp_path / "libhash_calc.so"
+    lib.touch()
+    called = []
+
+    class Dummy:
+        def __init__(self):
+            self.hash_file = lambda *a: 0
+
+    monkeypatch.setattr(inspector.ctypes.util, "find_library", lambda n: str(lib))
+
+    def fake_cdll(path):
+        called.append(path)
+        return Dummy()
+
+    monkeypatch.setattr(inspector.ctypes, "CDLL", fake_cdll)
+    monkeypatch.setattr(inspector, "_HASH_LIB", None)
+    monkeypatch.setattr(inspector, "_compile_hash_calc", lambda: False)
+    monkeypatch.setattr(inspector, "HASHCALC_LIB_DEFAULT", tmp_path / "missing.so")
+
+    lib_obj = inspector._load_hash_lib()
+    assert isinstance(lib_obj, Dummy)
+    assert called[0] == str(lib)
+
+
+def test_gather_info_algos(monkeypatch, tmp_path):
+    exe = tmp_path / "app.exe"
+    exe.write_text("x")
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    monkeypatch.setattr(inspector, "_powershell", lambda cmd: None)
+    monkeypatch.setattr(inspector, "calc_hash", lambda p, algo="sha256": algo)
+    monkeypatch.setattr(inspector, "_calc_hash_cpp", lambda p, a: None)
+    info = inspector.gather_info(exe, algos=["md5", "sha1"])
+    assert info["MD5"] == "md5"
+    assert info["SHA1"] == "sha1"
 
 
 def test_gather_info_denied(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- use pkg-config to determine OpenSSL compile flags
- unit test verifying pkg-config integration
- add env var overrides for hash helper paths
- unit test covering env var hash lib load
- respect `CXX` env var for compiler selection
- stub src package in tests to avoid heavy imports
- unit test ensuring `CXX` is honored
- fall back to `openssl version -d` and `ctypes.util.find_library` when pkg-config is unavailable
- unit test for OpenSSL fallback logic
- add environment variable `EXE_HASH_CXXFLAGS` for passing extra compiler flags
- unit test verifying custom flags are added
- check for system-installed hash library before compiling
- unit test exercising system-library lookup

## Testing
- `pytest -q tests/test_exe_inspector.py::test_compile_uses_pkgconfig`
- `pytest -q tests/test_exe_inspector.py::test_compile_respects_cxx_env`
- `pytest -q tests/test_exe_inspector.py::test_compile_extra_flags`
- `pytest -q tests/test_exe_inspector.py::test_openssl_flags_fallback`
- `pytest -q tests/test_exe_inspector.py::test_load_hash_lib_find`
- `pytest -q tests/test_exe_inspector.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686aaab18e64832b8be8b47687f0e8c7