### PR TITLE
feat: improve overlay responsiveness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 1.0.52 - 2025-08-26
+
+- **Perf:** Reduce active window poll interval and movement threshold so the
+  kill-by-click overlay reacts faster when switching windows.
+
 ## 1.0.51 - 2025-08-25
 
 - **Perf:** Query active window in a background thread and cache results to

--- a/src/views/about_view.py
+++ b/src/views/about_view.py
@@ -28,7 +28,7 @@ class AboutView(BaseView):
 
         info = info_label(
             container,
-            "CoolBox - A Modern Desktop App\nVersion 1.0.51",
+            "CoolBox - A Modern Desktop App\nVersion 1.0.52",
             font=self.font,
         )
         info.pack(anchor="w")

--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -55,14 +55,15 @@ COLORKEY_RECHECK_MS = int(
 )
 
 # Interval between background active window polls in milliseconds
-# Use a relatively slow default to avoid hammering the window manager.
+# Lower the default to improve responsiveness when the active window changes.
 ACTIVE_QUERY_MS = int(
-    os.getenv("KILL_BY_CLICK_ACTIVE_QUERY_MS", "500")
+    os.getenv("KILL_BY_CLICK_ACTIVE_QUERY_MS", "100")
 )
 
 # Minimum cursor movement in pixels before forcing an active window refresh
+# Smaller movements now trigger refreshes sooner for snappier hovering.
 ACTIVE_QUERY_DELTA = int(
-    os.getenv("KILL_BY_CLICK_ACTIVE_QUERY_DELTA", "40")
+    os.getenv("KILL_BY_CLICK_ACTIVE_QUERY_DELTA", "10")
 )
 
 # Cache TTL for window probing in seconds

--- a/tests/test_click_overlay.py
+++ b/tests/test_click_overlay.py
@@ -1570,6 +1570,32 @@ class TestClickOverlay(unittest.TestCase):
         root.destroy()
 
     @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_active_window_query_on_movement(self) -> None:
+        root = tk.Tk()
+        with (
+            patch("src.views.click_overlay.is_supported", return_value=False),
+            patch("src.views.click_overlay.make_window_clickthrough", return_value=False),
+            patch("src.views.click_overlay.get_active_window", return_value=WindowInfo(1)) as mock_active,
+            patch("src.views.click_overlay.ACTIVE_QUERY_MS", 1000),
+            patch("src.views.click_overlay.ACTIVE_QUERY_DELTA", 10),
+            patch.object(ClickOverlay, "_update_rect", return_value=None),
+        ):
+            overlay = ClickOverlay(root, interval=0.01)
+            overlay._last_active_query = time.monotonic()
+            overlay._last_active_pos = (0, 0)
+            overlay._cursor_x = 0
+            overlay._cursor_y = 0
+            with (
+                patch.object(overlay, "winfo_pointerx", return_value=15),
+                patch.object(overlay, "winfo_pointery", return_value=0),
+            ):
+                overlay._process_update()
+            time.sleep(0.05)
+            self.assertEqual(mock_active.call_count, 1)
+            overlay.destroy()
+        root.destroy()
+
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
     def test_probe_point_caches_cursor_movement(self) -> None:
         root = tk.Tk()
         with patch("src.views.click_overlay.is_supported", return_value=False):


### PR DESCRIPTION
## Summary
- reduce active window polling interval and cursor movement threshold for snappier kill-by-click overlay
- document responsiveness boost and bump version to 1.0.52
- test active window lookup on small cursor movement

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688dfe223ddc832ba12f204185e2979e