### PR TITLE
feat: add optional overlay label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.61 - 2025-08-26
+
+- **Feat:** Allow disabling click overlay label via parameter or `KILL_BY_CLICK_LABEL` env var.
+
 ## 1.0.60 - 2025-08-26
 
 - **Perf:** Vectorize cursor heat-map updates and window tracker confidence

--- a/src/views/about_view.py
+++ b/src/views/about_view.py
@@ -28,7 +28,7 @@ class AboutView(BaseView):
 
         info = info_label(
             container,
-            "CoolBox - A Modern Desktop App\nVersion 1.0.60",
+            "CoolBox - A Modern Desktop App\nVersion 1.0.61",
             font=self.font,
         )
         info.pack(anchor="w")

--- a/tests/test_click_overlay.py
+++ b/tests/test_click_overlay.py
@@ -52,6 +52,25 @@ class TestClickOverlay(unittest.TestCase):
             root.destroy()
 
     @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_overlay_can_disable_label(self) -> None:
+        root = tk.Tk()
+        with patch("src.views.click_overlay.is_supported", return_value=False):
+            overlay = ClickOverlay(root, show_label=False)
+        self.assertIsNone(overlay.label)
+        overlay.destroy()
+        root.destroy()
+
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_env_disables_label(self) -> None:
+        with patch.dict(os.environ, {"KILL_BY_CLICK_LABEL": "0"}):
+            root = tk.Tk()
+            with patch("src.views.click_overlay.is_supported", return_value=False):
+                overlay = ClickOverlay(root)
+            self.assertIsNone(overlay.label)
+            overlay.destroy()
+            root.destroy()
+
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
     def test_overlay_uses_transparent_color_key(self) -> None:
         root = tk.Tk()
         with patch("src.views.click_overlay.is_supported", return_value=False):


### PR DESCRIPTION
## Summary
- make click overlay label optional and toggle via KILL_BY_CLICK_LABEL
- document new toggle in changelog and bump version
- test disabling label via parameter and env var

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e70e40750832badf9a0a5482152cc