### PR TITLE
feat: cache x11 connection for window queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.25 - 2025-08-06
+
+- **Feat:** Direct X11 queries replace subprocess calls for Linux window lookup with cached fallback.
+
 ## 1.0.24 - 2025-08-05
 
 - **Perf:** Click overlay records frame durations and adjusts refresh delay based on average frame cost.

--- a/src/views/about_view.py
+++ b/src/views/about_view.py
@@ -28,7 +28,7 @@ class AboutView(BaseView):
 
         info = info_label(
             container,
-            "CoolBox - A Modern Desktop App\nVersion 1.0.24",
+            "CoolBox - A Modern Desktop App\nVersion 1.0.25",
             font=self.font,
         )
         info.pack(anchor="w")

--- a/tests/test_window_utils.py
+++ b/tests/test_window_utils.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest import mock
 
 from src.utils.window_utils import (
     WindowInfo,
@@ -31,6 +32,19 @@ class TestWindowUtils(unittest.TestCase):
         self.assertIsInstance(wins, list)
         for info in wins:
             self.assertIsInstance(info, WindowInfo)
+
+    def test_x11_shortcuts(self):
+        from src.utils import window_utils as wu
+
+        fake = WindowInfo(1, (0, 0, 10, 10), "t")
+        pointer = type("P", (), {"root_x": 5, "root_y": 6})()
+
+        with mock.patch.object(wu, "_X_DISPLAY", object()), \
+            mock.patch.object(wu, "_X_ROOT", mock.Mock(query_pointer=lambda: pointer)), \
+            mock.patch.object(wu, "_list_windows_x11", return_value=[fake]):
+            self.assertEqual(get_window_under_cursor(), fake)
+            self.assertEqual(wu.get_window_at(5, 6), fake)
+            self.assertEqual(wu.list_windows_at(5, 6), [fake])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- use persistent X11 display to query window at cursor or coordinates
- test X11 path and update app version to 1.0.25

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688be5468b08832b86ea2e91204bfe28