### PR TITLE
Prime global mouse listener before overlay usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.80 - 2025-09-03
+
+- **Fix:** Start global listener during Force Quit dialog initialization so hooks are primed before the first click.
+
 ## 1.0.79 - 2025-09-02
 
 - **Feat:** Allow disabling crosshair lines via ``show_crosshair`` and skip canvas updates for crosshair and label when hidden.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.0.79"
+__version__ = "1.0.80"
 
 import os
 

--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -1238,6 +1238,8 @@ class ClickOverlay(tk.Toplevel):
     def choose(self) -> tuple[int | None, str | None]:
         """Show the overlay and return the PID and title of the clicked window."""
         self._closed.set(False)
+        listener = get_global_listener()
+        listener.start()
         try:
             if is_supported():
                 make_window_clickthrough(self)
@@ -1263,7 +1265,6 @@ class ClickOverlay(tk.Toplevel):
                 pass
         use_hooks = is_supported()
         if use_hooks:
-            listener = get_global_listener()
             if not listener.start(on_move=self._on_move, on_click=self._click):
                 use_hooks = False
                 self.state = OverlayState.POLLING

--- a/src/views/force_quit_dialog.py
+++ b/src/views/force_quit_dialog.py
@@ -39,6 +39,7 @@ from src.utils.helpers import (
     lighten_color,
     darken_color,
 )
+from src.utils.mouse_listener import get_global_listener
 
 import importlib
 
@@ -54,6 +55,7 @@ class ForceQuitDialog(BaseDialog):
 
     def __init__(self, app):
         super().__init__(app, title="Force Quit", resizable=(True, True))
+        get_global_listener().start()
         width_env = os.getenv("FORCE_QUIT_WIDTH")
         height_env = os.getenv("FORCE_QUIT_HEIGHT")
         sort_env = os.getenv("FORCE_QUIT_SORT")


### PR DESCRIPTION
## Summary
- start shared global mouse listener during Force Quit dialog setup
- ensure click overlay enables callbacks only after showing the overlay
- bump version to 1.0.80 and document change

## Testing
- `pytest` *(terminated: killed after partial run)*
- `pytest tests/test_mouse_listener.py tests/test_force_quit.py`

------
https://chatgpt.com/codex/tasks/task_e_688f5db91a70832bacd4a9ee3ddd80e5