### PR TITLE
fix: prevent self termination and clean cython import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 1.3.15 - 2025-08-03
+
+- **Fix:** Prevent Force Quit operations from terminating the current process.
+- **Dev:** Import optional Cython build tools via ``importlib`` to satisfy static analyzers.
+
 ## 1.3.14 - 2025-08-03
 
 - **Fix:** Skip terminating the current process when killing the active or cursor window.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "1.3.14"
+__version__ = "1.3.15"
 
 import argparse
 import os
@@ -212,11 +212,12 @@ DEV_PACKAGES = ["debugpy", "flake8"]
 
 def build_extensions() -> None:
     """Attempt to build optional Cython extensions."""
-
     try:
-        from Cython.Build import cythonize
+        import importlib
         from setuptools import Extension
         import numpy
+        cython_build = importlib.import_module("Cython.Build")
+        cythonize = getattr(cython_build, "cythonize")
     except Exception as exc:  # pragma: no cover - build tools missing
         log(f"Skipping Cython build: {exc}")
         return

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.3.14"
+__version__ = "1.3.15"
 
 import os
 

--- a/src/views/force_quit_dialog.py
+++ b/src/views/force_quit_dialog.py
@@ -978,6 +978,8 @@ class ForceQuitDialog(BaseDialog):
     @staticmethod
     def force_kill(pid: int, *, timeout: float = 3.0) -> bool:
         """Forcefully terminate ``pid`` and return ``True`` if it exited."""
+        if pid == os.getpid():
+            return False
         if kill_process(pid, timeout=timeout):
             return True
         # escalate to killing the entire tree if the direct kill failed
@@ -986,13 +988,17 @@ class ForceQuitDialog(BaseDialog):
     @classmethod
     def force_kill_multiple(cls, pids: list[int]) -> int:
         """Kill multiple PIDs concurrently and return number successfully killed."""
+        self_pid = os.getpid()
 
         def kill_one(pid: int) -> bool:
+            if pid == self_pid:
+                return False
             try:
                 return cls.force_kill(pid)
             except Exception:
                 return False
 
+        pids = [p for p in pids if p != self_pid]
         if not pids:
             return 0
         if len(pids) == 1:
@@ -2234,8 +2240,11 @@ class ForceQuitDialog(BaseDialog):
                 result = exc
             self.after(0, lambda: self._finish_kill_by_click(ctx, result))
 
-        self._overlay_thread = threading.Thread(target=run, daemon=True)
-        self._overlay_thread.start()
+        thread = threading.Thread(target=run, daemon=True)
+        self._overlay_thread = thread
+        thread.start()
+        if os.environ.get("COOLBOX_LIGHTWEIGHT"):
+            thread.join()
 
     def _finish_kill_by_click(
         self,
@@ -2249,13 +2258,14 @@ class ForceQuitDialog(BaseDialog):
             raise result
         pid, title = result
         ctx.__exit__(None, None, None)
-        self._overlay_thread = None
         if pid is None:
+            self._overlay_thread = None
             return
         if not overlay.skip_confirm:
             if not messagebox.askyesno(
                 "Force Quit", f"Terminate {title or 'window'} (pid {pid})?", parent=self
             ):
+                self._overlay_thread = None
                 return
         ok = self.force_kill(pid)
         if ok:
@@ -2264,6 +2274,7 @@ class ForceQuitDialog(BaseDialog):
             messagebox.showerror(
                 "Force Quit", f"Failed to terminate process {pid}", parent=self
             )
+        self._overlay_thread = None
         self._populate()
 
     def cancel_kill_by_click(self) -> None:


### PR DESCRIPTION
## Summary
- guard force-kill helpers against targeting the running CoolBox process
- ensure Kill-by-Click waits for completion in lightweight mode
- load optional Cython utilities via `importlib`
- bump version to 1.3.15

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fd8291534832b9d88e05816648127