### PR TITLE
feat: add qtquick backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -359,3 +359,8 @@
 - **Fix:** Parse hex color strings without consulting Tk, ensuring reliable
   transparent color keys.
 
+## 1.1.3 - 2025-08-03
+
+- **Feat:** Support QtQuick/OpenGL overlay backend with shared drawing
+  interface and runtime selection via ``KILL_BY_CLICK_BACKEND``.
+

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.1.2"
+__version__ = "1.1.3"
 
 import os
 

--- a/tests/test_click_overlay.py
+++ b/tests/test_click_overlay.py
@@ -275,6 +275,17 @@ class TestClickOverlay(unittest.TestCase):
                 overlay.destroy()
                 root.destroy()
 
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_backend_env_falls_back_to_canvas_qtquick(self) -> None:
+        with patch.dict(os.environ, {"KILL_BY_CLICK_BACKEND": "qtquick"}):
+            root = tk.Tk()
+            overlay = ClickOverlay(root)
+            try:
+                self.assertEqual(getattr(overlay, "backend", ""), "canvas")
+            finally:
+                overlay.destroy()
+                root.destroy()
+
     def test_backend_selects_qt_when_available(self) -> None:
         class DummyOverlay:
             def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -285,6 +296,17 @@ class TestClickOverlay(unittest.TestCase):
         ):
             overlay = ClickOverlay(None, backend="qt")
             self.assertEqual(getattr(overlay, "backend", ""), "qt")
+
+    def test_backend_selects_qtquick_when_available(self) -> None:
+        class DummyOverlay:
+            def __init__(self, *args: Any, **kwargs: Any) -> None:
+                self.backend = "qtquick"
+
+        with patch("src.views.click_overlay.QT_QUICK_AVAILABLE", True), patch(
+            "src.views.click_overlay.QtQuickClickOverlay", DummyOverlay
+        ):
+            overlay = ClickOverlay(None, backend="qtquick")
+            self.assertEqual(getattr(overlay, "backend", ""), "qtquick")
 
     @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
     def test_basic_render_disables_transparency(self) -> None:


### PR DESCRIPTION
## Summary
- add QtQuick/OpenGL backend with shared drawing interface
- allow selecting canvas backend via `KILL_BY_CLICK_BACKEND`
- test QtQuick backend selection

## Testing
- `pytest tests/test_click_overlay.py::TestClickOverlay::test_backend_env_falls_back_to_canvas_qtquick tests/test_click_overlay.py::TestClickOverlay::test_backend_selects_qtquick_when_available -q`
- `pytest -q` *(fails: Terminated)*

------
https://chatgpt.com/codex/tasks/task_e_688f6e083df0832b9a7efe04410d039c