### PR TITLE
Optimize Kill-by-Click overlay responsiveness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## Unreleased
+
+- **Performance:** Kill-by-Click overlay no longer computes velocity and heat-map updates in the mouse hook thread. Movement is buffered and processed on the Tkinter main loop, preventing input lag.
+- **Efficiency:** Heat-map decay is skipped when `KILL_BY_CLICK_HEATMAP_WEIGHT` is zero, avoiding unnecessary loops.
+- **Defaults:** Reduced window probe attempts from 5 to 3 for faster detection.
+- **Tuning:** Refresh interval remains configurable via `KILL_BY_CLICK_INTERVAL`, `KILL_BY_CLICK_MIN_INTERVAL`, `KILL_BY_CLICK_MAX_INTERVAL` and `KILL_BY_CLICK_DELAY_SCALE`.
+

--- a/README.md
+++ b/README.md
@@ -107,7 +107,9 @@ A modern, feature-rich desktop application built with Python and CustomTkinter.
   ``KILL_BY_CLICK_HEATMAP_RES`` sets the resolution of a decaying heatmap that
   records cursor dwell time across the screen. ``KILL_BY_CLICK_HEATMAP_DECAY``
   controls how quickly old heat fades while ``KILL_BY_CLICK_HEATMAP_WEIGHT``
-  biases selection toward windows covering the hottest regions. When the same
+  biases selection toward windows covering the hottest regions. When
+  ``KILL_BY_CLICK_HEATMAP_WEIGHT`` is ``0`` the heatmap isn't used for
+  scoring and its updates are skipped to save CPU. When the same
   PID remains under the cursor across consecutive samples the overlay adds a
   ``KILL_BY_CLICK_STREAK_WEIGHT`` multiplier to reward consistent hovering,
   ensuring foreground windows dominate momentary background flashes.

--- a/src/utils/scoring_engine.py
+++ b/src/utils/scoring_engine.py
@@ -111,6 +111,13 @@ class CursorHeatmap:
         self.grid = [[0.0 for _ in range(self.w)] for _ in range(self.h)]
 
     def update(self, x: int, y: int) -> None:
+        """Decay the heat-map and bump the cell under ``(x, y)``.
+
+        When ``tuning.heatmap_weight`` is zero the heat-map is not used for
+        scoring so we skip the work entirely.
+        """
+        if self.tuning.heatmap_weight <= 0:
+            return
         gx = min(int(x / self.res), self.w - 1)
         gy = min(int(y / self.res), self.h - 1)
         for row in self.grid:

--- a/tests/test_click_overlay.py
+++ b/tests/test_click_overlay.py
@@ -411,11 +411,11 @@ class TestClickOverlay(unittest.TestCase):
         with patch("src.views.click_overlay.is_supported", return_value=False):
             overlay = ClickOverlay(root)
 
-        overlay._queue_update = unittest.mock.Mock()
+        overlay.after_idle = unittest.mock.Mock()
         overlay._on_move(55, 66)
 
-        self.assertEqual((overlay._cursor_x, overlay._cursor_y), (55, 66))
-        overlay._queue_update.assert_called_once()
+        overlay.after_idle.assert_called_once_with(overlay._handle_move)
+        self.assertEqual(overlay._pending_move[:2], (55, 66))
 
         overlay.destroy()
         root.destroy()
@@ -787,9 +787,11 @@ class TestClickOverlay(unittest.TestCase):
         overlay._last_move_pos = (0, 0)
         overlay._last_move_time = 0.0
 
+        overlay.after_idle = lambda cb: cb()
+
         with (
             patch("src.views.click_overlay.time.time", side_effect=[0.1, 0.2]),
-            patch("src.views.click_overlay.VELOCITY_SMOOTH", 0.5),
+            patch("src.utils.scoring_engine.tuning.velocity_smooth", 0.5),
         ):
             overlay._on_move(10, 0)
             first = overlay._velocity


### PR DESCRIPTION
## Summary
- reduce default probe attempts from 5 to 3
- process mouse movement on the Tk thread instead of the pynput hook
- skip heatmap updates when heatmap_weight is disabled
- document the change in CHANGELOG and README
- update tests for the deferred move handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6887ad09285c8325a26d86a12e95f1d6