### PR TITLE
fix: initialize overlay colorkey state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 1.0.32 - 2025-08-09
+
+- **Fix:** Initialize color key tracking before configuring the click overlay
+  to prevent missing attribute errors during setup.
+
 ## 1.0.31 - 2025-08-09
 
 - **Fix:** Smooth kill-by-click overlay by avoiding repeated transparency warnings and redundant hover callbacks.

--- a/src/views/about_view.py
+++ b/src/views/about_view.py
@@ -28,7 +28,7 @@ class AboutView(BaseView):
 
         info = info_label(
             container,
-            "CoolBox - A Modern Desktop App\nVersion 1.0.31",
+            "CoolBox - A Modern Desktop App\nVersion 1.0.32",
             font=self.font,
         )
         info.pack(anchor="w")

--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -156,18 +156,19 @@ class ClickOverlay(tk.Toplevel):
             except Exception:
                 pass
         self._bg_color = _normalize_color(self, bg_color)
-        self.configure(bg=self._bg_color)
-
-        if is_supported():
-            make_window_clickthrough(self)
-        # Keep track of whether the transparent color key is active. This is
-        # validated and restored as needed to avoid a fullscreen black window
-        # if the system drops support for the color key.
+        # Initialize color key tracking before configuring the widget so that
+        # ``configure`` can safely call ``_maybe_ensure_colorkey``.
         self._has_colorkey = False
         self._colorkey_warning_shown = False
         self._colorkey_last_check = 0.0
         self._colorkey_last_key = ""
         self._colorkey_last_bg = self._bg_color
+        self.configure(bg=self._bg_color)
+
+        if is_supported():
+            make_window_clickthrough(self)
+        # Validate and restore the transparent color key to avoid a fullscreen
+        # black window if the system drops support.
         self._maybe_ensure_colorkey(force=True)
 
         # Using an empty string for the canvas background causes a TclError on

--- a/tests/test_click_overlay.py
+++ b/tests/test_click_overlay.py
@@ -30,6 +30,15 @@ class TestClickOverlay(unittest.TestCase):
         root.destroy()
 
     @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_colorkey_attributes_initialized(self) -> None:
+        root = tk.Tk()
+        with patch("src.views.click_overlay.is_supported", return_value=False):
+            overlay = ClickOverlay(root)
+        self.assertFalse(overlay._colorkey_warning_shown)
+        overlay.destroy()
+        root.destroy()
+
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
     def test_env_sets_default_highlight(self) -> None:
         with patch.dict(os.environ, {"KILL_BY_CLICK_HIGHLIGHT": "green"}):
             root = tk.Tk()


### PR DESCRIPTION
## Summary
- guard click overlay initialization by setting color key tracking before configuring the window
- bump app version to 1.0.32 and document the fix
- add regression test for color key attribute setup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ccf646864832b9589b01f4fe99161