### PR TITLE
perf: cache transparent color normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,3 +37,19 @@
 - **Fix:** Normalize overlay background colors to hex so the transparent color
   key is honored, avoiding a persistent black overlay.
 
+## 1.0.15 - 2025-07-31
+
+- **Fix:** Accept uppercase transparent color keys so the click overlay
+  remains visible on platforms that canonicalize colour values.
+
+## 1.0.16 - 2025-07-31
+
+- **Fix:** Canonicalize transparent color keys to hex, keeping the overlay
+  visible even when the system returns shorthand codes.
+
+## 1.0.17 - 2025-07-31
+
+- **Perf:** Cache normalized colors to avoid repeated conversions.
+- **Fix:** Parse hex color strings without consulting Tk, ensuring reliable
+  transparent color keys.
+

--- a/src/views/about_view.py
+++ b/src/views/about_view.py
@@ -28,7 +28,7 @@ class AboutView(BaseView):
 
         info = info_label(
             container,
-            "CoolBox - A Modern Desktop App\nVersion 1.0.14",
+            "CoolBox - A Modern Desktop App\nVersion 1.0.17",
             font=self.font,
         )
         info.pack(anchor="w")


### PR DESCRIPTION
## Summary
- cache normalized colors and parse hex strings without Tk for robust transparent keys
- test system color names to ensure colorkey stability
- bump version to 1.0.17

## Testing
- `flake8 src/views/click_overlay.py src/views/about_view.py tests/test_click_overlay.py`
- `COOLBOX_LIGHTWEIGHT=1 pytest tests/test_click_overlay.py::TestClickOverlay::test_overlay_accepts_uppercase_color_key tests/test_click_overlay.py::TestClickOverlay::test_overlay_accepts_shorthand_color_key tests/test_click_overlay.py::TestClickOverlay::test_overlay_normalizes_system_color_to_hex -q`

------
https://chatgpt.com/codex/tasks/task_e_688adca1b648832ba958e7c931bfdade