### PR TITLE
feat: cache X11 window lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 1.0.45 - 2025-08-20
+
+- **Perf:** Keep X11 window enumeration on a background thread and return
+  cached results immediately so overlays never block.
+
 ## 1.0.44 - 2025-08-19
 
 - **Perf:** Enumerate X11 windows on a background thread and serve cached

--- a/src/utils/scoring_engine.py
+++ b/src/utils/scoring_engine.py
@@ -303,6 +303,7 @@ class ScoringEngine:
                 weights[pid] = weights.get(pid, 0.0) + dur * self.tuning.duration_weight
 
         if self.tuning.zorder_weight:
+            prime_window_cache()
             stack = list_windows_at(int(cursor_x), int(cursor_y))
             for idx, info in enumerate(stack):
                 if info.pid is None:

--- a/src/views/about_view.py
+++ b/src/views/about_view.py
@@ -28,7 +28,7 @@ class AboutView(BaseView):
 
         info = info_label(
             container,
-            "CoolBox - A Modern Desktop App\nVersion 1.0.44",
+            "CoolBox - A Modern Desktop App\nVersion 1.0.45",
             font=self.font,
         )
         info.pack(anchor="w")

--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -647,6 +647,7 @@ class ClickOverlay(tk.Toplevel):
         else:
             top = get_window_under_cursor()
             if top.pid in (self._own_pid, None):
+                prime_window_cache()
                 wins = list_windows_at(x, y)
             else:
                 wins = [top]


### PR DESCRIPTION
## Summary
- cache X11 window enumeration on a background thread
- use cached window stack in scoring and overlay without blocking
- bump version to 1.0.45

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688de2cfbebc832b89953d84dceeff03