### PR TITLE
feat: enrich overlay labels with app info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.3.0 - 2025-08-04
+
+- **Feat:** Optionally show executable names and icons in the click overlay via `KILL_BY_CLICK_APP_LABELS`.
+
 ## 1.2.17 - 2025-08-03
 
 - **Perf:** Use `canvas.move` for cursor translations and skip tiny movements.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "1.2.17"
+__version__ = "1.3.0"
 
 import argparse
 import os

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.2.17"
+__version__ = "1.3.0"
 
 import os
 

--- a/tests/test_click_overlay.py
+++ b/tests/test_click_overlay.py
@@ -117,6 +117,33 @@ class TestClickOverlay(unittest.TestCase):
             root.destroy()
 
     @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_enriched_label_uses_process_name(self) -> None:
+        root = tk.Tk()
+        with patch("src.views.click_overlay.is_supported", return_value=False):
+            overlay = ClickOverlay(root)
+        with patch("src.views.click_overlay.ENRICH_LABELS", True), patch(
+            "src.views.click_overlay._process_details", return_value=("proc", None)
+        ) as pd:
+            overlay._update_rect(WindowInfo(123, (0, 0, 10, 10), "win"))
+            self.assertEqual(overlay._buffer["label_text"], "proc")
+            pd.assert_called_once_with(123)
+        overlay.destroy()
+        root.destroy()
+
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_enriched_label_respects_flag(self) -> None:
+        root = tk.Tk()
+        with patch("src.views.click_overlay.is_supported", return_value=False):
+            overlay = ClickOverlay(root)
+        with patch("src.views.click_overlay.ENRICH_LABELS", False), patch(
+            "src.views.click_overlay._process_details"
+        ) as pd:
+            overlay._update_rect(WindowInfo(123, (0, 0, 10, 10), "win"))
+            pd.assert_not_called()
+        overlay.destroy()
+        root.destroy()
+
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
     def test_crosshair_updates_skipped_when_disabled(self) -> None:
         root = tk.Tk()
         with patch("src.views.click_overlay.is_supported", return_value=False):


### PR DESCRIPTION
## Summary
- fetch process name and optional icon for overlay targets
- add env flag `KILL_BY_CLICK_APP_LABELS` to toggle enriched labels
- bump version to 1.3.0

## Testing
- `flake8 src/views/click_overlay.py tests/test_click_overlay.py`
- `pytest tests/test_click_overlay.py::TestClickOverlay::test_enriched_label_uses_process_name tests/test_click_overlay.py::TestClickOverlay::test_enriched_label_respects_flag -q`

------
https://chatgpt.com/codex/tasks/task_e_688faa475f8c832ba061d1f86e43ea32