### PR TITLE
fix: avoid redundant selection on unchanged pid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.2.2 - 2025-09-12
+
+- **Fix:** Avoid redundant selection when highlighting the same PID.
+
 ## 1.2.1 - 2025-09-11
 
 - **Refactor:** Initialize kill-by-click overlay once and reuse configuration.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"
 
 import argparse
 import os

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"
 
 import os
 

--- a/src/views/force_quit_dialog.py
+++ b/src/views/force_quit_dialog.py
@@ -1775,7 +1775,9 @@ class ForceQuitDialog(BaseDialog):
             return
         iid = str(pid)
         self.tree.see(iid)
-        self.tree.selection_set(iid)
+        current = self.tree.selection()
+        if current != (iid,):
+            self.tree.selection_set(iid)
         self._set_hover_row(iid)
         self._show_details()
 

--- a/tests/test_force_quit.py
+++ b/tests/test_force_quit.py
@@ -1299,6 +1299,19 @@ class TestForceQuit(unittest.TestCase):
                 self.assertEqual(kbc_calls, kbc_calls_after)
                 overlay.canvas.itemconfigure.assert_not_called()
 
+    def test_highlight_pid_skips_duplicate_selection(self) -> None:
+        dialog = ForceQuitDialog.__new__(ForceQuitDialog)
+        tree = mock.Mock()
+        tree.exists.return_value = True
+        tree.selection.return_value = ("123",)
+        dialog.tree = tree
+        dialog._set_hover_row = mock.Mock()
+        dialog._show_details = mock.Mock()
+
+        dialog._highlight_pid(123)
+
+        tree.selection_set.assert_not_called()
+
     @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
     def test_hover_highlights_row(self) -> None:
         root = tk.Tk()


### PR DESCRIPTION
## Summary
- avoid reselecting already-selected PIDs in ForceQuitDialog
- test that highlighting the same PID doesn't select again
- bump version to 1.2.2

## Testing
- `pytest tests/test_force_quit.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f7c18b704832b85547195b58226fe