### PR TITLE
fix: avoid pointer lookup when hooks active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 1.0.53 - 2025-08-26
+
+- **Fix:** Skip Tk pointer lookups when hooks are active and fall back to polling
+  only when hooks are unavailable.
+
 ## 1.0.52 - 2025-08-26
 
 - **Perf:** Prime window cache on cursor movement so the click overlay reacts

--- a/src/views/about_view.py
+++ b/src/views/about_view.py
@@ -28,7 +28,7 @@ class AboutView(BaseView):
 
         info = info_label(
             container,
-            "CoolBox - A Modern Desktop App\nVersion 1.0.52",
+            "CoolBox - A Modern Desktop App\nVersion 1.0.53",
             font=self.font,
         )
         info.pack(anchor="w")

--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -517,12 +517,9 @@ class ClickOverlay(tk.Toplevel):
             self.engine.heatmap.update(_e.x_root, _e.y_root)
             self._cursor_x = _e.x_root
             self._cursor_y = _e.y_root
-        else:
-            try:
-                self._cursor_x = self.winfo_pointerx()
-                self._cursor_y = self.winfo_pointery()
-            except Exception:
-                pass
+        elif self.state is OverlayState.POLLING:
+            self._cursor_x = self.winfo_pointerx()
+            self._cursor_y = self.winfo_pointery()
         if self.update_state is UpdateState.IDLE:
             self.update_state = UpdateState.PENDING
             self.after_idle(self._process_update)
@@ -543,10 +540,10 @@ class ClickOverlay(tk.Toplevel):
 
     def _process_update(self) -> None:
         self.update_state = UpdateState.IDLE
-        try:
+        if self.state is OverlayState.POLLING:
             x = self.winfo_pointerx()
             y = self.winfo_pointery()
-        except Exception:
+        else:
             x = self._cursor_x
             y = self._cursor_y
         if x != self._cursor_x or y != self._cursor_y:


### PR DESCRIPTION
## Summary
- avoid Tk pointer lookups when hooks are active and poll only when unhooked
- bump version to 1.0.53

## Testing
- `pytest tests/test_click_overlay.py`


------
https://chatgpt.com/codex/tasks/task_e_688e4bf3cd64832b9190c2c811233380