### PR TITLE
test: add click overlay benchmark

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,29 @@
+name: Nightly Tests
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  slow-tests:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.13"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 pytest
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Build Cython extensions
+        run: |
+          cythonize -i src/utils/_score_samples.pyx src/utils/_heatmap.pyx
+      - name: Run slow tests
+        run: |
+          pytest -m slow

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -39,4 +39,4 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        pytest
+        pytest -m "not slow"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.1.6 - 2025-09-09
+
+- **Test:** Add click overlay pointer movement benchmark.
+
 ## 1.1.5 - 2025-09-08
 
 - **Feat:** Skip tiny or menu/tooltip windows and ignore their PIDs when scoring.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    slow: marks tests as slow (deselect with '-m "not slow"')

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.1.5"
+__version__ = "1.1.6"
 
 import os
 


### PR DESCRIPTION
## Summary
- add benchmark test for rapid pointer movement with avg frame delay assertion
- mark slow tests and run them nightly in CI
- bump version to 1.1.6

## Testing
- `flake8 src/__init__.py tests/test_click_overlay.py`
- `pytest tests/test_click_overlay.py::test_pointer_move_frame_delay_benchmark -m slow -vv`

------
https://chatgpt.com/codex/tasks/task_e_688f74b29c28832b892cb4ced3ee1503