### PR TITLE
feat: calibrate click overlay interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 1.2.12 - 2025-09-22
+
+- **Feat:** Calibrate click overlay intervals on Force Quit startup and cache results.
+- **Fix:** Clamp click overlay delays to tuned interval bounds.
+
 ## 1.2.11 - 2025-09-21
 
 - **Perf:** Scale pointer move debounce and pixel thresholds by cursor velocity and display DPI with configurable minimum caps.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.2.11"
+__version__ = "1.2.12"
 
 import os
 

--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -1056,7 +1056,8 @@ class ClickOverlay(tk.Toplevel):
 
     def _next_delay(self) -> int:
         """Return the delay in milliseconds until the next update."""
-        base_ms = self.interval * 1000.0
+        interval = max(min(self.interval, self.max_interval), self.min_interval)
+        base_ms = interval * 1000.0
         min_ms = self.min_interval * 1000.0
         max_ms = self.max_interval * 1000.0
         # Scale the refresh rate using a smooth curve so large
@@ -1072,8 +1073,6 @@ class ClickOverlay(tk.Toplevel):
         """Adjust refresh intervals based on recent frame rendering times."""
         avg_sec = self.avg_frame_ms / 1000.0
         interval = max(DEFAULT_INTERVAL, avg_sec * 2)
-        self.min_interval = max(avg_sec * 1.2, 0.001)
-        self.max_interval = interval * 5
         self.interval = max(min(interval, self.max_interval), self.min_interval)
 
     def _process_update(self) -> None:

--- a/tests/test_click_overlay_delay.py
+++ b/tests/test_click_overlay_delay.py
@@ -37,6 +37,28 @@ class TestClickOverlayDelay(unittest.TestCase):
         self.assertEqual(first, int(overlay.min_interval * 1000))
         self.assertEqual(second, int(overlay.min_interval * 1000))
 
