### PR TITLE
refactor: share global mouse listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 1.0.55 - 2025-08-26
+
+- **Refactor:** Introduce a shared global mouse listener to reuse across
+  overlays and stop once on exit.
+
 ## 1.0.54 - 2025-08-26
 
 - **Refactor:** Share click overlay executor and shut it down on exit.

--- a/src/views/about_view.py
+++ b/src/views/about_view.py
@@ -28,7 +28,7 @@ class AboutView(BaseView):
 
         info = info_label(
             container,
-            "CoolBox - A Modern Desktop App\nVersion 1.0.54",
+            "CoolBox - A Modern Desktop App\nVersion 1.0.55",
             font=self.font,
         )
         info.pack(anchor="w")

--- a/tests/test_mouse_listener.py
+++ b/tests/test_mouse_listener.py
@@ -1,0 +1,44 @@
+from src.utils import mouse_listener
+
+
+def test_global_listener_singleton(monkeypatch):
+    events = {"start": 0, "stop": 0}
+
+    class DummyListener:
+        def __init__(self, on_move=None, on_click=None):
+            self.on_move = on_move
+            self.on_click = on_click
+            self._alive = False
+
+        def start(self):
+            self._alive = True
+            events["start"] += 1
+
+        def stop(self):
+            self._alive = False
+            events["stop"] += 1
+
+        def join(self):
+            pass
+
+        def is_alive(self):
+            return self._alive
+
+    class DummyMouse:
+        Listener = DummyListener
+
+    monkeypatch.setattr(mouse_listener, "mouse", DummyMouse)
+
+    listener = mouse_listener.get_global_listener()
+    assert listener is mouse_listener.get_global_listener()
+
+    assert listener.start()
+    assert events["start"] == 1
+
+    assert listener.start()
+    assert events["start"] == 1  # no new Listener started
+
+    listener.stop()
+    assert events["stop"] == 1
+    listener.stop()
+    assert events["stop"] == 1  # stop only once


### PR DESCRIPTION
## Summary
- expose a singleton `GlobalMouseListener` with start/stop helpers
- reuse the shared listener in `ClickOverlay`
- bump version to 1.0.55

## Testing
- `pytest tests/test_mouse_listener.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688e5090123c832b98ef0d8244fe4f5d