### PR TITLE
feat: accelerate heatmap scoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 1.0.60 - 2025-08-26
+
+- **Perf:** Vectorize cursor heat-map updates and window tracker confidence
+  calculations with optional Cython helpers.
+
 ## 1.0.59 - 2025-08-26
 
 - **Fix:** Cancel in-flight window queries before launching new ones.

--- a/src/ensure_deps.py
+++ b/src/ensure_deps.py
@@ -26,6 +26,7 @@ _DEF_PILLOW = "11.0.0"
 _DEF_PYPERCLIP = "1.8.2"
 _DEF_RICH = "13.0.0"
 _DEF_MATPLOTLIB = "3.7.0"
+_DEF_NUMPY = "1.26.0"
 
 
 def ensure_import(
@@ -101,3 +102,9 @@ def ensure_matplotlib(version: str = _DEF_MATPLOTLIB) -> ModuleType:
     """Return the ``matplotlib`` module, installing it if needed."""
 
     return ensure_import("matplotlib", version=version)
+
+
+def ensure_numpy(version: str = _DEF_NUMPY) -> ModuleType:
+    """Return the ``numpy`` module, installing it if needed."""
+
+    return ensure_import("numpy", version=version)

--- a/src/utils/_heatmap.pyx
+++ b/src/utils/_heatmap.pyx
@@ -1,0 +1,24 @@
+# cython: boundscheck=False
+# cython: wraparound=False
+# Optional heatmap helpers implemented in Cython
+
+import cython
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cpdef double decay_and_bump(double[:, :] grid,
+                            double decay,
+                            double global_decay,
+                            int gx,
+                            int gy):
+    cdef Py_ssize_t h = grid.shape[0]
+    cdef Py_ssize_t w = grid.shape[1]
+    cdef Py_ssize_t y, x
+    global_decay *= decay
+    if global_decay < 1e-6:
+        for y in range(h):
+            for x in range(w):
+                grid[y, x] *= global_decay
+        global_decay = 1.0
+    grid[gy, gx] += 1.0 / global_decay
+    return global_decay

--- a/src/views/about_view.py
+++ b/src/views/about_view.py
@@ -28,7 +28,7 @@ class AboutView(BaseView):
 
         info = info_label(
             container,
-            "CoolBox - A Modern Desktop App\nVersion 1.0.59",
+            "CoolBox - A Modern Desktop App\nVersion 1.0.60",
             font=self.font,
         )
         info.pack(anchor="w")


### PR DESCRIPTION
## Summary
- vectorize cursor heatmap updates and window confidence checks with optional NumPy/Cython
- hook setup to build extensions and gracefully skip when tooling is absent
- bump version to 1.0.60

## Testing
- `pytest tests/test_cursor_heatmap.py -q`
- `pytest tests/test_click_overlay.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688e69c8d11c832ba63512856a6d5047