### PR TITLE
fix: show crosshair cursor in kill overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.0.18 - 2025-07-31
+
 - **Performance:** Kill-by-Click overlay no longer computes velocity and heat-map updates in the mouse hook thread. Movement is buffered and processed on the Tkinter main loop, preventing input lag.
 - **Efficiency:** Heat-map decay is skipped when `KILL_BY_CLICK_HEATMAP_WEIGHT` is zero, avoiding unnecessary loops.
 - **Defaults:** Reduced window probe attempts from 5 to 3 for faster detection.
@@ -15,6 +17,7 @@
   click-through hooks so it's fully invisible on all platforms.
 - **Fix:** Overlay stays invisible when transparency isn't supported,
   preventing a black fullscreen window.
+- **Fix:** Overlay canvas now uses a crosshair cursor so the pointer remains visible during Kill by Click.
 
 ## 1.0.11 - 2025-07-30
 

--- a/src/views/about_view.py
+++ b/src/views/about_view.py
@@ -28,7 +28,7 @@ class AboutView(BaseView):
 
         info = info_label(
             container,
-            "CoolBox - A Modern Desktop App\nVersion 1.0.17",
+            "CoolBox - A Modern Desktop App\nVersion 1.0.18",
             font=self.font,
         )
         info.pack(anchor="w")

--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -158,7 +158,9 @@ class ClickOverlay(tk.Toplevel):
         # Using an empty string for the canvas background causes a TclError on
         # some platforms. Use the chosen background color so the canvas itself
         # becomes transparent via the color key.
-        self.canvas = tk.Canvas(self, bg=self._bg_color, highlightthickness=0)
+        self.canvas = tk.Canvas(
+            self, bg=self._bg_color, highlightthickness=0, cursor="crosshair"
+        )
         self.canvas.pack(fill="both", expand=True)
         self.rect = self.canvas.create_rectangle(0, 0, 1, 1, outline=highlight, width=2)
         # crosshair lines spanning the entire screen for precise selection

--- a/tests/test_click_overlay.py
+++ b/tests/test_click_overlay.py
@@ -94,6 +94,16 @@ class TestClickOverlay(unittest.TestCase):
         root.destroy()
 
     @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_overlay_uses_crosshair_cursor(self) -> None:
+        root = tk.Tk()
+        with patch("src.views.click_overlay.is_supported", return_value=False):
+            overlay = ClickOverlay(root)
+        cursor = overlay.canvas.cget("cursor")
+        self.assertEqual(cursor, "crosshair")
+        overlay.destroy()
+        root.destroy()
+
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
     def test_overlay_invisible_when_color_key_missing(self) -> None:
         root = tk.Tk()
         with (


### PR DESCRIPTION
## Summary
- ensure Kill by Click overlay keeps the cursor visible by setting crosshair cursor on the canvas
- add regression test for crosshair cursor
- bump version to 1.0.18 and document changes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688ae62d6580832b9b47fa1279946bea