### PR TITLE
feat: configurable click overlay executor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.73 - 2025-08-30
+
+- **Perf:** Use configurable thread pool for click overlay tasks, leveraging available CPU cores.
+
 ## 1.0.72 - 2025-08-30
 
 - **Feat:** Display watchdog spinner during kill operations, allow cancellation on timeout and log kill duration metrics.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.0.72"
+__version__ = "1.0.73"
 
 import os
 

--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -36,12 +36,34 @@ from src.utils import get_screen_refresh_rate
 from src.utils.helpers import log
 from src.config import Config
 
-EXECUTOR = ThreadPoolExecutor(max_workers=1)
+CFG = Config()
+
+
+def _load_int(env: str, key: str, default: int) -> int:
+    """Return an int loaded from ``env`` or configuration ``key``."""
+    val = os.getenv(env)
+    if val is not None:
+        try:
+            return int(val)
+        except ValueError:
+            pass
+    try:
+        cfg_val = CFG.get(key)
+        if cfg_val is not None:
+            return int(cfg_val)
+    except Exception:
+        pass
+    return default
+
+
+EXECUTOR = ThreadPoolExecutor(
+    max_workers=_load_int(
+        "KILL_BY_CLICK_WORKERS", "kill_by_click_workers", os.cpu_count() or 1
+    )
+)
 atexit.register(EXECUTOR.shutdown, cancel_futures=True)
 
 DEFAULT_HIGHLIGHT = os.getenv("KILL_BY_CLICK_HIGHLIGHT", "red")
-
-CFG = Config()
 
 
 def _load_calibrated(env: str, key: str, default: float) -> float:


### PR DESCRIPTION
## Summary
- allow configuring click overlay thread pool with KILL_BY_CLICK_WORKERS env or config value
- bump version to 1.0.73

## Testing
- `python -m py_compile src/views/click_overlay.py`
- `pytest` *(fails: interrupted with KeyboardInterrupt after 229 passed, 104 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_688f4fb120d4832bb5282f501f0f54c0