### PR TITLE
Enhance geolocation accuracy

### DIFF
--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -77,6 +77,13 @@ from .network import (
     clear_ping_cache,
     clear_arp_cache,
 )
+from .geolocation import (
+    GeoInfo,
+    get_geo_info,
+    async_get_geo_info,
+    queue_geo_lookup,
+    shutdown_worker,
+)
 
 from .ui import center_window
 from .kill_utils import kill_process, kill_process_tree
@@ -180,6 +187,11 @@ __all__ = [
     "clear_ping_cache",
     "clear_arp_cache",
     "async_collect_http_info",
+    "GeoInfo",
+    "get_geo_info",
+    "async_get_geo_info",
+    "queue_geo_lookup",
+    "shutdown_worker",
     "TOP_PORTS",
     "PortInfo",
     "file_manager",

--- a/src/utils/geolocation.py
+++ b/src/utils/geolocation.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+import asyncio
+import os
+import threading
+import queue
+import requests
+
+from .cache import CacheManager
+
+
+@dataclass
+class GeoInfo:
+    """Geolocation details for an IP address."""
+
+    ip: str
+    city: str | None = None
+    region: str | None = None
+    country: str | None = None
+    latitude: float | None = None
+    longitude: float | None = None
+
+
+_CACHE_FILE = Path(
+    os.environ.get(
+        "GEO_CACHE_FILE",
+        str(Path.home() / ".coolbox" / "cache" / "geo_cache.json"),
+    )
+)
+_CACHE_TTL = float(os.environ.get("GEO_CACHE_TTL", 86400))
+GEO_CACHE: CacheManager[dict] = CacheManager(_CACHE_FILE)
+
+
+_QUEUE: queue.Queue[tuple[str, Callable[[GeoInfo | None], None]]] | None = None
+_WORKER: threading.Thread | None = None
+_STOP = object()
+
+
+def _ensure_worker() -> None:
+    global _QUEUE, _WORKER
+    if _WORKER is not None:
+        return
+    _QUEUE = queue.Queue()
+
+    def worker() -> None:
+        while True:
+            item = _QUEUE.get()
+            if item is _STOP:
+                break
+            ip, cb = item
+            try:
+                info = get_geo_info(ip)
+            except Exception:
+                info = None
+            try:
+                cb(info)
+            finally:
+                _QUEUE.task_done()
+
+    _WORKER = threading.Thread(target=worker, daemon=True)
+    _WORKER.start()
+
+
+def shutdown_worker() -> None:
+    global _QUEUE, _WORKER
+    if _WORKER and _QUEUE:
+        _QUEUE.put(_STOP)
+        _WORKER.join(timeout=2)
+    _WORKER = None
+    _QUEUE = None
+
+
+def queue_geo_lookup(ip: str, callback: Callable[[GeoInfo | None], None]) -> None:
+    _ensure_worker()
+    assert _QUEUE is not None
+    _QUEUE.put((ip, callback))
+
+
+def get_geo_info(ip: str) -> GeoInfo | None:
+    GEO_CACHE.prune()
+    cached = GEO_CACHE.get(ip, _CACHE_TTL)
+    if cached is not None:
+        return GeoInfo(
+            ip,
+            cached.get("city"),
+            cached.get("region"),
+            cached.get("country"),
+            cached.get("lat"),
+            cached.get("lon"),
+        )
+
+    sources = [
+        f"https://ipapi.co/{ip}/json",
+        f"https://ipwho.is/{ip}",
+    ]
+    for url in sources:
+        try:
+            resp = requests.get(url, timeout=5)
+            if resp.status_code != 200:
+                continue
+            data = resp.json()
+        except Exception:
+            continue
+
+        city = data.get("city")
+        region = data.get("region") or data.get("region_name")
+        country = data.get("country_name") or data.get("country")
+        lat = data.get("latitude") or data.get("lat")
+        lon = data.get("longitude") or data.get("lon") or data.get("lng")
+
+        GEO_CACHE.set(
+            ip,
+            {
+                "city": city,
+                "region": region,
+                "country": country,
+                "lat": lat,
+                "lon": lon,
+            },
+            _CACHE_TTL,
+        )
+        return GeoInfo(ip, city, region, country, lat, lon)
+
+    return None
+
+
+async def async_get_geo_info(ip: str) -> GeoInfo | None:
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(None, get_geo_info, ip)

--- a/src/utils/network.py
+++ b/src/utils/network.py
@@ -32,6 +32,7 @@ import ipaddress
 import psutil
 
 from .cache import CacheManager
+from .geolocation import GeoInfo, queue_geo_lookup
 
 # Default worker and timeout values can be tuned via environment variables so
 # large scans can be optimized without code changes.
@@ -274,6 +275,7 @@ class AutoScanInfo:
     vendor: str | None = None
     http_info: Dict[int, HTTPInfo] | None = None
     device_type: str | None = None
+    geo: GeoInfo | None = None
     _risk_score: int | None = field(default=None, init=False, repr=False)
 
     @property
@@ -1298,6 +1300,7 @@ async def async_auto_scan_iter(
     with_http_info: bool = False,
     with_device_type: bool = False,
     with_risk_score: bool = False,
+    with_geo: bool = False,
     http_concurrency: int = _DEFAULT_HTTP_CONCURRENCY,
     include_arp: bool = True,
     cancel_event: Any | None = None,
@@ -1470,6 +1473,8 @@ async def async_auto_scan_iter(
             info.device_type = _guess_device_type(info)
         if with_risk_score:
             info.compute_risk_score()
+        if with_geo:
+            queue_geo_lookup(host, lambda gi, i=info: setattr(i, "geo", gi))
         return host, info
 
     host_q: asyncio.Queue[str] = asyncio.Queue()
@@ -1542,6 +1547,7 @@ async def async_auto_scan(
     with_http_info: bool = False,
     with_device_type: bool = False,
     with_risk_score: bool = False,
+    with_geo: bool = False,
     http_concurrency: int = _DEFAULT_HTTP_CONCURRENCY,
     include_arp: bool = True,
     cancel_event: Any | None = None,
@@ -1594,6 +1600,7 @@ async def async_auto_scan(
         with_http_info=with_http_info,
         with_device_type=with_device_type,
         with_risk_score=with_risk_score,
+        with_geo=with_geo,
         http_concurrency=http_concurrency,
         include_arp=include_arp,
         cancel_event=cancel_event,
@@ -1631,6 +1638,7 @@ async def async_scan_hosts_iter(
     with_http_info: bool = False,
     with_device_type: bool = False,
     with_risk_score: bool = False,
+    with_geo: bool = False,
     http_concurrency: int = _DEFAULT_HTTP_CONCURRENCY,
     cancel_event: Any | None = None,
 ) -> AsyncIterator[
@@ -1796,6 +1804,8 @@ async def async_scan_hosts_iter(
             info.device_type = _guess_device_type(info)
         if with_risk_score:
             info.compute_risk_score()
+        if with_geo:
+            queue_geo_lookup(host, lambda gi, i=info: setattr(i, "geo", gi))
         return host, info
 
     host_q: asyncio.Queue[str] = asyncio.Queue()
@@ -1870,6 +1880,7 @@ async def async_scan_hosts_detailed(
     with_http_info: bool = False,
     with_device_type: bool = False,
     with_risk_score: bool = False,
+    with_geo: bool = False,
     http_concurrency: int = _DEFAULT_HTTP_CONCURRENCY,
     cancel_event: Any | None = None,
 ) -> Dict[str, AutoScanInfo]:
@@ -2051,6 +2062,9 @@ async def async_scan_hosts_detailed(
     if with_risk_score:
         for info in detailed.values():
             info.compute_risk_score()
+    if with_geo:
+        for host, info in detailed.items():
+            queue_geo_lookup(host, lambda gi, i=info: setattr(i, "geo", gi))
 
     return detailed
 

--- a/tests/test_geolocation.py
+++ b/tests/test_geolocation.py
@@ -1,0 +1,64 @@
+import asyncio
+import threading
+import sys
+from pathlib import Path
+import importlib.util
+import types
+
+import requests
+
+src_dir = Path(__file__).resolve().parents[1] / "src" / "utils"
+geo_path = src_dir / "geolocation.py"
+utils_pkg = types.ModuleType("utils")
+utils_pkg.__path__ = [str(src_dir)]
+sys.modules.setdefault("utils", utils_pkg)
+spec = importlib.util.spec_from_file_location("utils.geolocation", geo_path)
+geo = importlib.util.module_from_spec(spec)
+assert spec.loader
+sys.modules[spec.name] = geo
+spec.loader.exec_module(geo)
+async_get_geo_info = geo.async_get_geo_info
+queue_geo_lookup = geo.queue_geo_lookup
+shutdown_worker = geo.shutdown_worker
+geo.GEO_CACHE.clear()
+
+
+class DummyResp:
+    status_code = 200
+
+    def json(self):
+        return {
+            "city": "X",
+            "region": "Y",
+            "country_name": "Z",
+            "latitude": 1.23,
+            "longitude": 4.56,
+        }
+
+
+def fake_get(url, timeout=5):
+    assert "1.2.3.4" in url
+    return DummyResp()
+
+
+def test_async_get_geo_info(monkeypatch):
+    monkeypatch.setattr(requests, "get", fake_get)
+    info = asyncio.run(async_get_geo_info("1.2.3.4"))
+    assert info and info.city == "X" and info.country == "Z"
+    assert info.latitude == 1.23 and info.longitude == 4.56
+
+
+def test_queue_geo_lookup(monkeypatch):
+    monkeypatch.setattr(requests, "get", fake_get)
+    result: list[tuple[str, float, float]] = []
+    evt = threading.Event()
+
+    def cb(info):
+        if info:
+            result.append((info.city, info.latitude, info.longitude))
+        evt.set()
+
+    queue_geo_lookup("1.2.3.4", cb)
+    assert evt.wait(1)
+    shutdown_worker()
+    assert result == [("X", 1.23, 4.56)]


### PR DESCRIPTION
## Summary
- extend `GeoInfo` with latitude/longitude fields
- use multiple services to fetch geolocation data with better coverage
- clear cache in tests and validate new coordinates

## Testing
- `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics`
- `flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics`
- `pytest tests/test_geolocation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_686b29fbd0e4832bb393682c0d1c4fe0