### PR TITLE
fix: refine click overlay hover logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.31 - 2025-08-09
+
+- **Fix:** Smooth kill-by-click overlay by avoiding repeated transparency warnings and redundant hover callbacks.
+
 ## 1.0.30 - 2025-08-09
 
 - **Feat:** Offload window queries and scoring to a ``ThreadPoolExecutor`` to

--- a/src/views/about_view.py
+++ b/src/views/about_view.py
@@ -28,7 +28,7 @@ class AboutView(BaseView):
 
         info = info_label(
             container,
-            "CoolBox - A Modern Desktop App\nVersion 1.0.30",
+            "CoolBox - A Modern Desktop App\nVersion 1.0.31",
             font=self.font,
         )
         info.pack(anchor="w")

--- a/tests/test_click_overlay.py
+++ b/tests/test_click_overlay.py
@@ -1353,6 +1353,28 @@ class TestClickOverlay(unittest.TestCase):
         root.destroy()
 
     @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_on_hover_not_called_when_window_unchanged(self) -> None:
+        root = tk.Tk()
+        calls: list[tuple[int | None, str | None]] = []
+        with patch("src.views.click_overlay.is_supported", return_value=False):
+            overlay = ClickOverlay(
+                root, on_hover=lambda pid, title: calls.append((pid, title))
+            )
+
+        overlay._cursor_x = 1
+        overlay._cursor_y = 1
+        info = WindowInfo(5, (0, 0, 5, 5), "foo")
+        overlay._update_rect(info)
+        overlay._cursor_x = 2
+        overlay._cursor_y = 2
+        overlay._update_rect(info)
+
+        self.assertEqual(calls, [(5, "foo")])
+
+        overlay.destroy()
+        root.destroy()
+
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
     def test_tracker_add_runs_off_thread(self) -> None:
         root = tk.Tk()
         with patch("src.views.click_overlay.is_supported", return_value=False):


### PR DESCRIPTION
## Summary
- avoid repeated transparency fallback warnings in click overlay
- trigger hover callbacks only when hovered window changes
- document fix and bump version to 1.0.31

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688cbc1a97d8832bab9e5f6b1416b676