### PR TITLE
Fix pillow import bug

### DIFF
--- a/src/ensure_deps.py
+++ b/src/ensure_deps.py
@@ -67,5 +67,8 @@ def ensure_psutil(version: str = _DEF_PSUTIL) -> ModuleType:
 def ensure_pillow(version: str = _DEF_PILLOW) -> ModuleType:
     """Return the ``PIL`` module, installing Pillow if needed."""
 
-    require_package("Pillow", version)
-    return importlib.import_module("PIL")
+    try:
+        return importlib.import_module("PIL")
+    except ImportError:
+        require_package("Pillow", version)
+        return importlib.import_module("PIL")

--- a/src/views/about_view.py
+++ b/src/views/about_view.py
@@ -28,7 +28,7 @@ class AboutView(BaseView):
 
         info = info_label(
             container,
-            "CoolBox - A Modern Desktop App\nVersion 1.0",
+            "CoolBox - A Modern Desktop App\nVersion 1.0.1",
             font=self.font,
         )
         info.pack(anchor="w")


### PR DESCRIPTION
## Summary
- fix `ensure_pillow` to import `PIL` correctly
- bump About screen to version 1.0.1
- update `test_ensure_deps` for new behaviour

## Testing
- `COOLBOX_LIGHTWEIGHT=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a20062e28832b9ec9e8f5465d9c0e