### PR TITLE
feat: throttle colorkey checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 1.0.21 - 2025-08-03
+
+- **Perf:** Click overlay revalidates its transparent color key periodically
+  instead of on every update, avoiding redundant system calls.
+
 ## 1.0.20 - 2025-08-02
 
 - **Fix:** Click overlay uses a semi-transparent fallback and warns when the

--- a/src/views/about_view.py
+++ b/src/views/about_view.py
@@ -28,7 +28,7 @@ class AboutView(BaseView):
 
         info = info_label(
             container,
-            "CoolBox - A Modern Desktop App\nVersion 1.0.20",
+            "CoolBox - A Modern Desktop App\nVersion 1.0.21",
             font=self.font,
         )
         info.pack(anchor="w")


### PR DESCRIPTION
## Summary
- throttle transparency colorkey validation to only run periodically or on relevant changes
- bump to version 1.0.21
- test throttled colorkey revalidation

## Testing
- `pytest tests/test_click_overlay.py::TestClickOverlay::test_overlay_visible_when_color_key_missing tests/test_click_overlay.py::TestClickOverlay::test_colorkey_revalidation_throttled -q`


------
https://chatgpt.com/codex/tasks/task_e_688bd38c16c0832bac3585956e95cdbc