### PR TITLE
perf: async window enumeration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 1.0.44 - 2025-08-19
+
+- **Perf:** Enumerate X11 windows on a background thread and serve cached
+  results immediately to keep overlays responsive.
+
 ## 1.0.43 - 2025-08-19
 
 - **Perf:** Cache active window PID on a background thread so overlay updates never block.

--- a/src/utils/scoring_engine.py
+++ b/src/utils/scoring_engine.py
@@ -7,7 +7,7 @@ from collections import deque
 from dataclasses import dataclass, fields
 from typing import Deque, Dict, List, Tuple
 
-from .window_utils import WindowInfo, list_windows_at
+from .window_utils import WindowInfo, list_windows_at, prime_window_cache
 
 
 @dataclass(slots=True)
@@ -212,6 +212,7 @@ class ScoringEngine:
             maxlen=tuning.active_history_size
         )
         self.heatmap = CursorHeatmap(width, height, tuning)
+        prime_window_cache()
 
     def score_samples(
         self,

--- a/src/views/about_view.py
+++ b/src/views/about_view.py
@@ -28,7 +28,7 @@ class AboutView(BaseView):
 
         info = info_label(
             container,
-            "CoolBox - A Modern Desktop App\nVersion 1.0.43",
+            "CoolBox - A Modern Desktop App\nVersion 1.0.44",
             font=self.font,
         )
         info.pack(anchor="w")

--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -24,6 +24,7 @@ from src.utils.window_utils import (
     get_window_at,
     get_window_under_cursor,
     list_windows_at,
+    prime_window_cache,
     make_window_clickthrough,
     remove_window_clickthrough,
     set_window_colorkey,
@@ -319,6 +320,7 @@ class ClickOverlay(tk.Toplevel):
         self._window_cache_rect: tuple[int, int, int, int] | None = None
         self._window_cache: list[WindowInfo] = []
         self._window_cache_time: float = 0.0
+        prime_window_cache()
 
 
     def configure(self, cnf=None, **kw):  # type: ignore[override]


### PR DESCRIPTION
## Summary
- enumerate X11 windows on a background thread and prime cache for immediate, non-blocking queries
- prime window cache from scoring engine and click overlay
- bump version to 1.0.44

## Testing
- `pytest tests/test_window_utils.py tests/test_click_overlay.py`


------
https://chatgpt.com/codex/tasks/task_e_688de0f5876c832b8304169f65809b7d