### PR TITLE
feat: accelerate sample scoring

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -28,6 +28,9 @@ jobs:
         python -m pip install --upgrade pip
         pip install flake8 pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Build Cython extensions
+      run: |
+        cythonize -i src/utils/_score_samples.pyx src/utils/_heatmap.pyx
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.1.2 - 2025-09-06
+
+- **Perf:** Offload sample scoring loops to optional Cython extension with Python fallback.
+
 ## 1.1.1 - 2025-09-05
 
 - **Fix:** Pre-initialize click overlay and global mouse listener in Force Quit

--- a/setup.py
+++ b/setup.py
@@ -225,7 +225,11 @@ def build_extensions() -> None:
                     "src.utils._heatmap",
                     ["src/utils/_heatmap.pyx"],
                     include_dirs=[numpy.get_include()],
-                )
+                ),
+                Extension(
+                    "src.utils._score_samples",
+                    ["src/utils/_score_samples.pyx"],
+                ),
             ],
             quiet=True,
         )

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"
 
 import os
 

--- a/src/utils/_score_samples.pyx
+++ b/src/utils/_score_samples.pyx
@@ -1,0 +1,101 @@
+from libc.math cimport hypot
+cimport cython
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def update_weights(
+    samples,
+    double cursor_x,
+    double cursor_y,
+    double velocity,
+    path_history,
+    tuning,
+    int own_pid,
+    weights,
+    pid_history,
+    heatmap,
+    active_pid,
+):
+    cdef double power = 1.0
+    cdef double vel_factor, w
+    cdef double cx, cy, dist, diag
+    cdef double left, top, right, bottom, near_x, near_y, val
+    cdef double area_f, heat
+    cdef int area, inside
+    cdef object info
+    cdef object px, py
+    cdef tuple rect
+
+    for info in samples[::-1]:
+        if info.pid == own_pid or info.pid is None:
+            continue
+        vel_factor = 1.0 / (1.0 + velocity * tuning.velocity_scale)
+        w = tuning.sample_weight * power * vel_factor
+        if active_pid is not None and info.pid == active_pid:
+            w *= tuning.active_bonus
+        rect = info.rect
+        if rect is not None and tuning.area_weight:
+            area = rect[2] * rect[3]
+            if area:
+                w += tuning.area_weight / area
+        if rect is not None and tuning.center_weight:
+            cx = rect[0] + rect[2] / 2.0
+            cy = rect[1] + rect[3] / 2.0
+            dist = hypot(cx - cursor_x, cy - cursor_y)
+            diag = hypot(rect[2], rect[3])
+            if diag != 0:
+                dist = dist / diag
+                if dist > 1.0:
+                    dist = 1.0
+                w += tuning.center_weight * (1.0 - dist)
+        if rect is not None and tuning.edge_penalty:
+            left = rect[0]
+            top = rect[1]
+            right = left + rect[2]
+            bottom = top + rect[3]
+            near_x = cursor_x - left
+            if near_x < 0:
+                near_x = -near_x
+            val = cursor_x - right
+            if val < 0:
+                val = -val
+            if val < near_x:
+                near_x = val
+            near_y = cursor_y - top
+            if near_y < 0:
+                near_y = -near_y
+            val = cursor_y - bottom
+            if val < 0:
+                val = -val
+            if val < near_y:
+                near_y = val
+            if near_x <= tuning.edge_buffer or near_y <= tuning.edge_buffer:
+                val = 1.0 - tuning.edge_penalty
+                if val < 0.0:
+                    val = 0.0
+                w *= val
+        if rect is not None and tuning.path_weight and path_history:
+            inside = 0
+            for px, py in path_history:
+                if rect[0] <= px <= rect[0] + rect[2] and rect[1] <= py <= rect[1] + rect[3]:
+                    inside += 1
+            w += tuning.path_weight * inside / len(path_history)
+        if tuning.heatmap_weight and rect is not None:
+            heat = heatmap.region_score(rect)
+            area_f = rect[2] * rect[3]
+            if area_f == 0:
+                area_f = 1.0
+            w += tuning.heatmap_weight * heat / area_f
+        weights[info.pid] = weights.get(info.pid, 0.0) + w
+        power *= tuning.sample_decay
+
+    power = 1.0
+    for pid in pid_history[::-1]:
+        vel_factor = 1.0 / (1.0 + velocity * tuning.velocity_scale)
+        w = tuning.history_weight * power * vel_factor
+        if active_pid is not None and pid == active_pid:
+            w *= tuning.active_bonus
+        weights[pid] = weights.get(pid, 0.0) + w
+        power *= tuning.history_decay
+
+    return weights

--- a/tests/test_score_samples_extension.py
+++ b/tests/test_score_samples_extension.py
@@ -1,0 +1,28 @@
+from collections import deque
+from unittest.mock import patch
+
+import pytest
+
+from src.utils.scoring_engine import ScoringEngine, tuning, _cy_score_samples
+from src.utils.window_utils import WindowInfo
+
+
+def test_score_samples_extension_matches_python() -> None:
+    engine = ScoringEngine(tuning, 100, 100, own_pid=0)
+    samples = [WindowInfo(1, (0, 0, 10, 10)), WindowInfo(2, (10, 0, 10, 10))]
+    path = deque([(1, 1), (11, 1)])
+    if _cy_score_samples is None:
+        pytest.skip("Cython extension not built")
+    with patch.multiple(
+        tuning,
+        area_weight=1.0,
+        center_weight=1.0,
+        edge_penalty=0.5,
+        path_weight=1.0,
+        history_weight=0.5,
+        velocity_scale=0.1,
+    ):
+        with patch("src.utils.scoring_engine._cy_score_samples", None):
+            weights_py = engine.score_samples(samples, 5.0, 5.0, 0.5, path, None)
+        weights_cy = engine.score_samples(samples, 5.0, 5.0, 0.5, path, None)
+    assert weights_cy == weights_py


### PR DESCRIPTION
## Summary
- accelerate sample scoring with optional Cython loop
- build Cython modules during CI
- test parity between Python and Cython implementations

## Testing
- `flake8 .` *(fails: E402, F401, W293, etc.)*
- `pytest tests/test_score_samples_extension.py tests/test_scoring_engine.py`


------
https://chatgpt.com/codex/tasks/task_e_688f6b715890832bae5397b39fc06e36