### PR TITLE
feat: scale move debounce with display DPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 1.3.2 - 2025-08-06
+
+- **Feat:** Scale minimum cursor movement by screen DPI and expose per-instance
+  overrides via `KILL_BY_CLICK_MIN_MOVE_PX` / `kill_by_click_min_move_px`.
+
 ## 1.3.1 - 2025-08-05
 
 - **Refactor:** Lazily create the click overlay thread pool with a default two-worker limit and clean shutdown hooks.

--- a/README.md
+++ b/README.md
@@ -61,9 +61,10 @@ A modern, feature-rich desktop application built with Python and CustomTkinter.
   mouse events while polling the window under the cursor at ``KILL_BY_CLICK_INTERVAL``
   and tracks pointer coordinates from hook callbacks or motion events to keep
   updates smooth without flicker. ``KILL_BY_CLICK_MOVE_DEBOUNCE_MS`` sets the
-  minimum time between cursor updates while ``KILL_BY_CLICK_MIN_MOVE_PX`` ignores
-  subpixel jitter. Large or fast cursor moves bypass this debounce and refresh
-  immediately. Set ``KILL_BY_CLICK_INTERVAL`` to control the
+  minimum time between cursor updates while ``KILL_BY_CLICK_MIN_MOVE_PX`` (in
+  logical pixels) ignores subpixel jitter and scales with display DPI. Large or
+  fast cursor moves bypass this debounce and refresh immediately. Set
+  ``KILL_BY_CLICK_INTERVAL`` to control the
   base refresh rate (defaults to ``0.008`` seconds) or pass ``--interval`` when using
   ``scripts/kill_by_click.py``. The refresh interval expands and contracts
   between ``KILL_BY_CLICK_MIN_INTERVAL`` (``0.004`` seconds) and

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "1.3.1"
+__version__ = "1.3.2"
 
 import argparse
 import os

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.3.1"
+__version__ = "1.3.2"
 
 import os
 


### PR DESCRIPTION
## Summary
- compute per-instance min movement threshold based on screen DPI
- expose `KILL_BY_CLICK_MIN_MOVE_PX` override and drop global constant
- document DPI-aware threshold

## Testing
- `pytest tests/test_click_overlay.py -q`
- `pytest -q` *(fails: process terminated)*

------
https://chatgpt.com/codex/tasks/task_e_688fb07c95a8832ba36d1e665f72291b