### PR TITLE
refactor: centralize overlay highlight color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.2.6 - 2025-09-16
+
+- **Refactor:** Centralize overlay highlight color updates and tests.
+
 ## 1.2.5 - 2025-09-15
 
 - **Feat:** Auto-calibrate click overlay intervals and reuse saved tuning.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "1.2.5"
+__version__ = "1.2.6"
 
 import argparse
 import os

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.2.5"
+__version__ = "1.2.6"
 
 import os
 

--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -949,6 +949,16 @@ class ClickOverlay(tk.Toplevel):
             lambda: self.canvas.itemconfigure(self.rect, width=2),
         )
 
+    def set_highlight_color(self, color: str) -> None:
+        """Update the highlight color for all overlay elements."""
+        self.canvas.itemconfigure(self.rect, outline=color)
+        if self.hline is not None:
+            self.canvas.itemconfigure(self.hline, fill=color)
+        if self.vline is not None:
+            self.canvas.itemconfigure(self.vline, fill=color)
+        if self.label is not None:
+            self.canvas.itemconfigure(self.label, fill=color)
+
     def _calc_label_pos(self, px: int, py: int, sw: int, sh: int) -> tuple[int, int] | None:
         """Return label coordinates near the cursor, constrained to the screen."""
         if not self.show_label or self.label is None:

--- a/src/views/force_quit_dialog.py
+++ b/src/views/force_quit_dialog.py
@@ -2142,10 +2142,7 @@ class ForceQuitDialog(BaseDialog):
         interval_env = os.getenv("KILL_BY_CLICK_INTERVAL")
         overlay = self._overlay
         overlay.on_hover = self._highlight_pid
-        overlay.canvas.itemconfigure(overlay.rect, outline=color)
-        overlay.canvas.itemconfigure(overlay.hline, fill=color)
-        overlay.canvas.itemconfigure(overlay.vline, fill=color)
-        overlay.canvas.itemconfigure(overlay.label, fill=color)
+        overlay.set_highlight_color(color)
         if interval_env is not None:
             try:
                 overlay.interval = float(interval_env)

--- a/tests/test_click_overlay.py
+++ b/tests/test_click_overlay.py
@@ -64,6 +64,19 @@ class TestClickOverlay(unittest.TestCase):
             root.destroy()
 
     @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_set_highlight_color_updates_all_items(self) -> None:
+        root = tk.Tk()
+        with patch("src.views.click_overlay.is_supported", return_value=False):
+            overlay = ClickOverlay(root)
+        overlay.set_highlight_color("blue")
+        self.assertEqual(overlay.canvas.itemcget(overlay.rect, "outline"), "blue")
+        self.assertEqual(overlay.canvas.itemcget(overlay.hline, "fill"), "blue")
+        self.assertEqual(overlay.canvas.itemcget(overlay.vline, "fill"), "blue")
+        self.assertEqual(overlay.canvas.itemcget(overlay.label, "fill"), "blue")
+        overlay.destroy()
+        root.destroy()
+
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
     def test_overlay_can_disable_label(self) -> None:
         root = tk.Tk()
         with patch("src.views.click_overlay.is_supported", return_value=False):

--- a/tests/test_force_quit.py
+++ b/tests/test_force_quit.py
@@ -1273,6 +1273,7 @@ class TestForceQuit(unittest.TestCase):
         dialog._highlight_pid = mock.Mock()
         overlay = mock.Mock()
         overlay.choose.return_value = (None, None)
+        overlay.set_highlight_color = mock.Mock()
         overlay.canvas = mock.Mock()
         overlay.rect = object()
         overlay.hline = object()
@@ -1290,14 +1291,14 @@ class TestForceQuit(unittest.TestCase):
                     [c for c in getenv.call_args_list if c.args[0].startswith("KILL_BY_CLICK")]
                 )
                 self.assertGreater(kbc_calls, 0)
-                self.assertGreater(overlay.canvas.itemconfigure.call_count, 0)
-                overlay.canvas.itemconfigure.reset_mock()
+                overlay.set_highlight_color.assert_called_once()
+                overlay.set_highlight_color.reset_mock()
                 dialog._kill_by_click()
                 kbc_calls_after = len(
                     [c for c in getenv.call_args_list if c.args[0].startswith("KILL_BY_CLICK")]
                 )
                 self.assertEqual(kbc_calls, kbc_calls_after)
-                overlay.canvas.itemconfigure.assert_not_called()
+                overlay.set_highlight_color.assert_not_called()
 
     def test_highlight_pid_skips_duplicate_selection(self) -> None:
         dialog = ForceQuitDialog.__new__(ForceQuitDialog)


### PR DESCRIPTION
## Summary
- centralize overlay highlight updates via `set_highlight_color`
- use new API in `ForceQuitDialog` and add regression tests
- bump version to 1.2.6

## Testing
- `pytest tests/test_force_quit.py -vv`
- `pytest tests/test_click_overlay.py::TestClickOverlay::test_set_highlight_color_updates_all_items -vv` *(skipped: No display available)*
- `pytest` *(terminates mid-run)*

------
https://chatgpt.com/codex/tasks/task_e_688f83e4721c832bb4fc42928b593faa