### PR TITLE
feat: add basic rendering mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 1.0.70 - 2025-08-29
+
+- **Feat:** Add basic rendering mode toggle that disables compositing effects and drop shadows for legacy GPU compatibility.
+- **Feat:** Provide GPU usage benchmarking utility.
+
 ## 1.0.69 - 2025-08-28
 
 - **Feat:** Introduce thread manager with logger, process and monitor threads to detect deadlocks.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,5 +1,7 @@
 """Public package interface for CoolBox."""
 
+__version__ = "1.0.70"
+
 import os
 
 if not os.environ.get("COOLBOX_LIGHTWEIGHT"):

--- a/src/config.py
+++ b/src/config.py
@@ -33,6 +33,7 @@ class Config:
             "show_toolbar": True,
             "show_statusbar": True,
             "show_menu": True,
+            "basic_rendering": False,
             "section_states": {},
             "force_quit_cpu_alert": 80.0,
             "force_quit_mem_alert": 500.0,

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -129,6 +129,7 @@ from .security import (
     kill_port_range,
 )
 from .thread_manager import ThreadManager
+from .gpu import benchmark_gpu_usage
 
 from . import file_manager
 
@@ -248,4 +249,5 @@ __all__ = [
     "Tuning",
     "tuning",
     "ThreadManager",
+    "benchmark_gpu_usage",
 ]

--- a/src/utils/gpu.py
+++ b/src/utils/gpu.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+"""GPU benchmarking helpers."""
+
+import time
+from typing import List
+
+
+def benchmark_gpu_usage(samples: int = 5, interval: float = 0.1) -> List[float]:
+    """Return GPU load percentages sampled over time.
+
+    Uses :mod:`GPUtil` when available. Returns an empty list when no GPUs are
+    detected or the library is missing.
+    """
+    try:
+        import GPUtil  # type: ignore
+
+        gpus = GPUtil.getGPUs()
+    except Exception:
+        return []
+    if not gpus:
+        return []
+    usages: List[float] = []
+    for _ in range(samples):
+        for gpu in gpus:
+            try:
+                usages.append(gpu.load * 100)
+            except Exception:
+                usages.append(0.0)
+        time.sleep(interval)
+    return usages

--- a/src/views/exe_inspector_dialog.py
+++ b/src/views/exe_inspector_dialog.py
@@ -116,25 +116,26 @@ class ExeInspectorDialog(BaseDialog):
         )
         self.logo_label.pack(padx=15, pady=5)
         
-        # Title with shadow effect
+        # Title with optional shadow effect
         title_frame = ctk.CTkFrame(logo_section, fg_color=self.bg_glass_2)
         title_frame.pack(side="left", padx=(15, 0))
         
-        # Shadow text
-        title_shadow = ctk.CTkLabel(
-            title_frame,
-            text=f"AEGIS://SHIELD/{self.path.name.upper()}",
-            font=("Consolas", 16, "bold"),
-            text_color=self.bg_glass_4
-        )
-        title_shadow.place(x=2, y=2)
-        
+        # Shadow text (optional)
+        if not self.app.config.get("basic_rendering", False):
+            title_shadow = ctk.CTkLabel(
+                title_frame,
+                text=f"AEGIS://SHIELD/{self.path.name.upper()}",
+                font=("Consolas", 16, "bold"),
+                text_color=self.bg_glass_4,
+            )
+            title_shadow.place(x=2, y=2)
+
         # Main title
         title_main = ctk.CTkLabel(
             title_frame,
             text=f"AEGIS://SHIELD/{self.path.name.upper()}",
             font=("Consolas", 16, "bold"),
-            text_color=self.accent_cyan
+            text_color=self.accent_cyan,
         )
         title_main.pack()
         

--- a/src/views/force_quit_dialog.py
+++ b/src/views/force_quit_dialog.py
@@ -883,7 +883,9 @@ class ForceQuitDialog(BaseDialog):
         from .click_overlay import ClickOverlay
 
         prime_window_cache()
