### PR TITLE
Fix missing pyperclip dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,17 +10,29 @@ import time
 from pathlib import Path
 from typing import Iterable
 
-from rich.text import Text
-from rich.progress import (
-    Progress,
-    SpinnerColumn,
-    BarColumn,
-    TimeElapsedColumn,
-)
+try:
+    from rich.text import Text
+    from rich.progress import (
+        Progress,
+        SpinnerColumn,
+        BarColumn,
+        TimeElapsedColumn,
+    )
+except ImportError:  # pragma: no cover - runtime dependency check
+    from src.ensure_deps import ensure_rich
 
-os.environ.setdefault("COOLBOX_LIGHTWEIGHT", "1")
-from src.utils.helpers import log, get_system_info, run_with_spinner, console
-from src.utils.rainbow import NeonPulseBorder
+    ensure_rich()
+    from rich.text import Text
+    from rich.progress import (
+        Progress,
+        SpinnerColumn,
+        BarColumn,
+        TimeElapsedColumn,
+    )
+
+os.environ.setdefault("COOLBOX_LIGHTWEIGHT", "1")  # noqa: E402
+from src.utils.helpers import log, get_system_info, run_with_spinner, console  # noqa: E402
+from src.utils.rainbow import NeonPulseBorder  # noqa: E402
 
 
 MIN_PYTHON = (3, 10)

