### PR TITLE
Improve dependency fallback

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 customtkinter==5.2.2
-pillow>=10.0.0
+pillow>=11.0.0
 python-dotenv>=1.0.0
 colorama>=0.4.6
 rich>=13.0.0


### PR DESCRIPTION
## Summary
- ensure Pillow version 11.0.0
- install latest package if pinned version fails
- adjust Pillow tests
- test fallback installer logic

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q tests/test_ensure_deps.py::test_require_package_install_fallback -q`


------
https://chatgpt.com/codex/tasks/task_e_688a1d6e83a8832b8477890b9c847461