-        self._overlay = ClickOverlay(self)
+        self._overlay = ClickOverlay(
+            self, basic_render=self.app.config.get("basic_rendering", False)
+        )
         self._overlay.reset()
 
         self._auto_refresh()

--- a/src/views/quick_settings.py
+++ b/src/views/quick_settings.py
@@ -20,6 +20,7 @@ class QuickSettingsDialog(BaseDialog):
         self.menu_var = ctk.BooleanVar(value=app.config.get("show_menu", True))
         self.toolbar_var = ctk.BooleanVar(value=app.config.get("show_toolbar", True))
         self.status_var = ctk.BooleanVar(value=app.config.get("show_statusbar", True))
+        self.basic_render_var = ctk.BooleanVar(value=app.config.get("basic_rendering", False))
         self.theme_var = ctk.StringVar(value=app.config.get("appearance_mode", "dark").title())
         self.color_var = ctk.StringVar(value=app.config.get("color_theme", "blue"))
         self.accent_var = ctk.StringVar(
@@ -34,14 +35,18 @@ class QuickSettingsDialog(BaseDialog):
         self.add_tooltip(sw_toolbar, "Toggle the toolbar")
         sw_status = self.grid_switch(container, "Show Status Bar", self.status_var, 3)
         self.add_tooltip(sw_status, "Toggle the status bar")
-        self.grid_separator(container, 4)
+        sw_basic = self.grid_switch(
+            container, "Basic Rendering", self.basic_render_var, 4
+        )
+        self.add_tooltip(sw_basic, "Disable compositing effects for compatibility")
+        self.grid_separator(container, 5)
 
         theme_seg = self.grid_segmented(
             container,
             "Appearance:",
             self.theme_var,
             ["Light", "Dark", "System"],
-            5,
+            6,
             command=self._change_theme,
         )
         self.add_tooltip(theme_seg, "Preview appearance mode")
@@ -50,7 +55,7 @@ class QuickSettingsDialog(BaseDialog):
             "Color Theme:",
             self.color_var,
             ["blue", "green", "dark-blue"],
-            6,
+            7,
             command=self._change_color_theme,
         )
         self.add_tooltip(color_seg, "Preview color theme")
@@ -59,19 +64,19 @@ class QuickSettingsDialog(BaseDialog):
             container,
             "Accent Color...",
             self._choose_accent,
-            7,
+            8,
             columnspan=1,
         )
         self.accent_display = ctk.CTkLabel(container, textvariable=self.accent_var)
         self._mark_font_role(self.accent_display, "normal")
-        self.accent_display.grid(row=7, column=1, sticky="w", padx=self.gpadx, pady=self.gpady)
+        self.accent_display.grid(row=8, column=1, sticky="w", padx=self.gpadx, pady=self.gpady)
         self.add_tooltip(accent_btn, "Select custom accent color")
 
         slider, lbl = self.grid_slider(
             container,
             "Font Size:",
             self.font_size_var,
-            8,
+            9,
             from_=10,
             to=20,
         )
@@ -88,7 +93,7 @@ class QuickSettingsDialog(BaseDialog):
         slider.configure(command=_update_preview)
 
         self.preview = ctk.CTkFrame(container)
-        self.preview.grid(row=9, column=0, columnspan=2, sticky="ew", pady=(10, 0))
+        self.preview.grid(row=10, column=0, columnspan=2, sticky="ew", pady=(10, 0))
         self.preview.grid_columnconfigure(1, weight=1)
         lbl_preview = self.grid_label(self.preview, "Preview:", 0, columnspan=2)
         lbl_preview.configure(font=self.section_font)
@@ -98,7 +103,7 @@ class QuickSettingsDialog(BaseDialog):
         self._update_accent_preview()
 
         btn_frame = ctk.CTkFrame(container, fg_color="transparent")