--- a/src/app.py
+++ b/src/app.py
@@ -3,6 +3,7 @@ CoolBox Application Class
 Manages the main application window and navigation
 """
 from __future__ import annotations
+
 try:
     import customtkinter as ctk
 except ImportError:  # pragma: no cover - runtime dependency check

--- a/src/components/bar_chart.py
+++ b/src/components/bar_chart.py
@@ -1,6 +1,13 @@
 import customtkinter as ctk
-from matplotlib.figure import Figure
-from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
+try:
+    from matplotlib.figure import Figure
+    from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
+except ImportError:  # pragma: no cover - runtime dependency check
+    from ..ensure_deps import ensure_matplotlib
+
+    ensure_matplotlib()
+    from matplotlib.figure import Figure
+    from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 
 
 class BarChart(ctk.CTkFrame):

--- a/src/components/charts.py
+++ b/src/components/charts.py
@@ -1,6 +1,13 @@
 import customtkinter as ctk
-from matplotlib.figure import Figure
-from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
+try:
+    from matplotlib.figure import Figure
+    from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
+except ImportError:  # pragma: no cover - runtime dependency check
+    from ..ensure_deps import ensure_matplotlib
+
+    ensure_matplotlib()
+    from matplotlib.figure import Figure
+    from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 
 
 class LineChart(ctk.CTkFrame):

--- a/src/components/toolbar.py
+++ b/src/components/toolbar.py
@@ -7,7 +7,12 @@ from tkinter import filedialog
 
 from ..utils import file_manager, open_path
 from ..utils.ui import center_window
-import pyperclip
+try:
+    import pyperclip
+except ImportError:  # pragma: no cover - runtime dependency check
+    from ..ensure_deps import ensure_pyperclip
+
+    pyperclip = ensure_pyperclip()
 from .tooltip import Tooltip
 
 

--- a/src/ensure_deps.py
+++ b/src/ensure_deps.py
@@ -23,6 +23,21 @@ except Exception:  # pragma: no cover - fallback logger
 _DEF_VERSION = "5.2.2"
 _DEF_PSUTIL = "5.9.0"
 _DEF_PILLOW = "11.0.0"
+_DEF_PYPERCLIP = "1.8.2"
+_DEF_RICH = "13.0.0"
+_DEF_MATPLOTLIB = "3.7.0"
+
+
+def ensure_import(
+    module: str, package: str | None = None, version: str | None = None
+) -> ModuleType:
+    """Import *module* installing *package* if needed."""
+
+    try:
+        return importlib.import_module(module)
+    except ImportError:
+        require_package(package or module, version)
+        return importlib.import_module(module)
 
 
 def require_package(name: str, version: Optional[str] = None) -> ModuleType:
@@ -55,20 +70,34 @@ def require_package(name: str, version: Optional[str] = None) -> ModuleType:
 def ensure_customtkinter(version: str = _DEF_VERSION) -> ModuleType:
     """Return the ``customtkinter`` module, installing it if needed."""
 
-    return require_package("customtkinter", version)
+    return ensure_import("customtkinter", version=version)
 
 
 def ensure_psutil(version: str = _DEF_PSUTIL) -> ModuleType:
     """Return the ``psutil`` module, installing it if needed."""
 
-    return require_package("psutil", version)
+    return ensure_import("psutil", version=version)
 
 
 def ensure_pillow(version: str = _DEF_PILLOW) -> ModuleType:
     """Return the ``PIL`` module, installing Pillow if needed."""
 
-    try:
-        return importlib.import_module("PIL")
-    except ImportError:
-        require_package("Pillow", version)
-        return importlib.import_module("PIL")
+    return ensure_import("PIL", package="Pillow", version=version)
+
+
+def ensure_pyperclip(version: str = _DEF_PYPERCLIP) -> ModuleType:
+    """Return the ``pyperclip`` module, installing it if needed."""
+
+    return ensure_import("pyperclip", version=version)
+
+
+def ensure_rich(version: str = _DEF_RICH) -> ModuleType:
+    """Return the ``rich`` module, installing it if needed."""
+
+    return ensure_import("rich", version=version)
+
+
+def ensure_matplotlib(version: str = _DEF_MATPLOTLIB) -> ModuleType:
+    """Return the ``matplotlib`` module, installing it if needed."""
+
+    return ensure_import("matplotlib", version=version)

--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -18,13 +18,25 @@ except ImportError:  # pragma: no cover - runtime dependency check
 
     psutil = ensure_psutil()
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from rich.console import Console
-from rich.progress import (
-    Progress,
-    SpinnerColumn,
-    TextColumn,
-    TimeElapsedColumn,
-)
+try:
+    from rich.console import Console
+    from rich.progress import (
+        Progress,
+        SpinnerColumn,
+        TextColumn,
+        TimeElapsedColumn,
+    )
+except ImportError:  # pragma: no cover - runtime dependency check
+    from ..ensure_deps import ensure_rich
+
+    ensure_rich()
+    from rich.console import Console
+    from rich.progress import (
+        Progress,
+        SpinnerColumn,
+        TextColumn,
+        TimeElapsedColumn,
+    )
 
 console = Console()
 

--- a/src/utils/kill_utils.py
+++ b/src/utils/kill_utils.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import os
 import shutil
-
 try:
     import psutil
 except ImportError:  # pragma: no cover - runtime dependency check

--- a/src/utils/network.py
+++ b/src/utils/network.py
@@ -35,7 +35,6 @@ except ImportError:  # pragma: no cover - runtime dependency check
     from ..ensure_deps import ensure_psutil
 
     psutil = ensure_psutil()
-
 from .cache import CacheManager
 
 # Default worker and timeout values can be tuned via environment variables so

--- a/src/utils/rainbow.py
+++ b/src/utils/rainbow.py
@@ -7,8 +7,15 @@ import threading
 import time
 from typing import Iterable, Tuple
 
-from rich.console import Console, Control
-from rich.text import Text
+try:
+    from rich.console import Console, Control
+    from rich.text import Text
+except ImportError:  # pragma: no cover - runtime dependency check
+    from ..ensure_deps import ensure_rich
+
+    ensure_rich()
+    from rich.console import Console, Control
+    from rich.text import Text
 
 
 THEMES: dict[str, list[str]] = {

--- a/src/views/about_view.py
+++ b/src/views/about_view.py
@@ -28,7 +28,7 @@ class AboutView(BaseView):
 
         info = info_label(
             container,
-            "CoolBox - A Modern Desktop App\nVersion 1.0.1",
+            "CoolBox - A Modern Desktop App\nVersion 1.0.4",
             font=self.font,
         )
         info.pack(anchor="w")

--- a/src/views/force_quit_dialog.py
+++ b/src/views/force_quit_dialog.py
@@ -37,6 +37,7 @@ from src.utils.helpers import (
     lighten_color,
     darken_color,
 )
+
 import importlib
 
 # Preload the click overlay module so its heavy dependencies are

--- a/src/views/system_info_dialog.py
+++ b/src/views/system_info_dialog.py
@@ -7,9 +7,20 @@ except ImportError:  # pragma: no cover - runtime dependency check
 
     psutil = ensure_psutil()
 import customtkinter as ctk
-import pyperclip
+try:
+    import pyperclip
+except ImportError:  # pragma: no cover - runtime dependency check
+    from ..ensure_deps import ensure_pyperclip
+
+    pyperclip = ensure_pyperclip()
 import tkinter as tk
-from matplotlib.backends.backend_tkagg import NavigationToolbar2Tk
+try:
+    from matplotlib.backends.backend_tkagg import NavigationToolbar2Tk
+except ImportError:  # pragma: no cover - runtime dependency check
+    from ..ensure_deps import ensure_matplotlib
+
+    ensure_matplotlib()
+    from matplotlib.backends.backend_tkagg import NavigationToolbar2Tk
 
 from ..utils import get_system_info, get_system_metrics
 from ..components import LineChart, Gauge, BarChart

--- a/tests/test_ensure_deps.py
+++ b/tests/test_ensure_deps.py
@@ -6,6 +6,10 @@ from src.ensure_deps import (
     ensure_customtkinter,
     ensure_psutil,
     ensure_pillow,
+    ensure_pyperclip,
+    ensure_rich,
+    ensure_matplotlib,
+    ensure_import,
 )
 
 
@@ -59,7 +63,17 @@ def test_ensure_customtkinter_calls_require(monkeypatch):
         called["version"] = version
         return ModuleType(name)
 
+    imports = {"count": 0}
+
+    def fake_import(name):
+        imports["count"] += 1
+        if imports["count"] == 1:
+            raise ImportError
+        return ModuleType(name)
+
     monkeypatch.setattr("src.ensure_deps.require_package", fake_require)
+    monkeypatch.setattr(importlib, "import_module", fake_import)
+
     mod = ensure_customtkinter("5.0")
     assert mod.__name__ == "customtkinter"
     assert called == {"name": "customtkinter", "version": "5.0"}
@@ -73,7 +87,17 @@ def test_ensure_psutil_calls_require(monkeypatch):
         called["version"] = version
         return ModuleType(name)
 
+    imports = {"count": 0}
+
+    def fake_import(name):
+        imports["count"] += 1
+        if imports["count"] == 1:
+            raise ImportError
+        return ModuleType(name)
+
     monkeypatch.setattr("src.ensure_deps.require_package", fake_require)
+    monkeypatch.setattr(importlib, "import_module", fake_import)
+
     mod = ensure_psutil("5.9.0")
     assert mod.__name__ == "psutil"
     assert called == {"name": "psutil", "version": "5.9.0"}
@@ -117,3 +141,95 @@ def test_ensure_pillow_no_require_when_present(monkeypatch):
     mod = ensure_pillow("11.0.0")
     assert mod.__name__ == "PIL"
     assert called == {}
+
+
+def test_ensure_pyperclip_calls_require(monkeypatch):
+    called = {}
+
+    def fake_require(name, version=None):
+        called["name"] = name
+        called["version"] = version
+        return ModuleType(name)
+
+    imports = {"count": 0}
+
+    def fake_import(name):
+        imports["count"] += 1
+        if imports["count"] == 1:
+            raise ImportError
+        return ModuleType(name)
+
+    monkeypatch.setattr("src.ensure_deps.require_package", fake_require)
+    monkeypatch.setattr(importlib, "import_module", fake_import)
+
+    mod = ensure_pyperclip("1.8.2")
+    assert mod.__name__ == "pyperclip"
+    assert called == {"name": "pyperclip", "version": "1.8.2"}
+
+
+def test_ensure_import_installs(monkeypatch):
+    calls = {}
+    imports = {"count": 0}
+
+    def fake_import(name):
+        imports["count"] += 1
+        if imports["count"] == 1:
+            raise ImportError
+        return ModuleType(name)
+
+    def fake_require(name, version=None):
+        calls["name"] = name
+        calls["version"] = version
+
+    monkeypatch.setattr(importlib, "import_module", fake_import)
+    monkeypatch.setattr("src.ensure_deps.require_package", fake_require)
+
+    mod = ensure_import("mod", package="pkg", version="1")
+    assert mod.__name__ == "mod"
+    assert calls == {"name": "pkg", "version": "1"}
+
+
+def test_ensure_rich_calls_require(monkeypatch):
+    called = {}
+    imports = {"count": 0}
+
+    def fake_import(name):
+        imports["count"] += 1
+        if imports["count"] == 1:
+            raise ImportError
+        return ModuleType(name)
+
+    def fake_require(name, version=None):
+        called["name"] = name
+        called["version"] = version
+        return ModuleType(name)
+
+    monkeypatch.setattr(importlib, "import_module", fake_import)
+    monkeypatch.setattr("src.ensure_deps.require_package", fake_require)
+
+    mod = ensure_rich("13.0.0")
+    assert mod.__name__ == "rich"
+    assert called == {"name": "rich", "version": "13.0.0"}
+
+
+def test_ensure_matplotlib_calls_require(monkeypatch):
+    called = {}
+    imports = {"count": 0}
+
+    def fake_import(name):
+        imports["count"] += 1
+        if imports["count"] == 1:
+            raise ImportError
+        return ModuleType(name)
+
+    def fake_require(name, version=None):
+        called["name"] = name
+        called["version"] = version
+        return ModuleType(name)
+
+    monkeypatch.setattr(importlib, "import_module", fake_import)
+    monkeypatch.setattr("src.ensure_deps.require_package", fake_require)
+
+    mod = ensure_matplotlib("3.7.0")
+    assert mod.__name__ == "matplotlib"
+    assert called == {"name": "matplotlib", "version": "3.7.0"}


### PR DESCRIPTION
## Summary
- add generic `ensure_import` helper for on-demand installs
- hook specialized ensure_* functions into `ensure_import`
- auto-install missing pyperclip dependency
- bump About dialog version to 1.0.4
- update unit tests for new fallback behaviour

## Testing
- `flake8 setup.py src/app.py src/components/bar_chart.py src/components/charts.py src/components/toolbar.py src/ensure_deps.py src/utils/helpers.py src/utils/kill_utils.py src/utils/network.py src/utils/rainbow.py src/views/about_view.py src/views/force_quit_dialog.py src/views/system_info_dialog.py tests/test_ensure_deps.py`
- `COOLBOX_LIGHTWEIGHT=1 pytest tests/test_ensure_deps.py -q`
- `COOLBOX_LIGHTWEIGHT=1 pytest -q` *(360 passed, 70 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_688a22e631b4832bbf6ae42fcd708b66