### PR TITLE
feat: add active window callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.56 - 2025-08-26
+
+- **Feat:** Use foreground window callbacks to track active window without polling.
+
 ## 1.0.55 - 2025-08-26
 
 - **Refactor:** Introduce a shared global mouse listener to reuse across

--- a/src/views/about_view.py
+++ b/src/views/about_view.py
@@ -28,7 +28,7 @@ class AboutView(BaseView):
 
         info = info_label(
             container,
-            "CoolBox - A Modern Desktop App\nVersion 1.0.55",
+            "CoolBox - A Modern Desktop App\nVersion 1.0.56",
             font=self.font,
         )
         info.pack(anchor="w")


### PR DESCRIPTION
## Summary
- add cross-platform active window subscription API using event hooks
- update click overlay to track active window via callbacks instead of polling
- bump version to 1.0.56

## Testing
- `flake8 src/utils/window_utils.py src/views/about_view.py src/views/click_overlay.py tests/test_click_overlay.py tests/test_window_utils.py`
- `pytest tests/test_window_utils.py tests/test_click_overlay.py`


------
https://chatgpt.com/codex/tasks/task_e_688e55166ab0832b9294e1a3d7bf01f9