### PR TITLE
Improve click overlay initialization

### DIFF
--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -84,7 +84,8 @@ class ClickOverlay(tk.Toplevel):
         on_hover: Callable[[int | None, str | None], None] | None = None,
     ) -> None:
         super().__init__(parent)
-        # Start fully transparent to prevent a brief black flash
+        # Hide until fully configured to avoid a brief black flash
+        self.withdraw()
         try:
             self.attributes("-alpha", 0.0)
         except Exception:
@@ -124,6 +125,8 @@ class ClickOverlay(tk.Toplevel):
         )
         # Fade in now that the window is fully configured
         try:
+            self.update_idletasks()
+            self.deiconify()
             self.attributes("-alpha", 1.0)
         except Exception:
             pass

--- a/tests/test_click_overlay_fps.py
+++ b/tests/test_click_overlay_fps.py
@@ -41,5 +41,3 @@ class TestClickOverlayFPS(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-
-

--- a/tests/test_force_quit_fps.py
+++ b/tests/test_force_quit_fps.py
@@ -4,6 +4,7 @@ import unittest
 from src.app import CoolBoxApp
 from src.views.force_quit_dialog import ForceQuitDialog
 
+
 @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
 class TestForceQuitFPS(unittest.TestCase):
     def test_frame_delay_uses_refresh_rate(self):
@@ -29,6 +30,7 @@ class TestForceQuitFPS(unittest.TestCase):
         finally:
             os.environ.pop("FORCE_QUIT_FPS", None)
             app.destroy()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- avoid brief black flash by hiding click overlay until configured
- clean up test formatting

## Testing
- `pytest tests/test_click_overlay_fps.py tests/test_force_quit_fps.py -q`
- `flake8 src/views/click_overlay.py src/views/force_quit_dialog.py tests/test_force_quit_fps.py tests/test_click_overlay_fps.py`


------
https://chatgpt.com/codex/tasks/task_e_688a7460ff4c832b87f36cd17f82517d