### PR TITLE
perf: prime window cache from Force Quit dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.58 - 2025-08-26
+
+- **Perf:** Prime window cache in Force Quit dialog and remove redundant overlay warm-up.
+
 ## 1.0.57 - 2025-08-02
 
 - **Refactor:** Reuse a persistent click-to-kill overlay within the Force Quit dialog.

--- a/src/views/about_view.py
+++ b/src/views/about_view.py
@@ -28,7 +28,7 @@ class AboutView(BaseView):
 
         info = info_label(
             container,
-            "CoolBox - A Modern Desktop App\nVersion 1.0.57",
+            "CoolBox - A Modern Desktop App\nVersion 1.0.58",
             font=self.font,
         )
         info.pack(anchor="w")

--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -24,7 +24,6 @@ from src.utils.window_utils import (
     get_window_at,
     get_window_under_cursor,
     list_windows_at,
-    prime_window_cache,
     make_window_clickthrough,
     remove_window_clickthrough,
     set_window_colorkey,
@@ -316,10 +315,7 @@ class ClickOverlay(tk.Toplevel):
         self._window_cache: list[WindowInfo] = []
         self._window_cache_time: float = 0.0
         self._window_cache_future: Future[list[WindowInfo]] | None = None
-        # Warm the global window cache so probes reuse cached data.
-        prime_window_cache()
         self.reset()
-
 
     def configure(self, cnf=None, **kw):  # type: ignore[override]
         """Configure widget options and reapply transparency on bg changes."""

--- a/src/views/force_quit_dialog.py
+++ b/src/views/force_quit_dialog.py
@@ -11,6 +11,7 @@ from src.utils.window_utils import (
     get_window_under_cursor,
     has_active_window_support,
     has_cursor_window_support,
+    prime_window_cache,
 )
 from src.utils.kill_utils import kill_process, kill_process_tree
 from src.utils import get_screen_refresh_rate
@@ -872,6 +873,7 @@ class ForceQuitDialog(BaseDialog):
 
         from .click_overlay import ClickOverlay
 
+        prime_window_cache()
         self._overlay = ClickOverlay(self)
         self._overlay.reset()
 

--- a/tests/test_force_quit_cache.py
+++ b/tests/test_force_quit_cache.py
@@ -1,0 +1,44 @@
+import os
+import tkinter as tk
+import unittest
+from unittest import mock
+
+from src.views.force_quit_dialog import ForceQuitDialog
+
+
+@unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+class TestForceQuitCache(unittest.TestCase):
+    def test_primes_window_cache_once(self) -> None:
+        class DummyApp:
+            def __init__(self) -> None:
+                self.window = tk.Tk()
+                self.config = {}
+
+            def register_dialog(self, dialog) -> None:
+                pass
+
+            def unregister_dialog(self, dialog) -> None:
+                pass
+
+            def get_icon_photo(self):
+                return None
+
+        app = DummyApp()
+        with (
+            mock.patch("src.views.force_quit_dialog.prime_window_cache") as prime_mock,
+            mock.patch("src.utils.window_utils.prime_window_cache", prime_mock),
+            mock.patch(
+                "src.views.click_overlay.prime_window_cache", prime_mock, create=True
+            ),
+            mock.patch("src.views.click_overlay.ClickOverlay"),
+            mock.patch.object(ForceQuitDialog, "_auto_refresh"),
+        ):
+            dialog = ForceQuitDialog(app)
+            dialog.destroy()
+            app.window.destroy()
+        prime_mock.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- prime the window cache when opening the Force Quit dialog
- drop redundant overlay cache warming
- bump version to 1.0.58

## Testing
- `pytest -q`
- `pytest tests/test_force_quit_cache.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688e61696588832ba3f4bb308c3c162c