### PR TITLE
perf: skip requery when cursor stays in window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 1.0.36 - 2025-08-12
+
+- **Perf:** Reuse cached window info when the cursor remains inside a window,
+  eliminating hover lag.
+
 ## 1.0.35 - 2025-08-11
 
 - **Perf:** Halve kill-by-click refresh interval for smoother window switching.


### PR DESCRIPTION
## Summary
- speed up Kill-by-Click overlay by reusing cached window info when the cursor stays within the same window
- document the improvement in the changelog
- add regression test for cached-window reuse

## Testing
- `flake8 src/views/click_overlay.py tests/test_click_overlay.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d325e0398832b8c9137ac526deb01