### PR TITLE
refactor: centralize click overlay config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 1.3.10 - 2025-08-13
+
+- **Refactor:** Centralize click overlay configuration and apply updates when
+  settings change.
+- **Test:** Verify overlay configuration reacts to environment changes.
+
 ## 1.3.8 - 2025-08-12
 
 - **Refactor:** Use motion event coordinates for hover tracking, avoiding global pointer queries.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "1.3.9"
+__version__ = "1.3.10"
 
 import argparse
 import os

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.3.9"
+__version__ = "1.3.10"
 
 import os
 

--- a/tests/test_click_overlay.py
+++ b/tests/test_click_overlay.py
@@ -467,7 +467,7 @@ class TestClickOverlay(unittest.TestCase):
                 with (
                     patch("src.views.force_quit_dialog.get_global_listener") as mock_listener,
                     patch("src.views.force_quit_dialog.prime_window_cache"),
-                    patch.object(ForceQuitDialog, "initialize_click_overlay"),
+                    patch.object(ForceQuitDialog, "_configure_overlay"),
                     patch.object(ForceQuitDialog, "_auto_refresh"),
                     patch(
                         "src.views.force_quit_dialog.ClickOverlay.auto_tune_interval",
@@ -495,7 +495,7 @@ class TestClickOverlay(unittest.TestCase):
                 with (
                     patch("src.views.force_quit_dialog.get_global_listener") as mock_listener,
                     patch("src.views.force_quit_dialog.prime_window_cache"),
-                    patch.object(ForceQuitDialog, "initialize_click_overlay"),
+                    patch.object(ForceQuitDialog, "_configure_overlay"),
                     patch.object(ForceQuitDialog, "_auto_refresh"),
                     patch(
                         "src.views.force_quit_dialog.ClickOverlay.auto_tune_interval"

--- a/tests/test_force_quit_cache.py
+++ b/tests/test_force_quit_cache.py
@@ -73,7 +73,7 @@ class TestForceQuitCache(unittest.TestCase):
             mock.patch("src.views.force_quit_dialog.prime_window_cache"),
             mock.patch("src.views.force_quit_dialog.ClickOverlay", DummyOverlay),
             mock.patch.object(ForceQuitDialog, "_auto_refresh"),
-            mock.patch.object(ForceQuitDialog, "initialize_click_overlay", return_value=None),
+            mock.patch.object(ForceQuitDialog, "_configure_overlay", return_value=None),
         ):
             dialog = ForceQuitDialog(app)
             self.assertTrue(dialog._overlay.warmed)


### PR DESCRIPTION
## Summary
- configure click overlay once from environment and config
- use overlay.skip_confirm instead of parsing on each kill-by-click
- test overlay reconfiguration and skip confirm behavior

## Testing
- `COOLBOX_LIGHTWEIGHT=1 pytest tests/test_force_quit.py::TestForceQuit::test_kill_by_click_pauses_watcher tests/test_force_quit.py::TestForceQuit::test_kill_by_click_exception_cleanup tests/test_force_quit.py::TestForceQuit::test_kill_by_click_skip_confirm tests/test_force_quit.py::TestForceQuit::test_kill_by_click_per_run_isolation tests/test_force_quit.py::TestForceQuit::test_configure_overlay_applies_updates tests/test_click_overlay.py::TestClickOverlay::test_force_quit_dialog_applies_tuned_interval tests/test_force_quit_cache.py::TestForceQuitCache::test_primes_window_cache_once tests/test_force_quit_cache.py::TestForceQuitCache::test_first_choose_uses_warmed_cache -q`

------
https://chatgpt.com/codex/tasks/task_e_688fc296efe4832b9cb2d6891d47ec80