### PR TITLE
fix: prevent force quit from killing parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 1.3.15 - 2025-08-03
+
+- **Fix:** Prevent Force Quit executable kills from terminating parent processes.
+- **Fix:** Dynamically import optional Cython build dependency.
+
 ## 1.3.14 - 2025-08-03
 
 - **Fix:** Skip terminating the current process when killing the active or cursor window.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "1.3.14"
+__version__ = "1.3.15"
 
 import argparse
 import os
@@ -214,7 +214,10 @@ def build_extensions() -> None:
     """Attempt to build optional Cython extensions."""
 
     try:
-        from Cython.Build import cythonize
+        import importlib
+
+        cython_build = importlib.import_module("Cython.Build")
+        cythonize = cython_build.cythonize
         from setuptools import Extension
         import numpy
     except Exception as exc:  # pragma: no cover - build tools missing

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.3.14"
+__version__ = "1.3.15"
 
 import os
 

--- a/src/views/force_quit_dialog.py
+++ b/src/views/force_quit_dialog.py
@@ -1128,10 +1128,14 @@ class ForceQuitDialog(BaseDialog):
         cls, regex: re.Pattern[str], *, exclude_self: bool = True
     ) -> int:
         """Kill processes whose executable path matches regex."""
-        self_pid = os.getpid() if exclude_self else None
+        exclude: set[int]
+        if exclude_self:
+            exclude = {os.getpid(), os.getppid()}
+        else:
+            exclude = set()
         pids: list[int] = []
         for proc in psutil.process_iter(["pid", "exe"]):
-            if exclude_self and proc.pid == self_pid:
+            if proc.pid in exclude:
                 continue
             exe = proc.info.get("exe") or ""
             if exe and regex.search(exe):

--- a/tests/test_force_quit.py
+++ b/tests/test_force_quit.py
@@ -160,6 +160,17 @@ class TestForceQuit(unittest.TestCase):
         self.assertGreaterEqual(count, 1)
         self.assertFalse(psutil.pid_exists(proc.pid))
 
+    def test_force_kill_by_executable_excludes_parent(self) -> None:
+        regex = re.compile(re.escape(sys.executable))
+        parent_pid = os.getppid()
+        proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+        time.sleep(0.1)
+        self.assertTrue(psutil.pid_exists(proc.pid))
+        ForceQuitDialog.force_kill_by_executable(regex)
+        time.sleep(0.1)
+        self.assertFalse(psutil.pid_exists(proc.pid))
+        self.assertTrue(psutil.pid_exists(parent_pid))
+
     def test_force_kill_by_user(self) -> None:
         proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
         user = psutil.Process(proc.pid).username()


### PR DESCRIPTION
## Summary
- guard against killing parent process when force-quitting by executable
- import Cython.Build dynamically to avoid missing import errors
- bump version to 1.3.15

## Testing
- `pytest tests/test_force_quit.py::TestForceQuit::test_force_kill_by_executable tests/test_force_quit.py::TestForceQuit::test_force_kill_by_executable_excludes_parent tests/test_force_quit.py::TestForceQuit::test_force_kill -q`
- `pytest tests/test_ui.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688fd8291534832b9d88e05816648127