### PR TITLE
feat: report process enumeration progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.63 - 2025-08-26
+
+- **Feat:** Stream process enumeration progress and disable kill actions until ready.
+
 ## 1.0.62 - 2025-08-26
 
 - **Feat:** Calibrate click overlay refresh intervals and persist settings.

--- a/src/views/about_view.py
+++ b/src/views/about_view.py
@@ -28,7 +28,7 @@ class AboutView(BaseView):
 
         info = info_label(
             container,
-            "CoolBox - A Modern Desktop App\nVersion 1.0.62",
+            "CoolBox - A Modern Desktop App\nVersion 1.0.63",
             font=self.font,
         )
         info.pack(anchor="w")

--- a/tests/test_bulk_cpu_scan.py
+++ b/tests/test_bulk_cpu_scan.py
@@ -5,7 +5,7 @@ from src.utils.process_monitor import ProcessEntry, ProcessWatcher
 
 
 def test_scan_proc_stat_self() -> None:
-    q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, ProcessEntry], set[int], float]] = Queue()
     watcher = ProcessWatcher(q)
     try:
         if not os.path.isdir("/proc"):
@@ -18,7 +18,7 @@ def test_scan_proc_stat_self() -> None:
 
 
 def test_bulk_cpu_threshold_param() -> None:
-    q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, ProcessEntry], set[int], float]] = Queue()
     watcher = ProcessWatcher(q, bulk_cpu_threshold=5, bulk_cpu_workers=2)
     try:
         assert watcher.bulk_cpu_threshold == 5

--- a/tests/test_force_quit.py
+++ b/tests/test_force_quit.py
@@ -774,20 +774,20 @@ class TestForceQuit(unittest.TestCase):
         ProcessEntry.change_mad_mult = 3.0
 
     def test_stable_env_vars(self) -> None:
-        q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+        q: Queue[tuple[dict[int, ProcessEntry], set[int], float]] = Queue()
         watcher = ProcessWatcher(q, stable_cycles=5, stable_skip=2)
         assert watcher._stable_cycles == 5
         assert watcher._stable_skip == 2
         watcher.stop()
 
     def test_hide_system(self) -> None:
-        q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+        q: Queue[tuple[dict[int, ProcessEntry], set[int], float]] = Queue()
         watcher = ProcessWatcher(q, hide_system=True)
         assert watcher.hide_system is True
         watcher.stop()
 
     def test_exclude_users(self) -> None:
-        q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+        q: Queue[tuple[dict[int, ProcessEntry], set[int], float]] = Queue()
         watcher = ProcessWatcher(q, exclude_users={"root", "daemon"})
         assert watcher.exclude_users == {"root", "daemon"}
         watcher.stop()
@@ -868,32 +868,32 @@ class TestForceQuit(unittest.TestCase):
         assert entry.stable
 
     def test_ratio_env_vars(self) -> None:
-        q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+        q: Queue[tuple[dict[int, ProcessEntry], set[int], float]] = Queue()
         watcher = ProcessWatcher(q, slow_ratio=0.05, fast_ratio=0.3)
         assert watcher._slow_ratio == 0.05
         assert watcher._fast_ratio == 0.3
         watcher.stop()
 
     def test_ratio_window_option(self) -> None:
-        q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+        q: Queue[tuple[dict[int, ProcessEntry], set[int], float]] = Queue()
         watcher = ProcessWatcher(q, ratio_window=7)
         assert watcher._ratio_window == 7
         watcher.stop()
 
     def test_normal_window_option(self) -> None:
-        q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+        q: Queue[tuple[dict[int, ProcessEntry], set[int], float]] = Queue()
         watcher = ProcessWatcher(q, normal_window=4)
         assert watcher._normal_window == 4
         watcher.stop()
 
     def test_visible_auto_option(self) -> None:
-        q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+        q: Queue[tuple[dict[int, ProcessEntry], set[int], float]] = Queue()
         watcher = ProcessWatcher(q, visible_auto=True)
         assert watcher.visible_auto is True
         watcher.stop()
 
     def test_auto_baselines(self) -> None:
