### PR TITLE
Fix overlay transparency fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,4 +13,6 @@
   avoid the brief black flash.
 - **Fix:** Click overlay sets a transparent color key even when using
   click-through hooks so it's fully invisible on all platforms.
+- **Fix:** Overlay stays invisible when transparency isn't supported,
+  preventing a black fullscreen window.
 

--- a/src/views/about_view.py
+++ b/src/views/about_view.py
@@ -28,7 +28,7 @@ class AboutView(BaseView):
 
         info = info_label(
             container,
-            "CoolBox - A Modern Desktop App\nVersion 1.0.9",
+            "CoolBox - A Modern Desktop App\nVersion 1.0.10",
             font=self.font,
         )
         info.pack(anchor="w")

--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -107,9 +107,9 @@ class ClickOverlay(tk.Toplevel):
         if is_supported():
             make_window_clickthrough(self)
 
-        # Ensure the overlay background itself is invisible so only the
-        # drawn crosshair and rectangle remain visible.
-        set_window_colorkey(self)
+        # Apply a transparent color key so only the drawn crosshair remains
+        # visible. If this fails we'll keep the overlay fully transparent.
+        self._has_colorkey = set_window_colorkey(self)
 
         # Using an empty string for the canvas background causes a TclError on
         # some platforms. Use the chosen background color so the canvas itself
@@ -128,11 +128,14 @@ class ClickOverlay(tk.Toplevel):
             text="",
             font=("TkDefaultFont", 10, "bold"),
         )
-        # Fade in now that the window is fully configured
+        # Fade in now that the window is fully configured. If the color key
+        # could not be set keep the window fully transparent to avoid a black
+        # flash on platforms lacking this feature.
         try:
             self.update_idletasks()
             self.deiconify()
-            self.attributes("-alpha", 1.0)
+            if self._has_colorkey:
+                self.attributes("-alpha", 1.0)
         except Exception:
             pass
         self.probe_attempts = probe_attempts

--- a/tests/test_click_overlay.py
+++ b/tests/test_click_overlay.py
@@ -64,6 +64,22 @@ class TestClickOverlay(unittest.TestCase):
         root.destroy()
 
     @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_overlay_invisible_when_color_key_missing(self) -> None:
+        root = tk.Tk()
+        with (
+            patch("src.views.click_overlay.is_supported", return_value=False),
+            patch("src.views.click_overlay.set_window_colorkey", return_value=False),
+        ):
+            overlay = ClickOverlay(root)
+        try:
+            alpha = float(overlay.attributes("-alpha"))
+        except Exception:
+            alpha = 1.0
+        self.assertEqual(alpha, 0.0)
+        overlay.destroy()
+        root.destroy()
+
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
     def test_click_falls_back_to_last_info(self) -> None:
         root = tk.Tk()
         with (


### PR DESCRIPTION
## Summary
- keep click overlay hidden when color key can't be set
- bump version to 1.0.10
- document overlay transparency fallback
- test alpha value when color key fails

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a88e9d4f4832bbd4986f868070f6b