+    def test_next_delay_respects_interval_bounds(self) -> None:
+        overlay = self._create_overlay()
+        overlay.min_interval = 0.01
+        overlay.max_interval = 0.05
+        overlay.interval = 0.2
+        overlay._velocity = 0.0
+        delay = overlay._next_delay()
+        self.assertEqual(delay, int(overlay.max_interval * 1000))
+
+    def test_retune_interval_respects_bounds(self) -> None:
+        overlay = self._create_overlay()
+        overlay.min_interval = 0.01
+        overlay.max_interval = 0.05
+        overlay.avg_frame_ms = 1000.0
+        overlay._retune_interval()
+        self.assertEqual(overlay.interval, overlay.max_interval)
+        self.assertEqual(overlay.min_interval, 0.01)
+        self.assertEqual(overlay.max_interval, 0.05)
+        overlay.avg_frame_ms = 1.0
+        overlay._retune_interval()
+        self.assertEqual(overlay.interval, overlay.min_interval)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_force_quit_interval.py
+++ b/tests/test_force_quit_interval.py
@@ -1,0 +1,136 @@
+import os
+import sys
+import types
+import tkinter as tk
+import unittest
+from unittest import mock
+
+os.environ.setdefault("COOLBOX_LIGHTWEIGHT", "1")
+
+
+class _DummyWidget:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def pack(self, *args, **kwargs):
+        pass
+
+    def grid(self, *args, **kwargs):
+        pass
+
+    def configure(self, *args, **kwargs):
+        pass
+
+    def destroy(self):
+        pass
+
+    def bind(self, *args, **kwargs):
+        pass
+
+
+dummy_ctk = types.ModuleType("customtkinter")
+dummy_ctk.CTkTabview = _DummyWidget
+dummy_ctk.CTkScrollableFrame = _DummyWidget
+dummy_ctk.CTkButton = _DummyWidget
+dummy_ctk.CTkFrame = _DummyWidget
+dummy_ctk.StringVar = tk.StringVar
+dummy_ctk.CTkEntry = _DummyWidget
+dummy_ctk.CTkOptionMenu = _DummyWidget
+dummy_ctk.BooleanVar = tk.BooleanVar
+dummy_ctk.CTkLabel = _DummyWidget
+dummy_ctk.CTkCheckBox = _DummyWidget
+dummy_ctk.CTkTextbox = _DummyWidget
+sys.modules.setdefault("customtkinter", dummy_ctk)
+
+from src.views.force_quit_dialog import ForceQuitDialog
+
+
+@unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+class TestForceQuitInterval(unittest.TestCase):
+    def _dummy_app(self):
+        class DummyApp:
+            def __init__(self) -> None:
+                self.window = tk.Tk()
+                self.config = {}
+
+            def register_dialog(self, dialog) -> None:  # pragma: no cover - stub
+                pass
+
+            def unregister_dialog(self, dialog) -> None:  # pragma: no cover - stub
+                pass
+
+            def get_icon_photo(self):  # pragma: no cover - stub
+                return None
+
+        return DummyApp()
+
+    def test_auto_tune_called_and_cached(self) -> None:
+        app = self._dummy_app()
+        auto_mock = mock.MagicMock(return_value=(0.1, 0.05, 0.2))
+
+        class DummyOverlay:
+            auto_tune_interval = auto_mock
+
+            def __init__(self, *a, **kw) -> None:
+                pass
+
+            def reset(self) -> None:
+                pass
+
+            def _refresh_window_cache(self, *a, **kw) -> None:
+                pass
+
+        listener = mock.MagicMock()
+        with (
+            mock.patch("src.views.force_quit_dialog.prime_window_cache"),
+            mock.patch("src.views.force_quit_dialog.get_global_listener", return_value=listener),
+            mock.patch("src.views.force_quit_dialog.ClickOverlay", DummyOverlay),
+            mock.patch.object(ForceQuitDialog, "_auto_refresh"),
+        ):
+            dialog = ForceQuitDialog(app)
+            dialog.destroy()
+            app.window.destroy()
+
+        auto_mock.assert_called_once()
+        self.assertEqual(app.config.get("kill_by_click_interval"), 0.1)
+        self.assertEqual(app.config.get("kill_by_click_min_interval"), 0.05)
+        self.assertEqual(app.config.get("kill_by_click_max_interval"), 0.2)
+
+    def test_auto_tune_skipped_when_cached(self) -> None:
+        app = self._dummy_app()
+        app.config = {
+            "kill_by_click_interval": 0.1,
+            "kill_by_click_min_interval": 0.05,
+            "kill_by_click_max_interval": 0.2,
+        }
+
+        auto_mock = mock.MagicMock(return_value=(0.2, 0.1, 0.4))
+
+        class DummyOverlay:
+            auto_tune_interval = auto_mock
+
+            def __init__(self, *a, **kw) -> None:
+                self.args = kw
+
+            def reset(self) -> None:
+                pass
+
+            def _refresh_window_cache(self, *a, **kw) -> None:
+                pass
+
+        listener = mock.MagicMock()
+        with (
+            mock.patch("src.views.force_quit_dialog.prime_window_cache"),
+            mock.patch("src.views.force_quit_dialog.get_global_listener", return_value=listener),
+            mock.patch("src.views.force_quit_dialog.ClickOverlay", DummyOverlay),
+            mock.patch.object(ForceQuitDialog, "_auto_refresh"),
+        ):
+            dialog = ForceQuitDialog(app)
+            overlay_args = dialog._overlay
+            dialog.destroy()
+            app.window.destroy()
+
+        auto_mock.assert_not_called()
+        self.assertEqual(overlay_args.interval, 0.1)
+        self.assertEqual(overlay_args.min_interval, 0.05)
+        self.assertEqual(overlay_args.max_interval, 0.2)


### PR DESCRIPTION
## Summary
- auto-tune click overlay refresh rate on Force Quit dialog startup and cache results
- clamp overlay delay calculations within calibrated bounds
- document click overlay tuning and version bump

## Testing
- `pytest tests/test_click_overlay_delay.py tests/test_force_quit_interval.py`

------
https://chatgpt.com/codex/tasks/task_e_688f96cb49e0832bbd8f0d986033cdff