-        q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+        q: Queue[tuple[dict[int, ProcessEntry], set[int], float]] = Queue()
         watcher = ProcessWatcher(q, visible_auto=True)
         watcher._update_auto_baselines(
             [1.0, 2.0, 3.0, 4.0], [10, 20, 30, 40], [0.1, 0.2, 0.3, 0.4]
@@ -904,7 +904,7 @@ class TestForceQuit(unittest.TestCase):
         watcher.stop()
 
     def test_trend_env_vars(self) -> None:
-        q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+        q: Queue[tuple[dict[int, ProcessEntry], set[int], float]] = Queue()
         watcher = ProcessWatcher(
             q, trend_window=6, trend_cpu=2.5, trend_mem=20.0, trend_io=0.5
         )
@@ -915,26 +915,26 @@ class TestForceQuit(unittest.TestCase):
         watcher.stop()
 
     def test_trend_io_window(self) -> None:
-        q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+        q: Queue[tuple[dict[int, ProcessEntry], set[int], float]] = Queue()
         watcher = ProcessWatcher(q, trend_io_window=7)
         assert watcher._trend_io_window == 7
         watcher.stop()
 
     def test_trend_ratio_env_vars(self) -> None:
-        q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+        q: Queue[tuple[dict[int, ProcessEntry], set[int], float]] = Queue()
         watcher = ProcessWatcher(q, trend_slow_ratio=0.1, trend_fast_ratio=0.4)
         assert watcher._trend_slow_ratio == 0.1
         assert watcher._trend_fast_ratio == 0.4
         watcher.stop()
 
     def test_ignore_age_option(self) -> None:
-        q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+        q: Queue[tuple[dict[int, ProcessEntry], set[int], float]] = Queue()
         watcher = ProcessWatcher(q, ignore_age=2.5)
         assert watcher.ignore_age == 2.5
         watcher.stop()
 
     def test_change_mad_option(self) -> None:
-        q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+        q: Queue[tuple[dict[int, ProcessEntry], set[int], float]] = Queue()
         watcher = ProcessWatcher(q, change_mad_mult=5.0)
         assert watcher.change_mad_mult == 5.0
         watcher.stop()

--- a/tests/test_idle_cpu_skip.py
+++ b/tests/test_idle_cpu_skip.py
@@ -50,7 +50,7 @@ class _FakeProc:
 
 
 def test_proc_cpu_time_override() -> None:
-    q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, ProcessEntry], set[int], float]] = Queue()
     watcher = ProcessWatcher(q, idle_active_samples=0)
     watcher._system_time_delta = 1.0
 
@@ -68,7 +68,7 @@ def test_proc_cpu_time_override() -> None:
 
 
 def test_idle_global_alpha_param() -> None:
-    q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, ProcessEntry], set[int], float]] = Queue()
     watcher = ProcessWatcher(q, idle_global_alpha=0.7, idle_active_samples=0)
     watcher._system_time_delta = 1.0
     try:
@@ -78,7 +78,7 @@ def test_idle_global_alpha_param() -> None:
 
 
 def test_idle_cpu_skip_logic() -> None:
-    q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, ProcessEntry], set[int], float]] = Queue()
     watcher = ProcessWatcher(q, idle_cpu=1.0, idle_cycles=2, max_skip=4, idle_active_samples=0)
     watcher._cpu_count = 1
     watcher._system_time_delta = 1.0
@@ -128,7 +128,7 @@ def test_idle_cpu_skip_logic() -> None:
 
 
 def test_idle_skip_reset_on_activity() -> None:
-    q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, ProcessEntry], set[int], float]] = Queue()
     watcher = ProcessWatcher(q, idle_cpu=1.0, idle_cycles=2, max_skip=4, idle_active_samples=0)
     watcher._cpu_count = 1
     watcher._system_time_delta = 1.0
@@ -177,7 +177,7 @@ def test_idle_skip_reset_on_activity() -> None:
 
 
 def test_skip_interval_decay() -> None:
