### PR TITLE
feat: add crosshair toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.79 - 2025-09-02
+
+- **Feat:** Allow disabling crosshair lines via ``show_crosshair`` and skip canvas updates for crosshair and label when hidden.
+
 ## 1.0.77 - 2025-09-01
 
 - **Feat:** Add optional OpenGL/Qt overlay backend selectable via ``KILL_BY_CLICK_BACKEND``.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.0.78"
+__version__ = "1.0.79"
 
 import os
 


### PR DESCRIPTION
## Summary
- allow disabling crosshair lines with `show_crosshair` or `KILL_BY_CLICK_CROSSHAIR`
- skip canvas updates when crosshair or label are hidden
- bump version to 1.0.79

## Testing
- `pytest tests/test_click_overlay.py::TestClickOverlay::test_overlay_can_disable_crosshair tests/test_click_overlay.py::TestClickOverlay::test_env_disables_crosshair tests/test_click_overlay.py::TestClickOverlay::test_crosshair_updates_skipped_when_disabled` (skipped: DISPLAY not set)


------
https://chatgpt.com/codex/tasks/task_e_688f5bc2a520832bbac71944dca2f22b