### PR TITLE
feat: ignore transient windows in scoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.1.5 - 2025-09-08
+
+- **Feat:** Skip tiny or menu/tooltip windows and ignore their PIDs when scoring.
+
 ## 1.1.4 - 2025-09-07
 
 - **Perf:** Introduce off-screen buffer with selective canvas updates and frame

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.1.4"
+__version__ = "1.1.5"
 
 import os
 

--- a/src/config.py
+++ b/src/config.py
@@ -126,6 +126,8 @@ class Config:
             "kill_by_click_auto_interval": True,
             "kill_by_click_kf_process_noise": 1.0,
             "kill_by_click_kf_measurement_noise": 5.0,
+            "window_min_width": 0,
+            "window_min_height": 0,
         }
 
         # Load configuration

--- a/tests/test_window_utils.py
+++ b/tests/test_window_utils.py
@@ -113,6 +113,29 @@ class TestWindowUtils(unittest.TestCase):
         res2 = filter_windows_at(12, 12, wins)
         self.assertEqual(res2, [wins[1]])
 
+    def test_filter_windows_skips_small_and_tooltip(self):
+        from src.utils import window_utils as wu
+
+        small = wu.WindowInfo(1, (0, 0, 5, 5), "tiny")
+        normal = wu.WindowInfo(2, (0, 0, 50, 50), "normal")
+        tooltip = wu.WindowInfo(3, (0, 0, 50, 50), "tooltip window")
+
+        with mock.patch.object(wu, "_MIN_WINDOW_WIDTH", 10), mock.patch.object(
+            wu, "_MIN_WINDOW_HEIGHT", 10
+        ):
+            wu._TRANSIENT_PIDS.clear()
+            res = wu.filter_windows_at(1, 1, [small, normal])
+            self.assertEqual(res, [normal])
+            self.assertIn(1, wu._TRANSIENT_PIDS)
+
+        wu._TRANSIENT_PIDS.clear()
+        with mock.patch.object(wu, "_MIN_WINDOW_WIDTH", 0), mock.patch.object(
+            wu, "_MIN_WINDOW_HEIGHT", 0
+        ):
+            res = wu.filter_windows_at(1, 1, [tooltip, normal])
+            self.assertEqual(res, [normal])
+            self.assertIn(3, wu._TRANSIENT_PIDS)
+
     def test_x11_shortcuts(self):
         from src.utils import window_utils as wu
 


### PR DESCRIPTION
## Summary
- skip tiny or tooltip/menu windows when probing coordinates
- omit transient window PIDs from scoring calculations
- expose window size thresholds in config

## Testing
- `COOLBOX_LIGHTWEIGHT=1 pytest tests/test_window_utils.py tests/test_scoring_engine.py`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f72959f30832b91e8bd4cd3459c60