-    q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, ProcessEntry], set[int], float]] = Queue()
     watcher = ProcessWatcher(
         q,
         idle_cpu=1.0,
@@ -230,7 +230,7 @@ def test_skip_interval_decay() -> None:
 
 
 def test_global_baseline_used_for_new_process() -> None:
-    q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, ProcessEntry], set[int], float]] = Queue()
     watcher = ProcessWatcher(q, idle_cpu=1.0, idle_cycles=1, max_skip=3, idle_active_samples=0)
     watcher._cpu_count = 1
     watcher._system_time_delta = 1.0
@@ -248,7 +248,7 @@ def test_global_baseline_used_for_new_process() -> None:
 
 
 def test_exponential_backoff() -> None:
-    q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, ProcessEntry], set[int], float]] = Queue()
     watcher = ProcessWatcher(q, idle_cpu=1.0, idle_cycles=1, max_skip=8, idle_active_samples=0)
     watcher._cpu_count = 1
     watcher._system_time_delta = 1.0
@@ -301,7 +301,7 @@ def test_exponential_backoff() -> None:
 
 
 def test_idle_skip_jitter(monkeypatch) -> None:
-    q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, ProcessEntry], set[int], float]] = Queue()
     watcher = ProcessWatcher(
         q,
         idle_cpu=1.0,
@@ -344,7 +344,7 @@ def test_idle_skip_jitter(monkeypatch) -> None:
 
 
 def test_idle_skip_multiplier() -> None:
-    q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, ProcessEntry], set[int], float]] = Queue()
     watcher = ProcessWatcher(
         q,
         idle_cpu=1.0,
@@ -394,7 +394,7 @@ def test_idle_skip_multiplier() -> None:
 
 
 def test_idle_dynamic_multiplier() -> None:
-    q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, ProcessEntry], set[int], float]] = Queue()
     watcher = ProcessWatcher(
         q,
         idle_cpu=1.0,
@@ -440,7 +440,7 @@ def test_idle_dynamic_multiplier() -> None:
 
 
 def test_idle_dynamic_weighted_rms() -> None:
-    q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, ProcessEntry], set[int], float]] = Queue()
     watcher = ProcessWatcher(
         q,
         idle_cpu=1.0,
@@ -501,7 +501,7 @@ def test_idle_dynamic_weighted_rms() -> None:
 
 
 def test_idle_dynamic_exponent() -> None:
-    q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, ProcessEntry], set[int], float]] = Queue()
     watcher = ProcessWatcher(
         q,
         idle_cpu=1.0,
@@ -548,7 +548,7 @@ def test_idle_dynamic_exponent() -> None:
 
 
 def test_idle_decay_exponent() -> None:
-    q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, ProcessEntry], set[int], float]] = Queue()
     watcher = ProcessWatcher(
         q,
         idle_cpu=1.0,
@@ -598,7 +598,7 @@ def test_idle_decay_exponent() -> None:
 
 
 def test_idle_window_baseline() -> None:
-    q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, ProcessEntry], set[int], float]] = Queue()
     watcher = ProcessWatcher(
         q,
         idle_window=3,
@@ -648,7 +648,7 @@ def test_idle_window_baseline() -> None:
 
 
 def test_idle_refresh_forces_sample() -> None:
-    q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, ProcessEntry], set[int], float]] = Queue()
     watcher = ProcessWatcher(
         q,
         idle_cpu=1.0,
@@ -704,7 +704,7 @@ def test_idle_refresh_forces_sample() -> None:
 
 
 def test_idle_baseline_updates_during_skip() -> None:
-    q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, ProcessEntry], set[int], float]] = Queue()
     watcher = ProcessWatcher(
         q,
         idle_cpu=1.0,
@@ -751,7 +751,7 @@ def test_idle_baseline_updates_during_skip() -> None:
 
 
 def test_idle_grace_delay() -> None:
-    q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, ProcessEntry], set[int], float]] = Queue()
     watcher = ProcessWatcher(q, idle_cpu=1.0, idle_cycles=1, idle_grace=2, max_skip=4, idle_active_samples=0)
     watcher._cpu_count = 1
     watcher._system_time_delta = 1.0
