### PR TITLE
fix: avoid redundant PID highlighting

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "1.3.8"
+__version__ = "1.3.9"
 
 import argparse
 import os

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.3.8"
+__version__ = "1.3.9"
 
 import os
 

--- a/src/views/force_quit_dialog.py
+++ b/src/views/force_quit_dialog.py
@@ -1816,12 +1816,12 @@ class ForceQuitDialog(BaseDialog):
             self._set_hover_row(None)
             return
         iid = str(pid)
-        self.tree.see(iid)
         current = self.tree.selection()
         if current != (iid,):
+            self.tree.see(iid)
             self.tree.selection_set(iid)
+            self._show_details()
         self._set_hover_row(iid)
-        self._show_details()
 
     def _toggle_details(self) -> None:
         if self.show_details_var.get():

--- a/tests/test_force_quit_highlight.py
+++ b/tests/test_force_quit_highlight.py
@@ -1,0 +1,110 @@
+import os
+import sys
+import types
+import pathlib
+import unittest
+from unittest import mock
+
+
+class TestForceQuitHighlight(unittest.TestCase):
+    def setUp(self) -> None:
+        os.environ.setdefault("COOLBOX_LIGHTWEIGHT", "1")
+        src_pkg = types.ModuleType("src")
+        src_pkg.__path__ = [str(pathlib.Path(__file__).resolve().parents[1] / "src")]
+        views_pkg = types.ModuleType("src.views")
+        views_pkg.__path__ = [str(pathlib.Path(__file__).resolve().parents[1] / "src/views")]
+        modules = {
+            "src": src_pkg,
+            "src.views": views_pkg,
+            "customtkinter": types.SimpleNamespace(
+                CTk=object,
+                CTkFrame=object,
+                CTkButton=object,
+                CTkLabel=object,
+                CTkToplevel=object,
+                StringVar=object,
+            ),
+            "src.utils.window_utils": types.SimpleNamespace(
+                WindowInfo=object,
+                get_active_window=lambda: None,
+                get_window_under_cursor=lambda *_a, **_k: None,
+                has_active_window_support=lambda: False,
+                has_cursor_window_support=lambda: False,
+                prime_window_cache=lambda: None,
+            ),
+            "src.utils.kill_utils": types.SimpleNamespace(
+                kill_process=lambda *_a, **_k: None,
+                kill_process_tree=lambda *_a, **_k: None,
+            ),
+            "src.utils": types.SimpleNamespace(get_screen_refresh_rate=lambda: 60),
+            "src.utils.process_monitor": types.SimpleNamespace(
+                ProcessEntry=object, ProcessWatcher=object
+            ),
+            "src.views.base_dialog": types.SimpleNamespace(BaseDialog=object),
+            "src.utils.helpers": types.SimpleNamespace(
+                hex_brightness=lambda c: c,
+                lighten_color=lambda c, *_a: c,
+                darken_color=lambda c, *_a: c,
+            ),
+            "src.utils.mouse_listener": types.SimpleNamespace(
+                get_global_listener=lambda: types.SimpleNamespace(start=lambda: None)
+            ),
+            "src.views.click_overlay": types.SimpleNamespace(
+                ClickOverlay=object, KILL_BY_CLICK_INTERVAL=0.1
+            ),
+        }
+        self.patcher = mock.patch.dict(sys.modules, modules)
+        self.patcher.start()
+        sys.modules.pop("src.views.force_quit_dialog", None)
+        from src.views.force_quit_dialog import ForceQuitDialog
+        self.ForceQuitDialog = ForceQuitDialog
+
+    def tearDown(self) -> None:
+        self.patcher.stop()
+        sys.modules.pop("src.views.force_quit_dialog", None)
+
+    def test_highlight_pid_skips_duplicate_selection(self) -> None:
+        dialog = self.ForceQuitDialog.__new__(self.ForceQuitDialog)
+        tree = mock.Mock()
+        tree.exists.return_value = True
+        tree.selection.return_value = ("123",)
+        dialog.tree = tree
+        dialog._set_hover_row = mock.Mock()
+        dialog._show_details = mock.Mock()
+
+        dialog._highlight_pid(123)
+
+        tree.selection_set.assert_not_called()
+        tree.see.assert_not_called()
+        dialog._show_details.assert_not_called()
+
+    def test_repeated_hover_same_pid_no_update(self) -> None:
+        dialog = self.ForceQuitDialog.__new__(self.ForceQuitDialog)
+        tree = mock.Mock()
+        tree.exists.return_value = True
+        tree.selection.return_value = ("456",)
+        dialog.tree = tree
+        dialog._set_hover_row = mock.Mock()
+        dialog._show_details = mock.Mock()
+
+        dialog._highlight_pid(123)
+
+        tree.see.assert_called_once_with("123")
+        tree.selection_set.assert_called_once_with("123")
+        dialog._show_details.assert_called_once()
+
+        tree.selection.return_value = ("123",)
+        tree.see.reset_mock()
+        tree.selection_set.reset_mock()
+        dialog._show_details.reset_mock()
+
+        dialog._highlight_pid(123)
+
+        tree.see.assert_not_called()
+        tree.selection_set.assert_not_called()
+        dialog._show_details.assert_not_called()
+        self.assertEqual(dialog._set_hover_row.call_count, 2)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- avoid redundant tree updates in Force Quit highlight handler
- add regression tests for repeated PID hover
- bump version to 1.3.9

## Testing
- `pytest tests/test_force_quit_highlight.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688fbff0b2ac832b9dbb43ecec8ada24