### PR TITLE
fix: raise kill-by-click overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 1.0.19 - 2025-08-01
+
+- **Fix:** Kill-by-Click overlay now raises itself to ensure the crosshair
+  is visible immediately.
+
 ## 1.0.18 - 2025-07-31
 
 - **Performance:** Kill-by-Click overlay no longer computes velocity and heat-map updates in the mouse hook thread. Movement is buffered and processed on the Tkinter main loop, preventing input lag.

--- a/src/views/about_view.py
+++ b/src/views/about_view.py
@@ -28,7 +28,7 @@ class AboutView(BaseView):
 
         info = info_label(
             container,
-            "CoolBox - A Modern Desktop App\nVersion 1.0.18",
+            "CoolBox - A Modern Desktop App\nVersion 1.0.19",
             font=self.font,
         )
         info.pack(anchor="w")

--- a/src/views/force_quit_dialog.py
+++ b/src/views/force_quit_dialog.py
@@ -2116,6 +2116,7 @@ class ForceQuitDialog(BaseDialog):
         try:
             overlay.update_idletasks()
             overlay.wait_visibility()
+            overlay.lift()
         except Exception:
             pass
         try:


### PR DESCRIPTION
## Summary
- ensure kill-by-click overlay lifts itself so crosshair always shows
- bump version to 1.0.19

## Testing
- `pytest tests/test_force_quit.py::TestForceQuit::test_kill_by_click_pauses_watcher tests/test_kill_by_click_cli.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688aef4bdcec832bbc6c9d884fe554a4