### PR TITLE
feat: update window cache via events

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.0.74"
+__version__ = "1.0.75"
 
 import os
 


### PR DESCRIPTION
## Summary
- watch for OS window changes and refresh window cache
- fall back to polling when change notifications unsupported
- test window change subscription logic

## Testing
- `pytest -q`
- `pytest tests/test_click_overlay.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f53f724a0832b8b7ddc7e66bf7e78