### PR TITLE
perf: skip colorkey check during overlay updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 1.0.29 - 2025-08-08
+
+- **Perf:** Revalidate the transparent color key only during initialization or
+  when the background changes, reducing per-frame overhead.
+
 ## 1.0.28 - 2025-08-08
 
 - **Perf:** Cache X11 window enumeration to avoid per-frame process launches.

--- a/src/views/about_view.py
+++ b/src/views/about_view.py
@@ -28,7 +28,7 @@ class AboutView(BaseView):
 
         info = info_label(
             container,
-            "CoolBox - A Modern Desktop App\nVersion 1.0.28",
+            "CoolBox - A Modern Desktop App\nVersion 1.0.29",
             font=self.font,
         )
         info.pack(anchor="w")

--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -300,6 +300,17 @@ class ClickOverlay(tk.Toplevel):
         # Cache for window enumeration to minimize repeated list_windows_at calls
         self._window_cache_pos: tuple[int, int] | None = None
         self._window_cache: list[WindowInfo] = []
+    def configure(self, cnf=None, **kw):  # type: ignore[override]
+        """Configure widget options and reapply transparency on bg changes."""
+        result = super().configure(cnf or {}, **kw)
+        bg = kw.get("bg") or kw.get("background")
+        if bg is not None:
+            self._bg_color = _normalize_color(self, bg)
+            self._maybe_ensure_colorkey(force=True)
+        return result
+
+    config = configure
+
     def _worker_loop(self) -> None:
         """Process queued scoring tasks in a background thread."""
         while True:
@@ -627,7 +638,6 @@ class ClickOverlay(tk.Toplevel):
         return info
 
     def _update_rect(self, info: WindowInfo | None = None) -> None:
-        self._maybe_ensure_colorkey()
         if info is None:
             info = self._query_window()
         if not getattr(self, "_raised", False):

--- a/tests/test_click_overlay.py
+++ b/tests/test_click_overlay.py
@@ -191,6 +191,32 @@ class TestClickOverlay(unittest.TestCase):
             root.destroy()
 
     @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_update_rect_skips_colorkey_check(self) -> None:
+        root = tk.Tk()
+        with patch("src.views.click_overlay.is_supported", return_value=False):
+            overlay = ClickOverlay(root)
+        try:
+            with patch.object(overlay, "_maybe_ensure_colorkey") as mock:
+                overlay._update_rect(WindowInfo(None))
+                mock.assert_not_called()
+        finally:
+            overlay.destroy()
+            root.destroy()
+
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_configure_bg_triggers_colorkey(self) -> None:
+        root = tk.Tk()
+        with patch("src.views.click_overlay.is_supported", return_value=False):
+            overlay = ClickOverlay(root)
+        try:
+            with patch.object(overlay, "_maybe_ensure_colorkey") as mock:
+                overlay.configure(bg="#123456")
+                mock.assert_called_once()
+        finally:
+            overlay.destroy()
+            root.destroy()
+
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
     def test_overlay_accepts_shorthand_color_key(self) -> None:
         root = tk.Tk()
         root.configure(bg="white")


### PR DESCRIPTION
## Summary
- optimize click overlay: only refresh transparency colorkey on init or bg changes
- document optimization in changelog and bump version

## Testing
- `pytest tests/test_click_overlay.py::TestClickOverlay::test_update_rect_skips_colorkey_check -q`
- `pytest tests/test_click_overlay.py::TestClickOverlay::test_configure_bg_triggers_colorkey -q`
- `pytest tests/test_click_overlay.py::TestClickOverlay::test_colorkey_revalidation_throttled -q`


------
https://chatgpt.com/codex/tasks/task_e_688cb19eb908832bb9a7111c1cd67776