### PR TITLE
fix: protect self in force quit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 1.3.14 - 2025-08-03
+
+- **Fix:** Skip terminating the current process when killing the active or cursor window.
+- **Build:** Add Cython to dependencies for optional extensions.
+
 ## 1.3.13 - 2025-08-03
 
 - **Feat:** Derive move debounce from refresh rate with runtime override and

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ pillow>=11.0.0
 python-dotenv>=1.0.0
 colorama>=0.4.6
 rich>=13.0.0
+cython>=0.29.0
 matplotlib>=3.7.0
 requests>=2.31.0
 pyperclip>=1.8.2

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "1.3.13"
+__version__ = "1.3.14"
 
 import argparse
 import os

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.3.13"
+__version__ = "1.3.14"
 
 import os
 

--- a/src/views/force_quit_dialog.py
+++ b/src/views/force_quit_dialog.py
@@ -1093,7 +1093,7 @@ class ForceQuitDialog(BaseDialog):
     def force_kill_window_under_cursor(cls) -> bool:
         """Force kill the process owning the window currently under the cursor."""
         info = cls._get_window_under_cursor()
-        if info.pid is None:
+        if info.pid is None or info.pid == os.getpid():
             return False
         return cls.force_kill(info.pid)
 
@@ -1101,7 +1101,7 @@ class ForceQuitDialog(BaseDialog):
     def force_kill_active_window(cls) -> bool:
         """Force terminate the process owning the active window."""
         pid = cls._get_active_window_pid()
-        if pid is None:
+        if pid is None or pid == os.getpid():
             return False
         return cls.force_kill(pid)
 


### PR DESCRIPTION
## Summary
- guard Force Quit's active and cursor window kills against terminating the app itself
- depend on Cython to build optional extensions

## Testing
- `pytest tests/test_process_monitor_cli.py -q`
- `pytest tests/test_force_quit_highlight.py -q`
- `pytest tests/test_force_quit.py::TestForceQuit::test_force_kill_active_window -q`
- `pytest tests/test_force_quit.py::TestForceQuit::test_force_kill_window_under_cursor -q`


------
https://chatgpt.com/codex/tasks/task_e_688fcc4ee304832b96ffa9be85b853c1