### PR TITLE
Fix overlay transparency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,4 +11,6 @@
   arrives, preventing visible blank states.
 - **UI:** Click overlay matches the screen refresh rate and starts transparent to
   avoid the brief black flash.
+- **Fix:** Click overlay sets a transparent color key even when using
+  click-through hooks so it's fully invisible on all platforms.
 

--- a/src/views/about_view.py
+++ b/src/views/about_view.py
@@ -28,7 +28,7 @@ class AboutView(BaseView):
 
         info = info_label(
             container,
-            "CoolBox - A Modern Desktop App\nVersion 1.0.8",
+            "CoolBox - A Modern Desktop App\nVersion 1.0.9",
             font=self.font,
         )
         info.pack(anchor="w")

--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -106,8 +106,10 @@ class ClickOverlay(tk.Toplevel):
 
         if is_supported():
             make_window_clickthrough(self)
-        else:
-            set_window_colorkey(self)
+
+        # Ensure the overlay background itself is invisible so only the
+        # drawn crosshair and rectangle remain visible.
+        set_window_colorkey(self)
 
         # Using an empty string for the canvas background causes a TclError on
         # some platforms. Use the chosen background color so the canvas itself

--- a/tests/test_click_overlay.py
+++ b/tests/test_click_overlay.py
@@ -48,6 +48,22 @@ class TestClickOverlay(unittest.TestCase):
         root.destroy()
 
     @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_overlay_uses_color_key_with_hooks(self) -> None:
+        root = tk.Tk()
+        with (
+            patch("src.views.click_overlay.is_supported", return_value=True),
+            patch("src.views.click_overlay.make_window_clickthrough", return_value=True),
+        ):
+            overlay = ClickOverlay(root)
+        try:
+            key = overlay.attributes("-transparentcolor")
+        except Exception:
+            key = None
+        self.assertEqual(key, overlay.cget("bg"))
+        overlay.destroy()
+        root.destroy()
+
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
     def test_click_falls_back_to_last_info(self) -> None:
         root = tk.Tk()
         with (


### PR DESCRIPTION
## Summary
- make sure click overlay sets a transparent color key even with mouse hooks
- bump version string to 1.0.9
- note fix in changelog
- test overlay color key usage with hooks

## Testing
- `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics`
- `flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics`
- `pytest tests/test_click_overlay.py::TestClickOverlay::test_overlay_uses_color_key_with_hooks -q`

------
https://chatgpt.com/codex/tasks/task_e_688a83c8c89c832b9720da98e615d8a0