### PR TITLE
perf: make rainbow border stop instantly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.34 - 2025-08-09
+
+- **Perf:** Use event-based waiting in rainbow borders so animations stop without delay.
+
 ## 1.0.33 - 2025-08-09
 
 - **Fix:** Clear cached window info on cursor movement so the kill overlay

--- a/src/utils/rainbow.py
+++ b/src/utils/rainbow.py
@@ -4,7 +4,6 @@ import math
 
 import shutil
 import threading
-import time
 from typing import Iterable, Tuple
 
 try:
@@ -96,8 +95,8 @@ class RainbowBorder:
         offset = 0
         while not self._stop.is_set():
             self._draw(offset)
-            time.sleep(self.speed)
             offset += 1
+            self._stop.wait(self.speed)
 
     def _draw(self, offset: int) -> None:
         width, height = shutil.get_terminal_size(fallback=(80, 24))
@@ -194,6 +193,6 @@ class NeonPulseBorder(RainbowBorder):
             width, height = shutil.get_terminal_size(fallback=(80, 24))
             self.colors = self._generate_colors(width, height)
             self._draw(offset)
-            time.sleep(self.speed)
             self._phase += 0.05
             offset += 1
+            self._stop.wait(self.speed)

--- a/src/views/about_view.py
+++ b/src/views/about_view.py
@@ -28,7 +28,7 @@ class AboutView(BaseView):
 
         info = info_label(
             container,
-            "CoolBox - A Modern Desktop App\nVersion 1.0.33",
+            "CoolBox - A Modern Desktop App\nVersion 1.0.34",
             font=self.font,
         )
         info.pack(anchor="w")

--- a/tests/test_rainbow.py
+++ b/tests/test_rainbow.py
@@ -1,4 +1,6 @@
-from src.utils.rainbow import NeonPulseBorder
+import time
+
+from src.utils.rainbow import NeonPulseBorder, RainbowBorder
 
 
 def test_generate_colors_changes_with_phase():
@@ -15,3 +17,12 @@ def test_single_color_when_no_highlight():
     b = NeonPulseBorder(base_color="#123456", highlight_color="#123456")
     colors = b._generate_colors(8, 4)
     assert len(set(colors)) == 1
+
+
+def test_stop_returns_quickly():
+    b = RainbowBorder(speed=0.5)
+    b.start()
+    time.sleep(0.05)
+    start = time.perf_counter()
+    b.stop()
+    assert time.perf_counter() - start < 0.25


### PR DESCRIPTION
## Summary
- avoid sleep in rainbow border loops so stop reacts immediately
- verify border threads stop promptly
- bump version to 1.0.34

## Testing
- `COOLBOX_LIGHTWEIGHT=1 pytest`


------
https://chatgpt.com/codex/tasks/task_e_688d25490d90832b8073aee8a93c9b09