### PR TITLE
fix: refresh kill-by-click window selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.33 - 2025-08-09
+
+- **Fix:** Re-probe the window when the cursor moves so kill-by-click highlights the correct program.
+
 ## 1.0.32 - 2025-08-09
 
 - **Fix:** Initialize color key tracking before configuring the click overlay

--- a/src/views/about_view.py
+++ b/src/views/about_view.py
@@ -28,7 +28,7 @@ class AboutView(BaseView):
 
         info = info_label(
             container,
-            "CoolBox - A Modern Desktop App\nVersion 1.0.32",
+            "CoolBox - A Modern Desktop App\nVersion 1.0.33",
             font=self.font,
         )
         info.pack(anchor="w")

--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -249,6 +249,7 @@ class ClickOverlay(tk.Toplevel):
         self.title_text: str | None = None
         self._last_info: WindowInfo | None = None
         self._cached_info: WindowInfo | None = None
+        self._cached_pos: tuple[int, int] | None = None
         self._screen_w = self.winfo_screenwidth()
         self._screen_h = self.winfo_screenheight()
         self.engine = ScoringEngine(
@@ -612,6 +613,7 @@ class ClickOverlay(tk.Toplevel):
             and self._cached_info is not None
             and best.pid == self._cached_info.pid
             and ratio >= tuning.confidence_ratio
+            and self._cached_pos == (x, y)
         ):
             return self._cached_info
 
@@ -626,6 +628,7 @@ class ClickOverlay(tk.Toplevel):
                     remove_window_clickthrough(self)
 
         self._cached_info = info
+        self._cached_pos = (x, y)
         if info.pid is None:
             return self._last_info or WindowInfo(None)
         if info.pid == self._own_pid:

--- a/tests/test_click_overlay.py
+++ b/tests/test_click_overlay.py
@@ -491,6 +491,7 @@ class TestClickOverlay(unittest.TestCase):
         overlay.state = OverlayState.HOOKED
         cached = WindowInfo(7, (0, 0, 5, 5), "cached")
         overlay._cached_info = cached
+        overlay._cached_pos = (0, 0)
 
         with (
             patch.object(
@@ -516,6 +517,7 @@ class TestClickOverlay(unittest.TestCase):
         overlay.state = OverlayState.HOOKED
         cached = WindowInfo(7, (0, 0, 5, 5), "cached")
         overlay._cached_info = cached
+        overlay._cached_pos = (0, 0)
 
         new_info = WindowInfo(8, (0, 0, 5, 5), "new")
         with (
@@ -528,6 +530,34 @@ class TestClickOverlay(unittest.TestCase):
         ):
             info = overlay._query_window_at(0, 0)
             probe.assert_called_once()
+        self.assertEqual(info.pid, 8)
+
+        overlay.destroy()
+        root.destroy()
+
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_query_reprobes_when_position_changes(self) -> None:
+        root = tk.Tk()
+        with patch("src.views.click_overlay.is_supported", return_value=False):
+            overlay = ClickOverlay(root)
+
+        overlay.state = OverlayState.HOOKED
+        cached = WindowInfo(7, (0, 0, 5, 5), "cached")
+        overlay._cached_info = cached
+        overlay._cached_pos = (0, 0)
+
+        new_info = WindowInfo(8, (0, 0, 5, 5), "new")
+        with (
+            patch.object(
+                overlay.engine.tracker,
+                "best_with_confidence",
+                return_value=(cached, overlay.engine.tuning.confidence_ratio + 1),
+            ),
+            patch.object(overlay, "_probe_point", return_value=new_info) as probe,
+        ):
+            info = overlay._query_window_at(10, 10)
+            probe.assert_called_once()
+
         self.assertEqual(info.pid, 8)
 
         overlay.destroy()


### PR DESCRIPTION
## Summary
- ensure click overlay re-queries window when cursor moves, preventing stale selection
- document fix and bump version to 1.0.33
- cover cursor-change behavior with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cda2eaae8832bbd247b58acab2110