### PR TITLE
Refactor ForceQuit hover to use event coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 1.3.8 - 2025-08-12
+
+- **Refactor:** Use motion event coordinates for hover tracking, avoiding global pointer queries.
+- **Test:** Ensure hover updates do not rely on global pointer lookups.
+
 ## 1.3.7 - 2025-08-11
 
 - **Fix:** Update Force Quit hover handling to highlight rows immediately on motion.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "1.3.7"
+__version__ = "1.3.8"
 
 import argparse
 import os

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.3.7"
+__version__ = "1.3.8"
 
 import os
 


### PR DESCRIPTION
## Summary
- avoid global pointer queries by tracking last motion coordinates
- clear hover state on leave and ensure hover events only originate from tree
- assert no global pointer APIs are used during hover updates
- bump version to 1.3.8

## Testing
- `pytest tests/test_force_quit_debounce.py -q`
- `pytest -q` *(fails: Terminated)*

------
https://chatgpt.com/codex/tasks/task_e_688fbe82eff0832b81683a615b106075