@@ -797,7 +797,7 @@ def test_idle_grace_delay() -> None:
 
 
 def test_proc_cpu_time_no_such_process(monkeypatch) -> None:
-    q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, ProcessEntry], set[int], float]] = Queue()
     watcher = ProcessWatcher(q, idle_active_samples=0)
     proc = _FakeProc()
 
@@ -811,7 +811,7 @@ def test_proc_cpu_time_no_such_process(monkeypatch) -> None:
 
 
 def test_proc_cpu_time_generic_error(monkeypatch) -> None:
-    q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, ProcessEntry], set[int], float]] = Queue()
     watcher = ProcessWatcher(q, idle_active_samples=0)
     proc = _FakeProc()
 
@@ -824,7 +824,7 @@ def test_proc_cpu_time_generic_error(monkeypatch) -> None:
 
 
 def test_proc_cpu_time_attribute_error(monkeypatch) -> None:
-    q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, ProcessEntry], set[int], float]] = Queue()
     watcher = ProcessWatcher(q, idle_active_samples=0)
     proc = _FakeProc()
 
@@ -838,7 +838,7 @@ def test_proc_cpu_time_attribute_error(monkeypatch) -> None:
 
 
 def test_idle_reset_ratio() -> None:
-    q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, ProcessEntry], set[int], float]] = Queue()
     watcher = ProcessWatcher(
         q,
         idle_cpu=1.0,
@@ -891,7 +891,7 @@ def test_idle_reset_ratio() -> None:
 
 
 def test_idle_check_interval_breaks_skip() -> None:
-    q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, ProcessEntry], set[int], float]] = Queue()
     watcher = ProcessWatcher(
         q,
         idle_cpu=1.0,
@@ -942,7 +942,7 @@ def test_idle_check_interval_breaks_skip() -> None:
 
 
 def test_idle_active_samples_delay_skipping() -> None:
-    q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, ProcessEntry], set[int], float]] = Queue()
     watcher = ProcessWatcher(
         q,
         idle_cpu=1.0,
@@ -1005,7 +1005,7 @@ def test_idle_active_samples_delay_skipping() -> None:
 
 
 def test_idle_mem_delta_breaks_skip() -> None:
-    q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, ProcessEntry], set[int], float]] = Queue()
     watcher = ProcessWatcher(
         q,
         idle_cpu=1.0,
@@ -1054,7 +1054,7 @@ def test_idle_mem_delta_breaks_skip() -> None:
 
 
 def test_idle_io_delta_breaks_skip() -> None:
-    q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, ProcessEntry], set[int], float]] = Queue()
     watcher = ProcessWatcher(
         q,
         idle_cpu=1.0,
@@ -1103,7 +1103,7 @@ def test_idle_io_delta_breaks_skip() -> None:
 
 
 def test_idle_mem_ratio_breaks_skip() -> None:
-    q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, ProcessEntry], set[int], float]] = Queue()
     watcher = ProcessWatcher(
         q,
         idle_cpu=1.0,
@@ -1152,7 +1152,7 @@ def test_idle_mem_ratio_breaks_skip() -> None:
 
 
 def test_idle_io_ratio_breaks_skip() -> None:
-    q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, ProcessEntry], set[int], float]] = Queue()
     watcher = ProcessWatcher(
         q,
         idle_cpu=1.0,
@@ -1201,7 +1201,7 @@ def test_idle_io_ratio_breaks_skip() -> None:
 
 
 def test_idle_mem_reset_ratio() -> None:
-    q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, ProcessEntry], set[int], float]] = Queue()
     watcher = ProcessWatcher(
         q,
         idle_cpu=1.0,
@@ -1250,7 +1250,7 @@ def test_idle_mem_reset_ratio() -> None:
 
 
 def test_idle_io_reset_ratio() -> None:
-    q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, ProcessEntry], set[int], float]] = Queue()
     watcher = ProcessWatcher(
         q,
         idle_cpu=1.0,
@@ -1299,7 +1299,7 @@ def test_idle_io_reset_ratio() -> None:
 
 
 def test_idle_mem_reset_ratio_active() -> None:
-    q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, ProcessEntry], set[int], float]] = Queue()
     watcher = ProcessWatcher(
         q,
         idle_cpu=1.0,
@@ -1344,7 +1344,7 @@ def test_idle_mem_reset_ratio_active() -> None:
 
 
 def test_idle_io_reset_ratio_active() -> None:
-    q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, ProcessEntry], set[int], float]] = Queue()
     watcher = ProcessWatcher(
         q,
         idle_cpu=1.0,
@@ -1389,7 +1389,7 @@ def test_idle_io_reset_ratio_active() -> None:
 
 
 def test_global_mem_io_baseline_for_new_process() -> None:
-    q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, ProcessEntry], set[int], float]] = Queue()
     watcher = ProcessWatcher(
         q,
         idle_cpu=1.0,
@@ -1434,7 +1434,7 @@ def test_global_mem_io_baseline_for_new_process() -> None:
 
 
 def test_idle_trend_reset_breaks_skip() -> None:
-    q: Queue[tuple[dict[int, ProcessEntry], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, ProcessEntry], set[int], float]] = Queue()
     watcher = ProcessWatcher(
         q,
         idle_cpu=1.0,

--- a/tests/test_load_skip.py
+++ b/tests/test_load_skip.py
@@ -5,7 +5,7 @@ from src.utils.process_monitor import ProcessWatcher
 
 
 def test_load_skip_params() -> None:
-    q: Queue[tuple[dict[int, object], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, object], set[int], float]] = Queue()
     watcher = ProcessWatcher(q, load_threshold=50.0, load_cycles=3)
     try:
         assert watcher.load_threshold == 50.0
