### PR TITLE
Fix overlay transparency

### DIFF
--- a/src/views/about_view.py
+++ b/src/views/about_view.py
@@ -28,7 +28,7 @@ class AboutView(BaseView):
 
         info = info_label(
             container,
-            "CoolBox - A Modern Desktop App\nVersion 1.0.7",
+            "CoolBox - A Modern Desktop App\nVersion 1.0.8",
             font=self.font,
         )
         info.pack(anchor="w")

--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -22,6 +22,7 @@ from src.utils.window_utils import (
     list_windows_at,
     make_window_clickthrough,
     remove_window_clickthrough,
+    set_window_colorkey,
     WindowInfo,
 )
 from src.utils.mouse_listener import capture_mouse, is_supported
@@ -105,6 +106,8 @@ class ClickOverlay(tk.Toplevel):
 
         if is_supported():
             make_window_clickthrough(self)
+        else:
+            set_window_colorkey(self)
 
         # Using an empty string for the canvas background causes a TclError on
         # some platforms. Use the chosen background color so the canvas itself

--- a/tests/test_click_overlay.py
+++ b/tests/test_click_overlay.py
@@ -35,6 +35,19 @@ class TestClickOverlay(unittest.TestCase):
             root.destroy()
 
     @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_overlay_uses_transparent_color_key(self) -> None:
+        root = tk.Tk()
+        with patch("src.views.click_overlay.is_supported", return_value=False):
+            overlay = ClickOverlay(root)
+        try:
+            key = overlay.attributes("-transparentcolor")
+        except Exception:
+            key = None
+        self.assertEqual(key, overlay.cget("bg"))
+        overlay.destroy()
+        root.destroy()
+
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
     def test_click_falls_back_to_last_info(self) -> None:
         root = tk.Tk()
         with (


### PR DESCRIPTION
## Summary
- make click overlay transparent by default
- add helper for setting window colour key
- update version string
- test transparent colour key

## Testing
- `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics`
- `flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a7b61ebb0832bb2d2fe5c308248af