### PR TITLE
feat: add qt overlay backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.77 - 2025-09-01
+
+- **Feat:** Add optional OpenGL/Qt overlay backend selectable via ``KILL_BY_CLICK_BACKEND``.
+
 ## 1.0.76 - 2025-08-31
 
 - **Feat:** Debounce pointer motion with configurable ``KILL_BY_CLICK_MOVE_DEBOUNCE_MS``

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.0.76"
+__version__ = "1.0.77"
 
 import os
 


### PR DESCRIPTION
## Summary
- add optional Qt-based overlay backend
- allow selecting overlay renderer via `KILL_BY_CLICK_BACKEND`
- test backend selection and fallback

## Testing
- `pytest tests/test_click_overlay.py::TestClickOverlay::test_backend_env_falls_back_to_canvas tests/test_click_overlay.py::TestClickOverlay::test_backend_selects_qt_when_available -q`


------
https://chatgpt.com/codex/tasks/task_e_688f579cbc5c832b89226935821e5ed2