### PR TITLE
feat: boost kill priority for low latency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 1.0.64 - 2025-08-26
+
+- **Feat:** Boost kill priority to reduce termination latency and restore
+  normal priority when system load spikes.
+
 ## 1.0.63 - 2025-08-26
 
 - **Feat:** Stream process enumeration progress and disable kill actions until ready.

--- a/src/views/about_view.py
+++ b/src/views/about_view.py
@@ -28,7 +28,7 @@ class AboutView(BaseView):
 
         info = info_label(
             container,
-            "CoolBox - A Modern Desktop App\nVersion 1.0.63",
+            "CoolBox - A Modern Desktop App\nVersion 1.0.64",
             font=self.font,
         )
         info.pack(anchor="w")

--- a/tests/test_kill_priority.py
+++ b/tests/test_kill_priority.py
@@ -1,0 +1,28 @@
+import sys
+import subprocess
+import time
+from contextlib import contextmanager
+from unittest import mock
+
+import psutil
+
+from src.utils.kill_utils import kill_process
+
+
+def test_kill_process_uses_priority_boost():
+    proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    assert psutil.pid_exists(proc.pid)
+    called = False
+
+    @contextmanager
+    def fake_boost():
+        nonlocal called
+        called = True
+        yield
+
+    with mock.patch("src.utils.kill_utils._priority_boost", fake_boost):
+        kill_process(proc.pid, timeout=1.0)
+
+    time.sleep(0.1)
+    assert called
+    assert not psutil.pid_exists(proc.pid)


### PR DESCRIPTION
## Summary
- raise thread priority during process termination and restore if load is high
- log termination latency
- document and test high-priority kill helper

## Testing
- `pytest tests/test_security.py::test_kill_process_by_port tests/test_kill_priority.py tests/test_kill_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688e8233dd1c832bb12f1c5b70c9980c