### PR TITLE
feat: refine cursor tracking with kalman filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 1.1.0 - 2025-09-04
+
+- **Feat:** Replace exponential smoothing with a configurable Kalman filter for
+  click overlay cursor tracking.
+
 ## 1.0.83 - 2025-09-04
 
 - **Perf:** Use ``WindowFromPoint`` on Windows for direct lookups and avoid

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.0.83"
+__version__ = "1.1.0"
 
 import os
 

--- a/src/config.py
+++ b/src/config.py
@@ -124,6 +124,8 @@ class Config:
             "kill_by_click_min_interval": None,
             "kill_by_click_max_interval": None,
             "kill_by_click_auto_interval": True,
+            "kill_by_click_kf_process_noise": 1.0,
+            "kill_by_click_kf_measurement_noise": 5.0,
         }
 
         # Load configuration

--- a/tests/test_click_overlay.py
+++ b/tests/test_click_overlay.py
@@ -1372,7 +1372,7 @@ class TestClickOverlay(unittest.TestCase):
         root.destroy()
 
     @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
-    def test_velocity_smoothing_applied(self) -> None:
+    def test_kalman_velocity_updates(self) -> None:
         root = tk.Tk()
         with patch("src.views.click_overlay.is_supported", return_value=False):
             overlay = ClickOverlay(root)
@@ -1381,11 +1381,10 @@ class TestClickOverlay(unittest.TestCase):
         overlay._last_move_time = 0.0
 
         overlay.after_idle = lambda cb: cb()
+        overlay._kf_x.q = overlay._kf_y.q = 1e-5
+        overlay._kf_x.r = overlay._kf_y.r = 1e-3
 
-        with (
-            patch("src.views.click_overlay.time.time", side_effect=[0.1, 0.2]),
-            patch("src.utils.scoring_engine.tuning.velocity_smooth", 0.5),
-        ):
+        with patch("src.views.click_overlay.time.time", side_effect=[0.1, 0.2]):
             overlay._on_move(10, 0)
             first = overlay._velocity
             overlay._on_move(20, 0)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -75,6 +75,14 @@ def test_basic_rendering_default(monkeypatch):
     assert cfg.get("basic_rendering") is False
 
 
+def test_kill_by_click_kalman_defaults(monkeypatch):
+    tmp = Path(tempfile.mkdtemp())
+    monkeypatch.setattr(Path, "home", lambda: tmp)
+    cfg = Config()
+    assert cfg.get("kill_by_click_kf_process_noise") == 1.0
+    assert cfg.get("kill_by_click_kf_measurement_noise") == 5.0
+
+
 def test_force_quit_defaults(monkeypatch):
     tmp = Path(tempfile.mkdtemp())
     monkeypatch.setattr(Path, "home", lambda: tmp)

--- a/tests/test_kalman_filter.py
+++ b/tests/test_kalman_filter.py
@@ -1,0 +1,9 @@
+from src.views.click_overlay import _Kalman1D
+
+
+def test_kalman_update_tracks_velocity():
+    kf = _Kalman1D(0.0001, 0.01)
+    kf.update(0.0, 0.0)
+    x, v = kf.update(10.0, 1.0)
+    assert abs(x - 10.0) < 0.1
+    assert v > 4.0


### PR DESCRIPTION
## Summary
- replace cursor smoothing in click overlay with configurable Kalman filter
- expose process and measurement noise tuning via Config
- add tests for Kalman filter and configuration defaults

## Testing
- `pytest -q` *(fails: Terminated)*
- `pytest tests/test_kalman_filter.py tests/test_config.py::test_kill_by_click_kalman_defaults tests/test_click_overlay.py::TestClickOverlay::test_kalman_velocity_updates -q`

------
https://chatgpt.com/codex/tasks/task_e_688f67274e8c832bb5c9de63e870f499