### PR TITLE
Scale probe cache TTL with cursor speed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.2.4 - 2025-09-14
+
+- **Perf:** Scale window probe cache TTL inversely with cursor velocity for faster cache expiry when moving quickly.
+
 ## 1.2.3 - 2025-09-13
 
 - **Feat:** Scale click overlay debounce thresholds with cursor velocity.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "1.2.3"
+__version__ = "1.2.4"
 
 import argparse
 import os

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.2.3"
+__version__ = "1.2.4"
 
 import os
 

--- a/tests/test_click_overlay_cache_ttl.py
+++ b/tests/test_click_overlay_cache_ttl.py
@@ -1,0 +1,52 @@
+import os
+import time
+import unittest
+import tkinter as tk
+from unittest.mock import Mock, patch
+
+os.environ.setdefault("COOLBOX_LIGHTWEIGHT", "1")
+
+from src.views.click_overlay import ClickOverlay, WindowInfo, PROBE_CACHE_TTL  # noqa: E402
+
+
+class TestClickOverlayProbeTTL(unittest.TestCase):
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_fast_cursor_expires_cache_quickly(self) -> None:
+        root = tk.Tk()
+        with (
+            patch("src.views.click_overlay.is_supported", return_value=False),
+            patch("src.views.click_overlay.subscribe_window_change", return_value=None),
+            patch("src.views.click_overlay.get_active_window", return_value=WindowInfo(None)),
+            patch("src.views.click_overlay.subscribe_active_window", return_value=None),
+        ):
+            overlay = ClickOverlay(root)
+        try:
+            overlay._window_cache_rect = (0, 0, 100, 100)
+            overlay._window_cache_future = None
+
+            now = time.monotonic()
+            overlay._window_cache_time = now - PROBE_CACHE_TTL / 2
+            overlay._pending_move = (10, 10, now)
+            overlay._last_move_time = now - 0.1
+            overlay._kf_x.update = Mock(return_value=(10, 0.0))
+            overlay._kf_y.update = Mock(return_value=(10, 0.0))
+            with patch.object(overlay, "_refresh_window_cache") as refresh:
+                overlay._handle_move()
+                slow_ttl = overlay._probe_cache_ttl
+                self.assertFalse(refresh.called)
+
+            now = time.monotonic()
+            overlay._window_cache_time = now - PROBE_CACHE_TTL / 2
+            overlay._pending_move = (20, 20, now)
+            overlay._last_move_time = now - 0.1
+            overlay._kf_x.update = Mock(return_value=(20, 200.0))
+            overlay._kf_y.update = Mock(return_value=(20, 0.0))
+            with patch.object(overlay, "_refresh_window_cache") as refresh:
+                overlay._handle_move()
+                fast_ttl = overlay._probe_cache_ttl
+                self.assertTrue(refresh.called)
+
+            self.assertLess(fast_ttl, slow_ttl)
+        finally:
+            overlay.destroy()
+            root.destroy()


### PR DESCRIPTION
## Summary
- Scale window probe cache TTL inversely with cursor velocity for more responsive lookups
- Add regression test validating quicker cache refresh on fast cursor movement
- Bump version to 1.2.4 and document probe TTL tuning

## Testing
- `flake8 src/views/click_overlay.py tests/test_click_overlay_cache_ttl.py setup.py src/__init__.py` *(fails: E402, E704)*
- `pytest tests/test_click_overlay_cache_ttl.py -q` *(skipped: No display available)*

------
https://chatgpt.com/codex/tasks/task_e_688f7f312f38832bb60da4ade0c5587e