### PR TITLE
Fix circular import when psutil missing

### DIFF
--- a/src/ensure_deps.py
+++ b/src/ensure_deps.py
@@ -8,7 +8,16 @@ import sys
 from types import ModuleType
 from typing import Optional
 
-from .utils.helpers import log
+try:  # Avoid circular imports when utils.helpers requires ensure_deps
+    from .utils.helpers import log
+except Exception:  # pragma: no cover - fallback logger
+    import logging
+
+    logging.basicConfig(level=logging.INFO)
+
+    def log(message: str) -> None:
+        """Fallback logger used during early imports."""
+        logging.info(message)
 
 
 _DEF_VERSION = "5.2.2"


### PR DESCRIPTION
## Summary
- avoid importing `log` from helpers at module level in `ensure_deps`
- provide fallback logger to break circular dependency

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6889094c90f8832b94fc87ef6b2b968f