### PR TITLE
feat: support adaptive click overlay timing

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.0.77"
+__version__ = "1.0.78"
 
 import os
 

--- a/src/config.py
+++ b/src/config.py
@@ -123,6 +123,7 @@ class Config:
             "kill_by_click_interval": None,
             "kill_by_click_min_interval": None,
             "kill_by_click_max_interval": None,
+            "kill_by_click_auto_interval": True,
         }
 
         # Load configuration


### PR DESCRIPTION
## Summary
- add `_load_bool` utility
- add config-driven `adaptive_interval` toggle and refresh retuning
- cover new adaptive timing behavior with tests

## Testing
- `pytest` *(full test suite terminated)*
- `pytest tests/test_click_overlay.py`

------
https://chatgpt.com/codex/tasks/task_e_688f59fe31f8832ba4bbbb436d94b429