### PR TITLE
feat(click_overlay): async window queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 1.0.30 - 2025-08-09
+
+- **Feat:** Offload window queries and scoring to a ``ThreadPoolExecutor`` to
+  keep the click overlay responsive.
+
 ## 1.0.29 - 2025-08-08
 
 - **Perf:** Revalidate the transparent color key only during initialization or

--- a/src/views/about_view.py
+++ b/src/views/about_view.py
@@ -28,7 +28,7 @@ class AboutView(BaseView):
 
         info = info_label(
             container,
-            "CoolBox - A Modern Desktop App\nVersion 1.0.29",
+            "CoolBox - A Modern Desktop App\nVersion 1.0.30",
             font=self.font,
         )
         info.pack(anchor="w")


### PR DESCRIPTION
## Summary
- offload window probing and scoring to a background ThreadPoolExecutor
- test threaded click overlay path
- bump version to 1.0.30

## Testing
- `pytest tests/test_click_overlay.py::TestClickOverlay::test_click_falls_back_to_last_info -q`
- `pytest tests/test_click_overlay.py::TestClickOverlay::test_click_refreshes_window_info -q`
- `pytest tests/test_click_overlay.py::TestClickOverlay::test_crosshair_lines_follow_cursor -q`
- `pytest tests/test_click_overlay.py::TestClickOverlay::test_update_rect_async_uses_worker -q`


------
https://chatgpt.com/codex/tasks/task_e_688cb3eab204832bad2aefde2e2b0f84