### PR TITLE
perf: prime window cache on cursor move

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 1.0.52 - 2025-08-26
+
+- **Perf:** Prime window cache on cursor movement so the click overlay reacts
+  immediately when hovering new windows.
+
 ## 1.0.51 - 2025-08-25
 
 - **Perf:** Query active window in a background thread and cache results to

--- a/src/views/about_view.py
+++ b/src/views/about_view.py
@@ -28,7 +28,7 @@ class AboutView(BaseView):
 
         info = info_label(
             container,
-            "CoolBox - A Modern Desktop App\nVersion 1.0.51",
+            "CoolBox - A Modern Desktop App\nVersion 1.0.52",
             font=self.font,
         )
         info.pack(anchor="w")

--- a/tests/test_click_overlay.py
+++ b/tests/test_click_overlay.py
@@ -200,6 +200,22 @@ class TestClickOverlay(unittest.TestCase):
             root.destroy()
 
     @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_move_primes_window_cache(self) -> None:
+        root = tk.Tk()
+        with patch("src.views.click_overlay.is_supported", return_value=False):
+            overlay = ClickOverlay(root)
+        try:
+            overlay._window_cache_rect = (0, 0, 10, 10)
+            overlay._window_cache_time = time.monotonic()
+            overlay._pending_move = (50, 50, time.time())
+            with patch.object(overlay, "_refresh_window_cache") as mock_refresh:
+                overlay._handle_move()
+                mock_refresh.assert_called_once()
+        finally:
+            overlay.destroy()
+            root.destroy()
+
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
     def test_probe_point_async_refresh_fast(self) -> None:
         root = tk.Tk()
         from src.utils import window_utils as wu


### PR DESCRIPTION
## Summary
- prime window cache whenever cursor leaves cached region to avoid overlay lag
- test that cursor movement triggers cache refresh
- bump version to 1.0.52

## Testing
- `flake8 src/views/about_view.py src/views/click_overlay.py tests/test_click_overlay.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688dfe223ddc832ba12f204185e2979e