### PR TITLE
Adjust Kill by Click to 60 FPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ A modern, feature-rich desktop application built with Python and CustomTkinter.
   mouse events while polling the window under the cursor at ``KILL_BY_CLICK_INTERVAL``
   and tracks pointer coordinates from hook callbacks or motion events to keep
   updates smooth without flicker. Set ``KILL_BY_CLICK_INTERVAL`` to control the
-  base refresh rate (defaults to ``0.1`` seconds) or pass ``--interval`` when using
+  base refresh rate (defaults to ``0.016`` seconds) or pass ``--interval`` when using
   ``scripts/kill_by_click.py``. The refresh interval expands and contracts
-  between ``KILL_BY_CLICK_MIN_INTERVAL`` (``0.025`` seconds) and
-  ``KILL_BY_CLICK_MAX_INTERVAL`` (``0.2`` seconds) using an exponential curve
+  between ``KILL_BY_CLICK_MIN_INTERVAL`` (``0.008`` seconds) and
+  ``KILL_BY_CLICK_MAX_INTERVAL`` (``0.033`` seconds) using an exponential curve
   tied to pointer velocity. ``KILL_BY_CLICK_DELAY_SCALE`` controls how strongly
   speed influences this interval. Fast motion shortens the delay for responsive
   tracking while slower movement stretches it to conserve CPU. The window's normal interaction state is restored automatically when the overlay closes. The Force Quit dialog uses this overlay when you choose *Kill by Click* and falls back to the window under the cursor if no PID is detected. Set ``FORCE_QUIT_CLICK_SKIP_CONFIRM=1`` to skip the termination prompt. The overlay samples the window

--- a/src/utils/scoring_engine.py
+++ b/src/utils/scoring_engine.py
@@ -14,17 +14,22 @@ from .window_utils import WindowInfo, list_windows_at
 class Tuning:
     """Weight and scoring parameters loaded from environment variables."""
 
-    # Increase the default overlay update interval to reduce CPU
-    # usage while tracking the cursor. A 100ms refresh keeps the
-    # overlay responsive without the heavy overhead of the prior
-    # 50ms rate which could cause noticeable lag on some systems.
-    interval: float = 0.1
+    # Default overlay update interval in seconds. A higher frame rate keeps
+    # cursor tracking smooth so kill‑by‑click feels responsive. The previous
+    # 0.1s value updated at roughly 10 FPS which could appear choppy on fast
+    # movements. Using a 60 FPS baseline strikes a good balance between
+    # responsiveness and CPU usage while still allowing users to override via
+    # ``KILL_BY_CLICK_INTERVAL``.
+    interval: float = 1 / 60
     # Dynamic adjustment bounds for the overlay refresh delay.
     # The update interval scales between these values based on
     # cursor velocity so quick movements feel responsive while
     # idle periods use fewer resources.
-    min_interval: float = 0.025
-    max_interval: float = 0.2
+    # Allow the interval to scale between ~120 FPS and ~30 FPS based on cursor
+    # velocity so rapid motion speeds up updates and idle periods slow down to
+    # conserve resources.
+    min_interval: float = 1 / 120
+    max_interval: float = 1 / 30
     # Divisor controlling how strongly pointer speed compresses the overlay
     # refresh interval. Larger values make motion influence the delay more
     # gradually while smaller values cause faster updates during quick moves.


### PR DESCRIPTION
## Summary
- bump Kill by Click overlay refresh rate from ~10 FPS to 60 FPS
- document new defaults in README

## Testing
- `flake8 src setup.py tests` *(fails: numerous style violations in repo)*
- `pytest tests/test_click_overlay.py::TestClickOverlay::test_overlay_creation -q`
- `pytest tests/test_force_quit.py::TestForceQuit::test_force_kill -q`

------
https://chatgpt.com/codex/tasks/task_e_68887c249dfc832b9619c618f980dae9