### PR TITLE
fix: ensure overlay shows without colorkey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.3.16 - 2025-08-03
+
+- **Fix:** Ensure ClickOverlay window shows even when transparency color key is unsupported.
+
 ## 1.3.15 - 2025-08-03
 
 - **Fix:** Prevent Force Quit executable kills from terminating parent processes.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "1.3.15"
+__version__ = "1.3.16"
 
 import argparse
 import os

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.3.15"
+__version__ = "1.3.16"
 
 import os
 

--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -671,10 +671,13 @@ class ClickOverlay(tk.Toplevel):
         try:
             self.update_idletasks()
             self.deiconify()
-            if not self.basic_render:
-                self._maybe_ensure_colorkey(force=True)
         except Exception:
             pass
+        if not self.basic_render:
+            try:
+                self._maybe_ensure_colorkey(force=True)
+            except Exception:
+                pass
         self.probe_attempts = probe_attempts
         self.timeout = timeout
         if adaptive_interval is None:

--- a/tests/test_click_overlay.py
+++ b/tests/test_click_overlay.py
@@ -51,6 +51,19 @@ class TestClickOverlay(unittest.TestCase):
         root.destroy()
 
     @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_colorkey_failure_still_deiconifies(self) -> None:
+        root = tk.Tk()
+        with (
+            patch("src.views.click_overlay.is_supported", return_value=False),
+            patch.object(ClickOverlay, "_maybe_ensure_colorkey", side_effect=tk.TclError),
+            patch.object(ClickOverlay, "deiconify") as mock_deiconify,
+        ):
+            overlay = ClickOverlay(root)
+        mock_deiconify.assert_called_once()
+        overlay.destroy()
+        root.destroy()
+
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
     def test_env_sets_default_highlight(self) -> None:
         with patch.dict(os.environ, {"KILL_BY_CLICK_HIGHLIGHT": "green"}):
             root = tk.Tk()


### PR DESCRIPTION
## Summary
- ensure click overlay still appears if a transparency color key can't be set
- test overlay visibility when colorkey setup fails
- bump version to 1.3.16

## Testing
- `pytest` *(fails: tests terminated)*
- `pytest tests/test_click_overlay.py::TestClickOverlay::test_colorkey_failure_still_deiconifies -vv` *(skipped: No display available)*

------
https://chatgpt.com/codex/tasks/task_e_688fe66974e0832b90e6be603e4b0b01