### PR TITLE
Improve ForceQuit overlay responsiveness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,4 +9,6 @@
 - **UI:** Force Quit dialog adapts its refresh delay to the detected screen refresh rate for smoother updates and no initial black window.
 - **UI:** Initial refresh now loops at display frame rate until the first snapshot
   arrives, preventing visible blank states.
+- **UI:** Click overlay matches the screen refresh rate and starts transparent to
+  avoid the brief black flash.
 

--- a/src/views/about_view.py
+++ b/src/views/about_view.py
@@ -28,7 +28,7 @@ class AboutView(BaseView):
 
         info = info_label(
             container,
-            "CoolBox - A Modern Desktop App\nVersion 1.0.6",
+            "CoolBox - A Modern Desktop App\nVersion 1.0.7",
             font=self.font,
         )
         info.pack(anchor="w")

--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -26,14 +26,16 @@ from src.utils.window_utils import (
 )
 from src.utils.mouse_listener import capture_mouse, is_supported
 from src.utils.scoring_engine import ScoringEngine, tuning
+from src.utils import get_screen_refresh_rate
 
 DEFAULT_HIGHLIGHT = os.getenv("KILL_BY_CLICK_HIGHLIGHT", "red")
 
 # Allow the refresh interval to be configured via an environment
 # variable. Falling back to the tuning default keeps behaviour
 # consistent for tests while providing an easy knob for users.
+DEFAULT_INTERVAL = 1 / get_screen_refresh_rate()
 KILL_BY_CLICK_INTERVAL = float(
-    os.getenv("KILL_BY_CLICK_INTERVAL", str(tuning.interval))
+    os.getenv("KILL_BY_CLICK_INTERVAL", str(DEFAULT_INTERVAL))
 )
 
 
@@ -82,6 +84,11 @@ class ClickOverlay(tk.Toplevel):
         on_hover: Callable[[int | None, str | None], None] | None = None,
     ) -> None:
         super().__init__(parent)
+        # Start fully transparent to prevent a brief black flash
+        try:
+            self.attributes("-alpha", 0.0)
+        except Exception:
+            pass
         # Configure fullscreen before enabling override-redirect to avoid
         # "can't set fullscreen attribute" errors on some platforms.
         self.attributes("-topmost", True)
@@ -115,6 +122,11 @@ class ClickOverlay(tk.Toplevel):
             text="",
             font=("TkDefaultFont", 10, "bold"),
         )
+        # Fade in now that the window is fully configured
+        try:
+            self.attributes("-alpha", 1.0)
+        except Exception:
+            pass
         self.probe_attempts = probe_attempts
         self.timeout = timeout
         self.interval = interval

--- a/tests/test_click_overlay_fps.py
+++ b/tests/test_click_overlay_fps.py
@@ -1,0 +1,45 @@
+import os
+import unittest
+import tkinter as tk
+from unittest.mock import patch
+
+from src.views.click_overlay import ClickOverlay
+
+
+@unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+class TestClickOverlayFPS(unittest.TestCase):
+    def test_interval_uses_refresh_rate(self):
+        os.environ["COOLBOX_REFRESH_RATE"] = "75"
+        root = tk.Tk()
+        try:
+            with (
+                patch("src.views.click_overlay.is_supported", return_value=False),
+                patch("src.views.click_overlay.make_window_clickthrough", return_value=False),
+            ):
+                overlay = ClickOverlay(root)
+            self.assertAlmostEqual(overlay.interval, 1 / 75)
+            overlay.destroy()
+        finally:
+            os.environ.pop("COOLBOX_REFRESH_RATE", None)
+            root.destroy()
+
+    def test_interval_env_override(self):
+        os.environ["KILL_BY_CLICK_INTERVAL"] = "0.01"
+        root = tk.Tk()
+        try:
+            with (
+                patch("src.views.click_overlay.is_supported", return_value=False),
+                patch("src.views.click_overlay.make_window_clickthrough", return_value=False),
+            ):
+                overlay = ClickOverlay(root)
+            self.assertEqual(overlay.interval, 0.01)
+            overlay.destroy()
+        finally:
+            os.environ.pop("KILL_BY_CLICK_INTERVAL", None)
+            root.destroy()
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+


### PR DESCRIPTION
## Summary
- update about view version to 1.0.7
- adapt click overlay default refresh rate to screen
- start overlay transparent then fade in
- add tests covering click overlay fps
- document new overlay behaviour in CHANGELOG

## Testing
- `pytest -q tests/test_force_quit_fps.py tests/test_click_overlay_fps.py`

------
https://chatgpt.com/codex/tasks/task_e_688a6e30138c832b9c33b2ab45f26232