### PR TITLE
Improve Force Quit refresh startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,7 @@
 - **Efficiency:** Heat-map decay is skipped when `KILL_BY_CLICK_HEATMAP_WEIGHT` is zero, avoiding unnecessary loops.
 - **Defaults:** Reduced window probe attempts from 5 to 3 for faster detection.
 - **Tuning:** Refresh interval remains configurable via `KILL_BY_CLICK_INTERVAL`, `KILL_BY_CLICK_MIN_INTERVAL`, `KILL_BY_CLICK_MAX_INTERVAL` and `KILL_BY_CLICK_DELAY_SCALE`.
+- **UI:** Force Quit dialog adapts its refresh delay to the detected screen refresh rate for smoother updates and no initial black window.
+- **UI:** Initial refresh now loops at display frame rate until the first snapshot
+  arrives, preventing visible blank states.
 

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -93,10 +93,12 @@ from .network import (
 )
 
 if not os.environ.get("COOLBOX_LIGHTWEIGHT"):
-    from .ui import center_window
+    from .ui import center_window, get_screen_refresh_rate
 else:  # pragma: no cover - testing without UI deps
     def center_window(*_a: object, **_k: object) -> None:
         pass
+    def get_screen_refresh_rate(*_a: object, **_k: object) -> int:
+        return 60
 from .kill_utils import kill_process, kill_process_tree
 from .win_console import (
     hide_console,
@@ -216,6 +218,7 @@ __all__ = [
     "ProcessEntry",
     "ProcessWatcher",
     "center_window",
+    "get_screen_refresh_rate",
     "kill_process",
     "kill_process_tree",
     "hide_console",

--- a/src/utils/ui.py
+++ b/src/utils/ui.py
@@ -1,4 +1,20 @@
+import os
+import subprocess
+import sys
 import customtkinter as ctk
+
+try:  # pragma: no cover - optional OS modules
+    import ctypes
+except Exception:  # pragma: no cover
+    ctypes = None
+try:  # pragma: no cover - optional OS modules
+    from Quartz import (
+        CGDisplayCopyDisplayMode,
+        CGMainDisplayID,
+        CGDisplayModeGetRefreshRate,
+    )
+except Exception:  # pragma: no cover
+    CGDisplayCopyDisplayMode = None
 
 
 def center_window(window: ctk.CTkToplevel) -> None:
@@ -9,3 +25,54 @@ def center_window(window: ctk.CTkToplevel) -> None:
     x = (window.winfo_screenwidth() - width) // 2
     y = (window.winfo_screenheight() - height) // 2
     window.geometry(f"{width}x{height}+{x}+{y}")
+
+
+def get_screen_refresh_rate(default: int = 60) -> int:
+    """Return the primary monitor refresh rate in Hz.
+
+    If the rate cannot be determined, ``default`` is returned.
+    """
+
+    # Allow manual override for tests and edge cases
+    env = os.getenv("COOLBOX_REFRESH_RATE")
+    if env and env.isdigit():
+        return int(env)
+
+    # macOS
+    if sys.platform == "darwin" and CGDisplayCopyDisplayMode:
+        try:
+            mode = CGDisplayCopyDisplayMode(CGMainDisplayID())
+            rate = int(round(CGDisplayModeGetRefreshRate(mode)))
+            if rate:
+                return rate
+        except Exception:  # pragma: no cover - best effort only
+            pass
+
+    # Windows
+    if os.name == "nt" and ctypes is not None:
+        try:
+            user32 = ctypes.windll.user32
+            gdi32 = ctypes.windll.gdi32
+            dc = user32.GetDC(0)
+            VREFRESH = 116
+            rate = gdi32.GetDeviceCaps(dc, VREFRESH)
+            user32.ReleaseDC(0, dc)
+            if rate:
+                return int(rate)
+        except Exception:  # pragma: no cover - best effort only
+            pass
+
+    # X11 via xrandr
+    if sys.platform.startswith("linux"):
+        try:
+            out = subprocess.check_output(["xrandr", "--current"], text=True)
+            for line in out.splitlines():
+                if "*" in line:
+                    parts = line.split()
+                    for p in parts:
+                        if p.endswith("*") and p[:-1].replace(".", "", 1).isdigit():
+                            return int(float(p[:-1]))
+        except Exception:  # pragma: no cover - optional tool
+            pass
+
+    return int(default)

--- a/src/views/about_view.py
+++ b/src/views/about_view.py
@@ -28,7 +28,7 @@ class AboutView(BaseView):
 
         info = info_label(
             container,
-            "CoolBox - A Modern Desktop App\nVersion 1.0.4",
+            "CoolBox - A Modern Desktop App\nVersion 1.0.6",
             font=self.font,
         )
         info.pack(anchor="w")

--- a/tests/test_force_quit_fps.py
+++ b/tests/test_force_quit_fps.py
@@ -1,0 +1,34 @@
+import os
+import unittest
+
+from src.app import CoolBoxApp
+from src.views.force_quit_dialog import ForceQuitDialog
+
+@unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+class TestForceQuitFPS(unittest.TestCase):
+    def test_frame_delay_uses_refresh_rate(self):
+        os.environ["COOLBOX_REFRESH_RATE"] = "72"
+        app = CoolBoxApp()
+        try:
+            dialog = ForceQuitDialog(app)
+            expected = max(1, int(1000 / 72))
+            self.assertEqual(dialog.frame_delay, expected)
+            dialog.destroy()
+        finally:
+            os.environ.pop("COOLBOX_REFRESH_RATE", None)
+            app.destroy()
+
+    def test_force_quit_fps_override(self):
+        os.environ["FORCE_QUIT_FPS"] = "90"
+        app = CoolBoxApp()
+        try:
+            dialog = ForceQuitDialog(app)
+            expected = max(1, int(1000 / 90))
+            self.assertEqual(dialog.frame_delay, expected)
+            dialog.destroy()
+        finally:
+            os.environ.pop("FORCE_QUIT_FPS", None)
+            app.destroy()
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1,0 +1,15 @@
+import os
+import unittest
+
+from src.utils.ui import get_screen_refresh_rate
+
+class TestScreenRefreshRate(unittest.TestCase):
+    def test_env_override(self):
+        os.environ["COOLBOX_REFRESH_RATE"] = "75"
+        try:
+            self.assertEqual(get_screen_refresh_rate(), 75)
+        finally:
+            os.environ.pop("COOLBOX_REFRESH_RATE", None)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- keep Force Quit dialog updating at frame rate until a snapshot is ready
- expose FORCE_QUIT_FPS override test
- bump version to 1.0.6

## Testing
- `pytest tests/test_force_quit_fps.py tests/test_ui.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a60e0f2d0832b8a64b3442fb9946c