### PR TITLE
feat: speed window lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## 1.0.83 - 2025-09-04
+
+- **Perf:** Use ``WindowFromPoint`` on Windows for direct lookups and avoid
+  enumerating stacked windows unless deeper z-order data is requested.
+- **Perf:** Skip stack queries in ``ScoringEngine`` when scoring a single
+  window.
+
 ## 1.0.82 - 2025-09-04
 
 - **Perf:** Refresh window cache on OS events and query cache for window lookups,

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.0.82"
+__version__ = "1.0.83"
 
 import os
 

--- a/src/utils/scoring_engine.py
+++ b/src/utils/scoring_engine.py
@@ -342,14 +342,24 @@ class ScoringEngine:
                 weights[pid] = weights.get(pid, 0.0) + dur * self.tuning.duration_weight
 
         if self.tuning.zorder_weight:
-            prime_window_cache()
-            stack = list_windows_at(int(cursor_x), int(cursor_y))
-            for idx, info in enumerate(stack):
-                if info.pid is None:
-                    continue
-                weights[info.pid] = weights.get(
-                    info.pid, 0.0
-                ) + self.tuning.zorder_weight / (idx + 1)
+            if len(samples) <= 1:
+                for info in samples:
+                    if info.pid is None:
+                        continue
+                    weights[info.pid] = weights.get(
+                        info.pid, 0.0
+                    ) + self.tuning.zorder_weight
+            else:
+                prime_window_cache()
+                stack = list_windows_at(
+                    int(cursor_x), int(cursor_y), len(samples)
+                )
+                for idx, info in enumerate(stack):
+                    if info.pid is None:
+                        continue
+                    weights[info.pid] = weights.get(
+                        info.pid, 0.0
+                    ) + self.tuning.zorder_weight / (idx + 1)
 
         if self.tuning.gaze_weight:
             for pid, dur in self.gaze_duration.items():

--- a/tests/test_scoring_engine.py
+++ b/tests/test_scoring_engine.py
@@ -1,0 +1,25 @@
+from collections import deque
+from unittest.mock import patch
+
+from src.utils.scoring_engine import ScoringEngine, tuning
+from src.utils.window_utils import WindowInfo
+
+
+def test_skip_zorder_stack_for_single_sample() -> None:
+    engine = ScoringEngine(tuning, 100, 100, own_pid=0)
+    sample = [WindowInfo(1, (0, 0, 10, 10))]
+    with patch.object(tuning, "zorder_weight", 5.0), patch(
+        "src.utils.scoring_engine.list_windows_at"
+    ) as lwa, patch("src.utils.scoring_engine.prime_window_cache"):
+        engine.score_samples(sample, 0.0, 0.0, 0.0, deque(), None)
+        lwa.assert_not_called()
+
+
+def test_zorder_stack_limited_depth() -> None:
+    engine = ScoringEngine(tuning, 100, 100, own_pid=0)
+    samples = [WindowInfo(1, (0, 0, 10, 10)), WindowInfo(2, (0, 0, 10, 10))]
+    with patch.object(tuning, "zorder_weight", 5.0), patch(
+        "src.utils.scoring_engine.list_windows_at", return_value=samples
+    ) as lwa, patch("src.utils.scoring_engine.prime_window_cache"):
+        engine.score_samples(samples, 5.0, 5.0, 0.0, deque(), None)
+        lwa.assert_called_once_with(5, 5, len(samples))

--- a/tests/test_window_utils.py
+++ b/tests/test_window_utils.py
@@ -41,6 +41,19 @@ class TestWindowUtils(unittest.TestCase):
             self.assertIsInstance(info, WindowInfo)
             self.assertTrue(hasattr(info, "handle"))
 
+    def test_list_windows_fast_path(self):
+        from src.utils import window_utils as wu
+
+        fake = wu.WindowInfo(1)
+        with (
+            mock.patch.object(wu, "get_window_at", return_value=fake) as gwa,
+            mock.patch.object(wu, "_fallback_list_windows_at") as fallback,
+        ):
+            res = wu.list_windows_at(0, 0, 1)
+        self.assertEqual(res, [fake])
+        gwa.assert_called_once_with(0, 0)
+        fallback.assert_not_called()
+
     def test_fallback_async_cache(self):
         from src.utils import window_utils as wu
 


### PR DESCRIPTION
## Summary
- avoid costly window enumeration when only the top window is needed
- skip z-order stack queries in scoring engine for single-window samples
- document and expose the optimization in the changelog

## Testing
- `pytest tests/test_window_utils.py tests/test_scoring_engine.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f6499e458832ba68c9c0286472734