### PR TITLE
perf: skip tiny cursor moves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.2.17 - 2025-08-03
+
+- **Perf:** Use `canvas.move` for cursor translations and skip tiny movements.
+
 ## 1.2.16 - 2025-08-03
 
 - **Refactor:** Extract hover tracking into reusable `HoverTracker` class.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "1.2.16"
+__version__ = "1.2.17"
 
 import argparse
 import os

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.2.16"
+__version__ = "1.2.17"
 
 import os
 


### PR DESCRIPTION
## Summary
- use canvas.move for crosshair, label, and rect translations
- avoid re-render when pointer moves less than MIN_MOVE_PX and window unchanged
- bump version to 1.2.17

## Testing
- `pytest -q tests/test_click_overlay.py`
- `python - <<'PY'
...benchmark script...
PY`


------
https://chatgpt.com/codex/tasks/task_e_688fa3adc914832b88a725eebdbd32e2