### PR TITLE
perf: debounce force quit refresh and hover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.67 - 2025-08-28
+
+- **Perf:** Debounce process list refresh and hover updates to reduce redundant renders.
+
 ## 1.0.66 - 2025-08-28
 
 - **Feat:** Cache running processes and refresh on OS notifications, rebuilding

--- a/src/views/about_view.py
+++ b/src/views/about_view.py
@@ -28,7 +28,7 @@ class AboutView(BaseView):
 
         info = info_label(
             container,
-            "CoolBox - A Modern Desktop App\nVersion 1.0.66",
+            "CoolBox - A Modern Desktop App\nVersion 1.0.67",
             font=self.font,
         )
         info.pack(anchor="w")

--- a/src/views/force_quit_dialog.py
+++ b/src/views/force_quit_dialog.py
@@ -78,6 +78,7 @@ class ForceQuitDialog(BaseDialog):
         self.attributes("-topmost", on_top)
         self._after_id: int | None = None
         self._debounce_id: int | None = None
+        self._hover_after_id: int | None = None
         self.process_snapshot: dict[int, ProcessEntry] = {}
         self._row_cache: dict[int, tuple[tuple, tuple]] = {}
         self._changed_tags: dict[int, int] = {}
@@ -1304,7 +1305,7 @@ class ForceQuitDialog(BaseDialog):
     def _populate(self) -> None:
         if self._debounce_id is not None:
             self.after_cancel(self._debounce_id)
-        self._debounce_id = self.after(150, self._apply_filter_sort)
+        self._debounce_id = self.after(100, self._apply_filter_sort)
 
     def _current_filter_key(self) -> tuple[str, str, str, bool]:
         return (
@@ -1746,10 +1747,13 @@ class ForceQuitDialog(BaseDialog):
         self._hover_iid = iid
         self._apply_hover_tag()
 
-    def _on_hover(self, event) -> None:
-        self._set_hover_row(self.tree.identify_row(event.y))
+    def _on_hover(self, _event) -> None:
+        if self._hover_after_id is not None:
+            self.after_cancel(self._hover_after_id)
+        self._hover_after_id = self.after(100, self._update_hover)
 
     def _update_hover(self) -> None:
+        self._hover_after_id = None
         x, y = self.winfo_pointerxy()
         widget = self.winfo_containing(x, y)
         if widget is self.tree or widget in self.tree.winfo_children():

--- a/tests/test_force_quit_debounce.py
+++ b/tests/test_force_quit_debounce.py
@@ -1,0 +1,66 @@
+import types
+from unittest import mock
+
+import types
+from unittest import mock
+
+from src.views.force_quit_dialog import ForceQuitDialog
+
+
+def test_populate_debounce():
+    dialog = ForceQuitDialog.__new__(ForceQuitDialog)
+    delays: list[int] = []
+    callbacks = []
+
+    def fake_after(delay: int, func):
+        delays.append(delay)
+        callbacks.append(func)
+        return f"id{len(callbacks)}"
+
+    cancelled = []
+
+    def fake_after_cancel(ident: str) -> None:
+        cancelled.append(ident)
+
+    dialog.after = fake_after
+    dialog.after_cancel = fake_after_cancel
+    dialog._apply_filter_sort = mock.Mock()
+    dialog._debounce_id = None
+
+    dialog._populate()
+    dialog._populate()
+
+    assert delays == [100, 100]
+    assert cancelled == ["id1"]
+
+    callbacks[-1]()
+    dialog._apply_filter_sort.assert_called_once()
+
+
+def test_hover_debounce():
+    dialog = ForceQuitDialog.__new__(ForceQuitDialog)
+    callbacks = []
+
+    def fake_after(delay: int, func):
+        callbacks.append((delay, func))
+        return f"id{len(callbacks)}"
+
+    cancelled = []
+
+    def fake_after_cancel(ident: str) -> None:
+        cancelled.append(ident)
+
+    dialog.after = fake_after
+    dialog.after_cancel = fake_after_cancel
+    dialog._update_hover = mock.Mock()
+    dialog._hover_after_id = None
+
+    evt = types.SimpleNamespace(y=5)
+    dialog._on_hover(evt)
+    dialog._on_hover(evt)
+
+    assert [d for d, _ in callbacks] == [100, 100]
+    assert cancelled == ["id1"]
+
+    callbacks[-1][1]()
+    dialog._update_hover.assert_called_once()


### PR DESCRIPTION
## Summary
- debounce ForceQuitDialog list refresh and hover updates to reduce redundant renders
- document change in changelog and bump version to 1.0.67
- add tests covering refresh and hover debouncing

## Testing
- `pytest tests/test_force_quit_debounce.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f37fe4a84832ba82e09d3a8b8cedd