### PR TITLE
feat: async active window lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 1.0.37 - 2025-08-13
+
+- **Perf:** Query the active window asynchronously with caching so the click
+  overlay stays responsive.
+
 ## 1.0.36 - 2025-08-12
 
 - **Perf:** Reuse cached window info when the cursor remains inside a window,

--- a/src/views/about_view.py
+++ b/src/views/about_view.py
@@ -28,7 +28,7 @@ class AboutView(BaseView):
 
         info = info_label(
             container,
-            "CoolBox - A Modern Desktop App\nVersion 1.0.35",
+            "CoolBox - A Modern Desktop App\nVersion 1.0.37",
             font=self.font,
         )
         info.pack(anchor="w")


### PR DESCRIPTION
## Summary
- query active window asynchronously and throttle to avoid blocking the click overlay
- cache active window lookups in window_utils to reduce subprocess churn
- update overlay tests and bump version

## Testing
- `pytest tests/test_window_utils.py::TestWindowUtils::test_get_active_window tests/test_click_overlay.py::TestClickOverlay::test_active_window_query_async -q`

------
https://chatgpt.com/codex/tasks/task_e_688d37c18bac832b82ce484c9add5b69