### PR TITLE
Use cached window enumeration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 1.0.48 - 2025-08-23
+
+- **Perf:** Use cached window lists for click overlay queries so enumeration never blocks.
+- **Test:** Assert window lookups finish under 50 ms with mocked subprocess calls.
+
 ## 1.0.47 - 2025-08-22
 
 - **Perf:** Enumerate windows in a background thread and update a shared

--- a/src/utils/window_utils.py
+++ b/src/utils/window_utils.py
@@ -446,7 +446,7 @@ def _fallback_list_windows_at(x: int, y: int) -> List[WindowInfo]:
     with _WINDOWS_LOCK:
         last = _WINDOWS_CACHE.get("time", 0.0)
         windows: List[WindowInfo] = list(_WINDOWS_CACHE.get("windows", []))
-    if now - last >= _WINDOWS_CACHE_SEC and not _WINDOWS_REFRESH.is_set():
+    if (now - last >= _WINDOWS_CACHE_SEC or not windows) and not _WINDOWS_REFRESH.is_set():
         _WINDOWS_REFRESH.set()
     results: List[WindowInfo] = []
     for win in windows:

--- a/src/views/about_view.py
+++ b/src/views/about_view.py
@@ -28,7 +28,7 @@ class AboutView(BaseView):
 
         info = info_label(
             container,
-            "CoolBox - A Modern Desktop App\nVersion 1.0.47",
+            "CoolBox - A Modern Desktop App\nVersion 1.0.48",
             font=self.font,
         )
         info.pack(anchor="w")

--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -316,6 +316,7 @@ class ClickOverlay(tk.Toplevel):
         self._window_cache_rect: tuple[int, int, int, int] | None = None
         self._window_cache: list[WindowInfo] = []
         self._window_cache_time: float = 0.0
+        # Warm the global window cache so probes reuse cached data.
         prime_window_cache()
 
 
@@ -646,7 +647,6 @@ class ClickOverlay(tk.Toplevel):
         else:
             top = get_window_under_cursor()
             if top.pid in (self._own_pid, None):
-                prime_window_cache()
                 wins = list_windows_at(x, y)
             else:
                 wins = [top]


### PR DESCRIPTION
## Summary
- refresh window cache asynchronously when empty or stale
- have the click overlay rely solely on cached window enumerations
- assert overlay lookups complete under 50 ms and document the change

## Testing
- `pytest tests/test_window_utils.py::TestWindowUtils::test_fallback_async_cache tests/test_click_overlay.py::TestClickOverlay::test_probe_point_caches_cursor_movement tests/test_click_overlay.py::TestClickOverlay::test_probe_point_async_refresh_fast -q`

------
https://chatgpt.com/codex/tasks/task_e_688ded97a3bc832b85303bfc6d5aa598