### PR TITLE
feat: add thread manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.69 - 2025-08-28
+
+- **Feat:** Introduce thread manager with logger, process and monitor threads to detect deadlocks.
+
 ## 1.0.68 - 2025-08-28
 
 - **Feat:** Preload window titles, icons and handles in a background thread.

--- a/src/app.py
+++ b/src/app.py
@@ -36,6 +36,7 @@ from .views.about_view import AboutView
 from .models.app_state import AppState
 from .utils.theme import ThemeManager
 from .utils.helpers import log
+from .utils.thread_manager import ThreadManager
 
 if TYPE_CHECKING:  # pragma: no cover - used for type hints only
     from .views.quick_settings import QuickSettingsDialog
@@ -51,6 +52,9 @@ class CoolBoxApp:
         # Load configuration
         self.config = Config()
         self.state = AppState()
+        # Background threads: process manager and logger with monitoring
+        self.thread_manager = ThreadManager()
+        self.thread_manager.start()
 
         # Set appearance
         ctk.set_appearance_mode(self.config.get("appearance_mode", "dark"))
@@ -405,5 +409,6 @@ class CoolBoxApp:
 
     def destroy(self):
         """Destroy the application window."""
+        self.thread_manager.stop()
         self.window.destroy()
         log("Window destroyed")

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -128,6 +128,7 @@ from .security import (
     kill_process_by_port,
     kill_port_range,
 )
+from .thread_manager import ThreadManager
 
 from . import file_manager
 
@@ -246,4 +247,5 @@ __all__ = [
     "ScoringEngine",
     "Tuning",
     "tuning",
+    "ThreadManager",
 ]

--- a/src/utils/thread_manager.py
+++ b/src/utils/thread_manager.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import threading
+import time
+from queue import Empty, SimpleQueue
+from typing import Any, Dict
+
+
+class ThreadManager:
+    """Coordinate background threads for CoolBox.
+
+    A process manager thread consumes commands from ``cmd_queue`` and a logger
+    thread consumes log messages from ``log_queue``.  A monitor thread watches
+    heartbeat timestamps to detect stalled threads which could indicate
+    deadlocks or priority inversions during stress testing.
+    """
+
+    def __init__(self) -> None:
+        self.log_queue: SimpleQueue[str] = SimpleQueue()
+        self.cmd_queue: SimpleQueue[Any] = SimpleQueue()
+        self.shutdown = threading.Event()
+        self.lock = threading.Lock()
+        self.heartbeats: Dict[str, float] = {}
+        self.logs: list[str] = []
+
+        self.logger_thread = threading.Thread(
+            target=self._logger_loop, name="logger", daemon=True
+        )
+        self.process_thread = threading.Thread(
+            target=self._process_loop, name="process_manager", daemon=True
+        )
+        self.monitor_thread = threading.Thread(
+            target=self._monitor_loop, name="thread_monitor", daemon=True
+        )
+
+    def start(self) -> None:
+        """Start all background threads."""
+        now = time.time()
+        with self.lock:
+            self.heartbeats = {"logger": now, "process": now}
+        self.logger_thread.start()
+        self.process_thread.start()
+        self.monitor_thread.start()
+
+    def stop(self) -> None:
+        """Signal threads to stop and wait briefly for them."""
+        self.shutdown.set()
+        for t in (self.logger_thread, self.process_thread):
+            t.join(timeout=1)
+
+    def _logger_loop(self) -> None:
+        while not self.shutdown.is_set():
+            try:
+                msg = self.log_queue.get(timeout=0.1)
+            except Empty:
+                pass
+            else:
+                self.logs.append(msg)
+            with self.lock:
+                self.heartbeats["logger"] = time.time()
+
+    def _process_loop(self) -> None:
+        while not self.shutdown.is_set():
+            try:
+                _task = self.cmd_queue.get(timeout=0.1)
+            except Empty:
+                pass
+            else:
+                time.sleep(0.01)
+            with self.lock:
+                self.heartbeats["process"] = time.time()
+
+    def _monitor_loop(self) -> None:
+        while not self.shutdown.is_set():
+            if not self.lock.acquire(timeout=0.1):
+                self.log_queue.put("heartbeat lock contention")
+                time.sleep(0.5)
+                continue
+            try:
+                now = time.time()
+                for name, last in self.heartbeats.items():
+                    if now - last > 1.0:
+                        self.log_queue.put(f"{name} stalled")
+            finally:
+                self.lock.release()
+            time.sleep(0.5)

--- a/src/utils/vm.py
+++ b/src/utils/vm.py
@@ -95,4 +95,4 @@ def launch_vm_debug(
     env["DEBUG_PORT"] = str(port)
     if skip_deps:
         env["SKIP_DEPS"] = "1"
-    run_command([str(root / "scripts" / "run_debug.sh")], timeout=None, env=env)
+    run_command_ex([str(root / "scripts" / "run_debug.sh")], timeout=None, env=env)

--- a/src/views/about_view.py
+++ b/src/views/about_view.py
@@ -28,7 +28,7 @@ class AboutView(BaseView):
 
         info = info_label(
             container,
-            "CoolBox - A Modern Desktop App\nVersion 1.0.68",
+            "CoolBox - A Modern Desktop App\nVersion 1.0.69",
             font=self.font,
         )
         info.pack(anchor="w")

--- a/tests/test_thread_manager.py
+++ b/tests/test_thread_manager.py
@@ -1,0 +1,26 @@
+from time import sleep
+
+from src.utils.thread_manager import ThreadManager
+
+
+def test_thread_manager_threads_and_communication():
+    tm = ThreadManager()
+    tm.start()
+    for _ in range(5):
+        tm.cmd_queue.put("work")
+        tm.log_queue.put("msg")
+    sleep(0.5)
+    tm.stop()
+    assert any(log == "msg" for log in tm.logs)
+    assert not any("stalled" in log for log in tm.logs)
+
+
+def test_thread_manager_detects_contention():
+    tm = ThreadManager()
+    tm.start()
+    tm.lock.acquire()
+    sleep(1.2)
+    tm.lock.release()
+    sleep(0.5)
+    tm.stop()
+    assert any("lock contention" in log for log in tm.logs)


### PR DESCRIPTION
## Summary
- introduce ThreadManager with logger, process and watchdog threads
- start/stop background threads from CoolBoxApp
- use run_command_ex for VM debug fallback
- update version to 1.0.69

## Testing
- `pytest tests/test_thread_manager.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f3fad9d50832b9814f6190b482e2c