### PR TITLE
refactor: context manage kill-by-click overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.2.7 - 2025-09-17
+
+- **Refactor:** Manage Kill-by-Click overlay cleanup with a context manager.
+
 ## 1.2.6 - 2025-09-16
 
 - **Refactor:** Centralize overlay highlight color updates and tests.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "1.2.6"
+__version__ = "1.2.7"
 
 import argparse
 import os

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.2.6"
+__version__ = "1.2.7"
 
 import os
 


### PR DESCRIPTION
## Summary
- use a context manager for Kill-by-Click overlay to handle withdrawal, reset, and hover callbacks
- add regression test for exception cleanup
- bump version to 1.2.7

## Testing
- `pytest tests/test_force_quit.py`


------
https://chatgpt.com/codex/tasks/task_e_688f864a8648832bac88d3757be7d7f6