### PR TITLE
perf: vectorize overlay confidence scoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.74 - 2025-08-30
+
+- **Perf:** Vectorize weighted confidence scoring with NumPy and expose a Python wrapper for seamless integration.
+
 ## 1.0.73 - 2025-08-30
 
 - **Perf:** Use configurable thread pool for click overlay tasks, leveraging available CPU cores.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.0.73"
+__version__ = "1.0.74"
 
 import os
 

--- a/src/views/_fast_confidence.py
+++ b/src/views/_fast_confidence.py
@@ -1,0 +1,62 @@
+"""NumPy-accelerated weighted confidence scoring.
+
+This module provides a drop-in replacement for the Python implementation
+of :meth:`ScoringEngine.weighted_confidence`. When NumPy is available the
+probability calculations are performed with vectorized operations; if it
+is not installed we fall back to the original method so callers do not
+need to handle ImportError.
+"""
+
+from __future__ import annotations
+
+from typing import Deque, Tuple, List
+
+try:  # Optional NumPy acceleration
+    import numpy as _np
+except Exception:  # pragma: no cover - optional dependency
+    _np = None
+
+from src.utils.scoring_engine import ScoringEngine
+from src.utils.window_utils import WindowInfo
+
+
+def weighted_confidence(
+    engine: ScoringEngine,
+    samples: List[WindowInfo],
+    cursor_x: float,
+    cursor_y: float,
+    velocity: float,
+    path_history: Deque[Tuple[int, int]],
+    initial_active_pid: int | None,
+) -> Tuple[WindowInfo | None, float, float]:
+    """Return ``(info, ratio, probability)`` for ``samples``.
+
+    The heavy probability math is executed with NumPy when available to
+    avoid Python-level loops. When NumPy is not installed the function
+    simply delegates to ``engine.weighted_confidence``.
+    """
+
+    if _np is None:
+        return engine.weighted_confidence(
+            samples, cursor_x, cursor_y, velocity, path_history, initial_active_pid
+        )
+
+    weights = engine.score_samples(
+        samples, cursor_x, cursor_y, velocity, path_history, initial_active_pid
+    )
+    if not weights:
+        return None, 0.0, 0.0
+
+    w_arr = _np.fromiter(weights.values(), dtype=_np.float64)
+    scale = 1.0 / max(engine.tuning.softmax_temp, 1e-6)
+    exps = _np.exp(w_arr * scale)
+    probs = exps / _np.sum(exps)
+    best_idx = int(_np.argmax(probs))
+    best_prob = float(probs[best_idx])
+    if probs.size > 1:
+        second_prob = float(_np.partition(probs, -2)[-2])
+    else:
+        second_prob = 0.0
+    ratio = best_prob / (second_prob or 1e-6)
+    info = engine.select_from_weights(samples, weights)
+    return info, ratio, best_prob

--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -32,6 +32,7 @@ from src.utils.window_utils import (
 )
 from src.utils.mouse_listener import get_global_listener, is_supported
 from src.utils.scoring_engine import ScoringEngine, tuning
+from ._fast_confidence import weighted_confidence as _weighted_confidence_np
 from src.utils import get_screen_refresh_rate
 from src.utils.helpers import log
 from src.config import Config
@@ -455,7 +456,8 @@ class ClickOverlay(tk.Toplevel):
         """Run ``engine.weighted_confidence`` on the worker thread."""
 
         self._score_async(
-            lambda: self.engine.weighted_confidence(
+            lambda: _weighted_confidence_np(
+                self.engine,
                 samples,
                 self._cursor_x,
                 self._cursor_y,
@@ -476,7 +478,8 @@ class ClickOverlay(tk.Toplevel):
         """
 
         future = self._score_async(
-            lambda: self.engine.weighted_confidence(
+            lambda: _weighted_confidence_np(
+                self.engine,
                 samples,
                 self._cursor_x,
                 self._cursor_y,

--- a/tests/test_fast_confidence.py
+++ b/tests/test_fast_confidence.py
@@ -1,0 +1,33 @@
+from collections import deque
+import pytest
+
+try:
+    import numpy  # noqa: F401
+except Exception:  # pragma: no cover - skip if NumPy unavailable
+    pytest.skip("NumPy not available", allow_module_level=True)
+
+from src.utils.scoring_engine import ScoringEngine, tuning
+from src.utils.window_utils import WindowInfo
+from src.views._fast_confidence import weighted_confidence as fast_wc
+
+
+def test_fast_confidence_matches_engine() -> None:
+    engine = ScoringEngine(tuning, 200, 200, own_pid=0)
+    samples = [
+        WindowInfo(1, (0, 0, 100, 100)),
+        WindowInfo(2, (50, 0, 100, 100)),
+    ]
+    cursor_x = 75
+    cursor_y = 50
+    velocity = 0.0
+    path_history = deque(maxlen=1)
+    initial_active_pid = None
+
+    expected = engine.weighted_confidence(
+        samples, cursor_x, cursor_y, velocity, path_history, initial_active_pid
+    )
+    result = fast_wc(
+        engine, samples, cursor_x, cursor_y, velocity, path_history, initial_active_pid
+    )
+
+    assert result == expected


### PR DESCRIPTION
## Summary
- accelerate click overlay confidence calculations with optional NumPy backend
- add unit test for NumPy-powered weighted confidence
- bump version to 1.0.74

## Testing
- `flake8 src/views/_fast_confidence.py src/views/click_overlay.py tests/test_fast_confidence.py`
- `pytest tests/test_fast_confidence.py -q`
- `pytest tests/test_click_overlay.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688f515b3468832ba8ff0d5203ecc7ee