### PR TITLE
fix: highlight force quit rows immediately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 1.3.7 - 2025-08-11
+
+- **Fix:** Update Force Quit hover handling to highlight rows immediately on motion.
+- **Test:** Verify hover highlight updates on every Motion event without delay.
+
 ## 1.3.6 - 2025-08-10
 
 - **Test:** Exercise motion debouncing and frame-time auto-tuning.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "1.3.6"
+__version__ = "1.3.7"
 
 import argparse
 import os

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.3.6"
+__version__ = "1.3.7"
 
 import os
 

--- a/src/views/force_quit_dialog.py
+++ b/src/views/force_quit_dialog.py
@@ -124,7 +124,6 @@ class ForceQuitDialog(BaseDialog):
         self.attributes("-topmost", on_top)
         self._after_id: int | None = None
         self._debounce_id: int | None = None
-        self._hover_after_id: int | None = None
         self.process_snapshot: dict[int, ProcessEntry] = {}
         self._row_cache: dict[int, tuple[tuple, tuple]] = {}
         self._changed_tags: dict[int, int] = {}
@@ -1788,13 +1787,11 @@ class ForceQuitDialog(BaseDialog):
         self._hover_iid = iid
         self._apply_hover_tag()
 
-    def _on_hover(self, _event) -> None:
-        if self._hover_after_id is not None:
-            self.after_cancel(self._hover_after_id)
-        self._hover_after_id = self.after(100, self._update_hover)
+    def _on_hover(self, event) -> None:
+        iid = self.tree.identify_row(event.y)
+        self._set_hover_row(iid)
 
     def _update_hover(self) -> None:
-        self._hover_after_id = None
         x, y = self.winfo_pointerxy()
         widget = self.winfo_containing(x, y)
         if widget is self.tree or widget in self.tree.winfo_children():

--- a/tests/test_force_quit_debounce.py
+++ b/tests/test_force_quit_debounce.py
@@ -1,9 +1,6 @@
 import types
 from unittest import mock
 
-import types
-from unittest import mock
-
 from src.views.force_quit_dialog import ForceQuitDialog
 
 
@@ -37,30 +34,20 @@ def test_populate_debounce():
     dialog._apply_filter_sort.assert_called_once()
 
 
-def test_hover_debounce():
+def test_hover_immediate():
     dialog = ForceQuitDialog.__new__(ForceQuitDialog)
-    callbacks = []
+    dialog.tree = mock.Mock()
+    dialog._set_hover_row = mock.Mock()
+    dialog.after = mock.Mock()
+    dialog.after_cancel = mock.Mock()
 
-    def fake_after(delay: int, func):
-        callbacks.append((delay, func))
-        return f"id{len(callbacks)}"
+    dialog.tree.identify_row.side_effect = ["row1", "row2"]
 
-    cancelled = []
+    evt1 = types.SimpleNamespace(y=5)
+    evt2 = types.SimpleNamespace(y=10)
+    dialog._on_hover(evt1)
+    dialog._on_hover(evt2)
 
-    def fake_after_cancel(ident: str) -> None:
-        cancelled.append(ident)
-
-    dialog.after = fake_after
-    dialog.after_cancel = fake_after_cancel
-    dialog._update_hover = mock.Mock()
-    dialog._hover_after_id = None
-
-    evt = types.SimpleNamespace(y=5)
-    dialog._on_hover(evt)
-    dialog._on_hover(evt)
-
-    assert [d for d, _ in callbacks] == [100, 100]
-    assert cancelled == ["id1"]
-
-    callbacks[-1][1]()
-    dialog._update_hover.assert_called_once()
+    assert dialog._set_hover_row.call_args_list == [mock.call("row1"), mock.call("row2")]
+    dialog.after.assert_not_called()
+    dialog.after_cancel.assert_not_called()


### PR DESCRIPTION
## Summary
- update Force Quit hover handler to set hovered row on each Motion event
- test hover highlight updates without delay
- bump version to 1.3.7

## Testing
- `pytest -q` *(fails: terminated at 43%)*
- `pytest tests/test_force_quit_debounce.py -q`
- `pytest tests/test_force_quit.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688fbcf480a0832bb8b36fe1b35439f3