@@ -15,7 +15,7 @@ def test_load_skip_params() -> None:
 
 
 def test_should_pause_for_load(monkeypatch) -> None:
-    q: Queue[tuple[dict[int, object], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, object], set[int], float]] = Queue()
     watcher = ProcessWatcher(q, load_threshold=10.0, load_cycles=2)
     called = []
 

--- a/tests/test_process_monitor_alert.py
+++ b/tests/test_process_monitor_alert.py
@@ -3,7 +3,7 @@ from src.utils.process_monitor import ProcessWatcher
 
 
 def test_process_watcher_alert_defaults():
-    q: Queue[tuple[dict[int, object], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, object], set[int], float]] = Queue()
     watcher = ProcessWatcher(q)
     assert watcher.cpu_alert == 80.0
     assert watcher.mem_alert == 500.0
@@ -11,7 +11,7 @@ def test_process_watcher_alert_defaults():
 
 
 def test_process_watcher_alert_custom():
-    q: Queue[tuple[dict[int, object], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, object], set[int], float]] = Queue()
     watcher = ProcessWatcher(q, cpu_alert=70.0, mem_alert=400.0)
     assert watcher.cpu_alert == 70.0
     assert watcher.mem_alert == 400.0
@@ -19,7 +19,7 @@ def test_process_watcher_alert_custom():
 
 
 def test_process_watcher_batch_size():
-    q: Queue[tuple[dict[int, object], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, object], set[int], float]] = Queue()
     watcher = ProcessWatcher(q, batch_size=25)
     try:
         assert watcher.batch_size == 25
@@ -44,7 +44,7 @@ def test_next_batch(monkeypatch):
     monkeypatch.setattr("psutil.pids", fake_pids)
     monkeypatch.setattr("psutil.process_iter", fake_iter)
 
-    q: Queue[tuple[dict[int, object], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, object], set[int], float]] = Queue()
     watcher = ProcessWatcher(q, batch_size=3)
     try:
         batch, end = watcher._next_batch([])
@@ -58,7 +58,7 @@ def test_next_batch(monkeypatch):
 
 
 def test_update_batch_size():
-    q: Queue[tuple[dict[int, object], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, object], set[int], float]] = Queue()
     watcher = ProcessWatcher(q, batch_size=50, auto_batch=True, min_batch_size=20, max_batch_size=100)
     try:
         watcher._cycle_elapsed = watcher.target_interval * 2
