### PR TITLE
perf: double kill overlay refresh rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.35 - 2025-08-11
+
+- **Perf:** Halve kill-by-click refresh interval for smoother window switching.
+
 ## 1.0.34 - 2025-08-10
 
 - **Perf:** Avoid blocking when gathering CPU metrics to keep the UI responsive.

--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ A modern, feature-rich desktop application built with Python and CustomTkinter.
   mouse events while polling the window under the cursor at ``KILL_BY_CLICK_INTERVAL``
   and tracks pointer coordinates from hook callbacks or motion events to keep
   updates smooth without flicker. Set ``KILL_BY_CLICK_INTERVAL`` to control the
-  base refresh rate (defaults to ``0.016`` seconds) or pass ``--interval`` when using
+  base refresh rate (defaults to ``0.008`` seconds) or pass ``--interval`` when using
   ``scripts/kill_by_click.py``. The refresh interval expands and contracts
-  between ``KILL_BY_CLICK_MIN_INTERVAL`` (``0.008`` seconds) and
-  ``KILL_BY_CLICK_MAX_INTERVAL`` (``0.033`` seconds) using an exponential curve
+  between ``KILL_BY_CLICK_MIN_INTERVAL`` (``0.004`` seconds) and
+  ``KILL_BY_CLICK_MAX_INTERVAL`` (``0.016`` seconds) using an exponential curve
   tied to pointer velocity. ``KILL_BY_CLICK_DELAY_SCALE`` controls how strongly
   speed influences this interval. Fast motion shortens the delay for responsive
   tracking while slower movement stretches it to conserve CPU. The window's normal interaction state is restored automatically when the overlay closes. The Force Quit dialog uses this overlay when you choose *Kill by Click* and falls back to the window under the cursor if no PID is detected. Set ``FORCE_QUIT_CLICK_SKIP_CONFIRM=1`` to skip the termination prompt. The overlay samples the window

--- a/src/utils/scoring_engine.py
+++ b/src/utils/scoring_engine.py
@@ -14,22 +14,19 @@ from .window_utils import WindowInfo, list_windows_at
 class Tuning:
     """Weight and scoring parameters loaded from environment variables."""
 
-    # Default overlay update interval in seconds. A higher frame rate keeps
-    # cursor tracking smooth so kill‑by‑click feels responsive. The previous
-    # 0.1s value updated at roughly 10 FPS which could appear choppy on fast
-    # movements. Using a 60 FPS baseline strikes a good balance between
-    # responsiveness and CPU usage while still allowing users to override via
-    # ``KILL_BY_CLICK_INTERVAL``.
-    interval: float = 1 / 60
+    # Default overlay update interval in seconds. Doubling the frame rate to
+    # 120 FPS keeps cursor tracking smooth while still allowing users to
+    # override via ``KILL_BY_CLICK_INTERVAL``.
+    interval: float = 1 / 120
     # Dynamic adjustment bounds for the overlay refresh delay.
     # The update interval scales between these values based on
     # cursor velocity so quick movements feel responsive while
     # idle periods use fewer resources.
-    # Allow the interval to scale between ~120 FPS and ~30 FPS based on cursor
+    # Allow the interval to scale between ~240 FPS and ~60 FPS based on cursor
     # velocity so rapid motion speeds up updates and idle periods slow down to
     # conserve resources.
-    min_interval: float = 1 / 120
-    max_interval: float = 1 / 30
+    min_interval: float = 1 / 240
+    max_interval: float = 1 / 60
     # Divisor controlling how strongly pointer speed compresses the overlay
     # refresh interval. Larger values make motion influence the delay more
     # gradually while smaller values cause faster updates during quick moves.

--- a/src/views/about_view.py
+++ b/src/views/about_view.py
@@ -28,7 +28,7 @@ class AboutView(BaseView):
 
         info = info_label(
             container,
-            "CoolBox - A Modern Desktop App\nVersion 1.0.34",
+            "CoolBox - A Modern Desktop App\nVersion 1.0.35",
             font=self.font,
         )
         info.pack(anchor="w")

--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -35,9 +35,10 @@ from src.utils.helpers import log
 DEFAULT_HIGHLIGHT = os.getenv("KILL_BY_CLICK_HIGHLIGHT", "red")
 
 # Allow the refresh interval to be configured via an environment
-# variable. Falling back to the tuning default keeps behaviour
-# consistent for tests while providing an easy knob for users.
-DEFAULT_INTERVAL = 1 / get_screen_refresh_rate()
+# variable. Falling back to half the screen refresh period keeps the
+# overlay snappy (120 FPS on a 60 Hz display) while providing an easy
+# knob for users.
+DEFAULT_INTERVAL = 1 / (get_screen_refresh_rate() * 2)
 KILL_BY_CLICK_INTERVAL = float(
     os.getenv("KILL_BY_CLICK_INTERVAL", str(DEFAULT_INTERVAL))
 )

--- a/tests/test_click_overlay_fps.py
+++ b/tests/test_click_overlay_fps.py
@@ -17,7 +17,7 @@ class TestClickOverlayFPS(unittest.TestCase):
                 patch("src.views.click_overlay.make_window_clickthrough", return_value=False),
             ):
                 overlay = ClickOverlay(root)
-            self.assertAlmostEqual(overlay.interval, 1 / 75)
+            self.assertAlmostEqual(overlay.interval, 1 / 150)
             overlay.destroy()
         finally:
             os.environ.pop("COOLBOX_REFRESH_RATE", None)


### PR DESCRIPTION
## Summary
- halve kill-by-click overlay interval to track windows faster
- document new defaults and bump version to 1.0.35

## Testing
- `COOLBOX_LIGHTWEIGHT=1 pytest tests/test_click_overlay_fps.py -q` *(skipped: No display available)*


------
https://chatgpt.com/codex/tasks/task_e_688d2a90cba0832ba63d14694e9f347f