### PR TITLE
feat: auto-calibrate click overlay intervals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.2.5 - 2025-09-15
+
+- **Feat:** Auto-calibrate click overlay intervals and reuse saved tuning.
+
 ## 1.2.4 - 2025-09-14
 
 - **Perf:** Scale window probe cache TTL inversely with cursor velocity for faster cache expiry when moving quickly.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "1.2.4"
+__version__ = "1.2.5"
 
 import argparse
 import os

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.2.4"
+__version__ = "1.2.5"
 
 import os
 


### PR DESCRIPTION
## Summary
- auto-tune click overlay refresh rate before overlay creation and persist results
- add integration test to ensure ForceQuitDialog uses tuned intervals from config
- bump version to 1.2.5

## Testing
- `pytest` *(terminated early during tests)*
- `pytest tests/test_click_overlay.py::TestClickOverlay::test_force_quit_dialog_applies_tuned_interval -q` *(skipped: No display available)*

------
https://chatgpt.com/codex/tasks/task_e_688f8153af4c832baa555aff682792c5