@@ -73,7 +73,7 @@ def test_update_batch_size():
 
 
 def test_update_batch_size_activity():
-    q: Queue[tuple[dict[int, object], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, object], set[int], float]] = Queue()
     watcher = ProcessWatcher(q, batch_size=50, auto_batch=True, min_batch_size=20, max_batch_size=100)
     try:
         watcher.process_count = 10
@@ -87,7 +87,7 @@ def test_update_batch_size_activity():
 
 
 def test_finish_cycle_metrics():
-    q: Queue[tuple[dict[int, object], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, object], set[int], float]] = Queue()
     watcher = ProcessWatcher(q, batch_size=50)
     try:
         watcher.process_count = 10
@@ -101,7 +101,7 @@ def test_finish_cycle_metrics():
 
 
 def test_average_metrics():
-    q: Queue[tuple[dict[int, object], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, object], set[int], float]] = Queue()
     watcher = ProcessWatcher(q, batch_size=40)
     try:
         watcher.process_count = 10
@@ -120,7 +120,7 @@ def test_average_metrics():
 
 
 def test_interval_bounds():
-    q: Queue[tuple[dict[int, object], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, object], set[int], float]] = Queue()
     watcher = ProcessWatcher(q, interval=5.0, min_interval=1.0, max_interval=3.0)
     try:
         assert watcher.interval == 3.0
@@ -132,7 +132,7 @@ def test_interval_bounds():
 
 
 def test_average_interval():
-    q: Queue[tuple[dict[int, object], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, object], set[int], float]] = Queue()
     watcher = ProcessWatcher(q, interval=1.5)
     try:
         watcher._cycle_elapsed = 0.1
@@ -150,7 +150,7 @@ def test_auto_interval_env(monkeypatch):
     import importlib
     import src.utils.process_monitor as pm
     importlib.reload(pm)
-    q: Queue[tuple[dict[int, object], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, object], set[int], float]] = Queue()
     watcher = pm.ProcessWatcher(q)
     try:
         assert watcher.adaptive is False
@@ -159,7 +159,7 @@ def test_auto_interval_env(monkeypatch):
 
 
 def test_resize_executor(monkeypatch):
-    q: Queue[tuple[dict[int, object], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, object], set[int], float]] = Queue()
     watcher = ProcessWatcher(q, max_workers=2, min_workers=2, max_worker_limit=8)
     try:
         watcher.process_count = 20
@@ -179,7 +179,7 @@ def test_min_workers_env(monkeypatch):
     import importlib
     import src.utils.process_monitor as pm
     importlib.reload(pm)
-    q: Queue[tuple[dict[int, object], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, object], set[int], float]] = Queue()
     watcher = pm.ProcessWatcher(q)
     try:
         assert watcher.min_workers == 3
@@ -188,7 +188,7 @@ def test_min_workers_env(monkeypatch):
 
 
 def test_ignore_names_check():
-    q: Queue[tuple[dict[int, object], set[int]]] = Queue()
+    q: Queue[tuple[dict[int, object], set[int], float]] = Queue()
     watcher = ProcessWatcher(q, ignore_names={"bash"})
     try:
         assert watcher._should_ignore_process("bash") is True

--- a/tests/test_process_watcher_progress.py
+++ b/tests/test_process_watcher_progress.py
@@ -1,0 +1,14 @@
+from queue import Queue
+from src.utils.process_monitor import ProcessEntry, ProcessWatcher
+
+
+def test_process_watcher_reports_progress() -> None:
+    q: Queue[tuple[dict[int, ProcessEntry], set[int], float]] = Queue()
+    watcher = ProcessWatcher(q, batch_size=1)
+    watcher.start()
+    try:
+        updates, removed, progress = q.get(timeout=5)
+        assert 0.0 <= progress <= 1.0
+    finally:
+        watcher.stop()
+        watcher.join(timeout=1)


### PR DESCRIPTION
## Summary
- stream process enumeration progress from worker thread
- block kill actions until enumeration completes
- bump version to 1.0.63

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688e771c74a4832b87410c79a9b46316