### PR TITLE
refactor: async kill-by-click overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 - **Feat:** Derive move debounce from refresh rate with runtime override and
   allow disabling via ``kill_by_click_move_debounce_ms``.
 
+## 1.3.12 - 2025-08-03
+
+- **Refactor:** Run Kill by Click overlay asynchronously with cancel support.
+- **Test:** Ensure Force Quit dialog stays responsive during window selection.
+
 ## 1.3.10 - 2025-08-13
 
 - **Refactor:** Centralize click overlay configuration and apply updates when

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "1.3.11"
+__version__ = "1.3.12"
 
 import argparse
 import os

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.3.11"
+__version__ = "1.3.12"
 
 import os
 


### PR DESCRIPTION
## Summary
- run Force Quit's kill-by-click overlay on a background thread to keep the UI responsive
- add cancel handler so the overlay can be closed without killing a process
- test Force Quit remains responsive while waiting for click selection

## Testing
- `COOLBOX_LIGHTWEIGHT=1 pytest tests/test_force_quit.py::TestForceQuit::test_kill_by_click_pauses_watcher tests/test_force_quit.py::TestForceQuit::test_kill_by_click_exception_cleanup tests/test_force_quit.py::TestForceQuit::test_kill_by_click_skip_confirm tests/test_force_quit.py::TestForceQuit::test_kill_by_click_per_run_isolation tests/test_force_quit.py::TestForceQuit::test_kill_by_click_nonblocking_and_cancel -q`

------
https://chatgpt.com/codex/tasks/task_e_688fc758a1e4832bab1ae3920ad77903