### PR TITLE
refactor: lazily init click overlay executor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.3.1 - 2025-08-05
+
+- **Refactor:** Lazily create the click overlay thread pool with a default two-worker limit and clean shutdown hooks.
+
 ## 1.3.0 - 2025-08-04
 
 - **Feat:** Optionally show executable names and icons in the click overlay via `KILL_BY_CLICK_APP_LABELS`.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 
 import argparse
 import os

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 
 import os
 

--- a/tests/test_click_overlay_executor.py
+++ b/tests/test_click_overlay_executor.py
@@ -1,0 +1,37 @@
+import os
+import importlib
+
+os.environ.setdefault("COOLBOX_LIGHTWEIGHT", "1")
+
+
+def reload_module(monkeypatch, workers=None):
+    if workers is None:
+        monkeypatch.delenv("KILL_BY_CLICK_WORKERS", raising=False)
+    else:
+        monkeypatch.setenv("KILL_BY_CLICK_WORKERS", str(workers))
+    import src.views.click_overlay as click_overlay
+    return importlib.reload(click_overlay)
+
+
+def shutdown_executor(mod):
+    if mod._EXECUTOR is not None:
+        mod._EXECUTOR.shutdown(cancel_futures=True)
+        mod._EXECUTOR = None
+
+
+def test_get_executor_defaults_to_two_workers(monkeypatch):
+    mod = reload_module(monkeypatch)
+    try:
+        ex = mod.get_executor()
+        assert ex._max_workers == 2
+    finally:
+        shutdown_executor(mod)
+
+
+def test_get_executor_respects_env_override(monkeypatch):
+    mod = reload_module(monkeypatch, workers=5)
+    try:
+        ex = mod.get_executor()
+        assert ex._max_workers == 5
+    finally:
+        shutdown_executor(mod)


### PR DESCRIPTION
## Summary
- lazily create shared ThreadPoolExecutor for click overlay with two-worker default
- cap worker count via env var and ensure clean shutdown at exit
- test executor creation and env override

## Testing
- `flake8 src/views/click_overlay.py tests/test_click_overlay_executor.py`
- `pytest tests/test_click_overlay_executor.py tests/test_click_overlay.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688fae763118832bacde1e258ac3f587