-        btn_frame.grid(row=10, column=0, columnspan=2, pady=10)
+        btn_frame.grid(row=11, column=0, columnspan=2, pady=10)
         btn_frame.grid_columnconfigure((0, 1, 2), weight=1)
         self.apply_btn = self.grid_button(btn_frame, "Apply", self._apply, 0, column=0, columnspan=1)
         self.add_tooltip(self.apply_btn, "Save settings")
@@ -139,6 +144,7 @@ class QuickSettingsDialog(BaseDialog):
         cfg.set("show_menu", self.menu_var.get())
         cfg.set("show_toolbar", self.toolbar_var.get())
         cfg.set("show_statusbar", self.status_var.get())
+        cfg.set("basic_rendering", self.basic_render_var.get())
         cfg.set("appearance_mode", self.theme_var.get().lower())
         cfg.set("color_theme", self.color_var.get())
         theme_cfg = cfg.get("theme", {})
@@ -160,6 +166,7 @@ class QuickSettingsDialog(BaseDialog):
         self.menu_var.set(cfg.get("show_menu", True))
         self.toolbar_var.set(cfg.get("show_toolbar", True))
         self.status_var.set(cfg.get("show_statusbar", True))
+        self.basic_render_var.set(cfg.get("basic_rendering", False))
         self.theme_var.set(cfg.get("appearance_mode", "dark").title())
         self.color_var.set(cfg.get("color_theme", "blue"))
         self.accent_var.set(cfg.get("theme", {}).get("accent_color", "#007acc"))

--- a/tests/test_click_overlay.py
+++ b/tests/test_click_overlay.py
@@ -225,6 +225,22 @@ class TestClickOverlay(unittest.TestCase):
             root.destroy()
 
     @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_basic_render_disables_transparency(self) -> None:
+        root = tk.Tk()
+        with patch("src.views.click_overlay.is_supported", return_value=False):
+            overlay = ClickOverlay(root, basic_render=True)
+        try:
+            self.assertFalse(overlay._has_colorkey)
+            try:
+                key = overlay.attributes("-transparentcolor")
+            except Exception:
+                key = None
+            self.assertIsNone(key)
+        finally:
+            overlay.destroy()
+            root.destroy()
+
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
     def test_auto_tune_interval_persists(self) -> None:
         tmp = Path(tempfile.mkdtemp())
         with patch.dict(os.environ, {}, clear=True):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -68,6 +68,13 @@ def test_menu_default(monkeypatch):
     assert cfg.get("show_menu") is True
 
 
+def test_basic_rendering_default(monkeypatch):
+    tmp = Path(tempfile.mkdtemp())
+    monkeypatch.setattr(Path, "home", lambda: tmp)
+    cfg = Config()
+    assert cfg.get("basic_rendering") is False
+
+
 def test_force_quit_defaults(monkeypatch):
     tmp = Path(tempfile.mkdtemp())
     monkeypatch.setattr(Path, "home", lambda: tmp)

--- a/tests/test_gpu.py
+++ b/tests/test_gpu.py
@@ -1,0 +1,20 @@
+import types
+from unittest.mock import patch
+
+from src.utils.gpu import benchmark_gpu_usage
+
+
+class DummyGPU:
+    def __init__(self, load: float) -> None:
+        self.load = load
+
+
+def fake_getGPUs():
+    return [DummyGPU(0.5)]
+
+
+def test_benchmark_gpu_usage(monkeypatch):
+    gputil = types.SimpleNamespace(getGPUs=fake_getGPUs)
+    with patch.dict("sys.modules", {"GPUtil": gputil}):
+        usage = benchmark_gpu_usage(samples=1, interval=0)
+    assert usage == [50.0]


### PR DESCRIPTION
## Summary
- add basic rendering toggle to fall back to simpler drawing without compositing or drop shadows
- export GPU usage benchmark helper for verifying legacy hardware compatibility
- document feature and bump version to 1.0.70

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f462506f4832bad6c0f7b857017ae