### PR TITLE
Handle missing psutil at runtime

### DIFF
--- a/src/ensure_deps.py
+++ b/src/ensure_deps.py
@@ -12,6 +12,7 @@ from .utils.helpers import log
 
 
 _DEF_VERSION = "5.2.2"
+_DEF_PSUTIL = "5.9.0"
 
 
 def require_package(name: str, version: Optional[str] = None) -> ModuleType:
@@ -41,3 +42,9 @@ def ensure_customtkinter(version: str = _DEF_VERSION) -> ModuleType:
     """Return the ``customtkinter`` module, installing it if needed."""
 
     return require_package("customtkinter", version)
+
+
+def ensure_psutil(version: str = _DEF_PSUTIL) -> ModuleType:
+    """Return the ``psutil`` module, installing it if needed."""
+
+    return require_package("psutil", version)

--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -11,7 +11,12 @@ from typing import Literal, Dict, Any, Iterable, Callable
 from pathlib import Path
 
 from .cache import CacheManager
-import psutil
+try:
+    import psutil
+except ImportError:  # pragma: no cover - runtime dependency check
+    from ..ensure_deps import ensure_psutil
+
+    psutil = ensure_psutil()
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from rich.console import Console
 from rich.progress import (

--- a/src/utils/kill_utils.py
+++ b/src/utils/kill_utils.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 import os
 import shutil
 
-import psutil
+try:
+    import psutil
+except ImportError:  # pragma: no cover - runtime dependency check
+    from ..ensure_deps import ensure_psutil
+
+    psutil = ensure_psutil()
 from .process_utils import run_command
 
 

--- a/src/utils/network.py
+++ b/src/utils/network.py
@@ -29,7 +29,12 @@ from .process_utils import (
 )
 import time
 import ipaddress
-import psutil
+try:
+    import psutil
+except ImportError:  # pragma: no cover - runtime dependency check
+    from ..ensure_deps import ensure_psutil
+
+    psutil = ensure_psutil()
 
 from .cache import CacheManager
 

--- a/src/utils/process_monitor.py
+++ b/src/utils/process_monitor.py
@@ -15,7 +15,12 @@ from collections import deque
 import heapq
 import random
 import math
-import psutil
+try:
+    import psutil
+except ImportError:  # pragma: no cover - runtime dependency check
+    from ..ensure_deps import ensure_psutil
+
+    psutil = ensure_psutil()
 
 
 @dataclass(slots=True)

--- a/src/utils/security.py
+++ b/src/utils/security.py
@@ -14,7 +14,12 @@ from pathlib import Path
 import sys
 import socket
 from dataclasses import dataclass
-import psutil
+try:
+    import psutil
+except ImportError:  # pragma: no cover - runtime dependency check
+    from ..ensure_deps import ensure_psutil
+
+    psutil = ensure_psutil()
 from .win_console import hidden_creation_flags
 from .process_utils import run_command as _run, run_command_background
 from .kill_utils import kill_process, kill_process_tree

--- a/src/views/force_quit_dialog.py
+++ b/src/views/force_quit_dialog.py
@@ -24,7 +24,12 @@ from tkinter import messagebox, filedialog
 from tkinter import ttk
 
 import customtkinter as ctk
-import psutil
+try:
+    import psutil
+except ImportError:  # pragma: no cover - runtime dependency check
+    from ..ensure_deps import ensure_psutil
+
+    psutil = ensure_psutil()
 from src.utils.process_monitor import ProcessEntry, ProcessWatcher
 from .base_dialog import BaseDialog
 from src.utils.helpers import (

--- a/src/views/system_info_dialog.py
+++ b/src/views/system_info_dialog.py
@@ -1,6 +1,11 @@
 import json
 
-import psutil
+try:
+    import psutil
+except ImportError:  # pragma: no cover - runtime dependency check
+    from ..ensure_deps import ensure_psutil
+
+    psutil = ensure_psutil()
 import customtkinter as ctk
 import pyperclip
 import tkinter as tk

--- a/tests/test_ensure_deps.py
+++ b/tests/test_ensure_deps.py
@@ -1,7 +1,11 @@
 import importlib
 from types import ModuleType
 
-from src.ensure_deps import require_package, ensure_customtkinter
+from src.ensure_deps import (
+    require_package,
+    ensure_customtkinter,
+    ensure_psutil,
+)
 
 
 def test_require_package_installs(monkeypatch):
@@ -35,3 +39,17 @@ def test_ensure_customtkinter_calls_require(monkeypatch):
     mod = ensure_customtkinter("5.0")
     assert mod.__name__ == "customtkinter"
     assert called == {"name": "customtkinter", "version": "5.0"}
+
+
+def test_ensure_psutil_calls_require(monkeypatch):
+    called = {}
+
+    def fake_require(name, version=None):
+        called["name"] = name
+        called["version"] = version
+        return ModuleType(name)
+
+    monkeypatch.setattr("src.ensure_deps.require_package", fake_require)
+    mod = ensure_psutil("5.9.0")
+    assert mod.__name__ == "psutil"
+    assert called == {"name": "psutil", "version": "5.9.0"}


### PR DESCRIPTION
## Summary
- extend `ensure_deps` with `ensure_psutil`
- import psutil via `ensure_psutil` across modules
- test new helper for psutil

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688906c2e5a8832b9841cc2561fbbcae