### PR TITLE
fix: clamp click overlay delay to minimum interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.2.8 - 2025-09-18
+
+- **Fix:** Clamp delay smoothing to the minimum interval to avoid negative scheduling after slow frames.
+
 ## 1.2.7 - 2025-09-17
 
 - **Refactor:** Manage Kill-by-Click overlay cleanup with a context manager.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "1.2.7"
+__version__ = "1.2.8"
 
 import argparse
 import os

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.2.7"
+__version__ = "1.2.8"
 
 import os
 

--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -1049,7 +1049,7 @@ class ClickOverlay(tk.Toplevel):
         scale = 1.0 / (1.0 + self._velocity / self.delay_scale)
         delay = base_ms * scale
         if self.avg_frame_ms:
-            delay -= self.avg_frame_ms
+            delay = max(delay - self.avg_frame_ms, min_ms)
         delay = max(min(delay, max_ms), min_ms)
         return int(delay)
 

--- a/tests/test_click_overlay_delay.py
+++ b/tests/test_click_overlay_delay.py
@@ -1,0 +1,42 @@
+import os
+import unittest
+import tkinter as tk
+from unittest.mock import patch
+
+from src.views.click_overlay import ClickOverlay
+
+
+@unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+class TestClickOverlayDelay(unittest.TestCase):
+    def setUp(self) -> None:
+        self.root = tk.Tk()
+
+    def tearDown(self) -> None:
+        self.root.destroy()
+
+    def _create_overlay(self) -> ClickOverlay:
+        with patch("src.views.click_overlay.is_supported", return_value=False), patch(
+            "src.views.click_overlay.make_window_clickthrough", return_value=False
+        ):
+            overlay = ClickOverlay(self.root)
+        self.addCleanup(overlay.destroy)
+        return overlay
+
+    def test_next_delay_clamped_after_high_frame_time(self) -> None:
+        overlay = self._create_overlay()
+        overlay.avg_frame_ms = 1000.0
+        delay = overlay._next_delay()
+        self.assertEqual(delay, int(overlay.min_interval * 1000))
+
+    def test_next_delay_consistent_with_high_frame_time(self) -> None:
+        overlay = self._create_overlay()
+        overlay.avg_frame_ms = 1000.0
+        first = overlay._next_delay()
+        overlay._velocity = 500.0
+        second = overlay._next_delay()
+        self.assertEqual(first, int(overlay.min_interval * 1000))
+        self.assertEqual(second, int(overlay.min_interval * 1000))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- clamp click overlay delay to minimum interval when frame times spike
- add tests for stable delay with high frame times
- bump version to 1.2.8

## Testing
- `flake8 tests/test_click_overlay_delay.py setup.py src/__init__.py`
- `flake8 src/views/click_overlay.py tests/test_click_overlay_delay.py tests/test_click_overlay_fps.py setup.py src/__init__.py` *(fails: module level import not at top of file, etc.)*
- `pytest` *(fails: tests/test_app.py, tests/test_auto_setup.py)*
- `pytest tests/test_click_overlay_delay.py tests/test_click_overlay_fps.py`

------
https://chatgpt.com/codex/tasks/task_e_688f88f15028832bacd507b76dff763e