### PR TITLE
fix: warn when colorkey missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.3.16 - 2025-08-03
+
+- **Fix:** Replace print with warning when transparent color key is unavailable to avoid premature exit.
+
 ## 1.3.15 - 2025-08-03
 
 - **Fix:** Prevent Force Quit executable kills from terminating parent processes.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "1.3.15"
+__version__ = "1.3.16"
 
 import argparse
 import os

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.3.15"
+__version__ = "1.3.16"
 
 import os
 

--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -12,6 +12,7 @@ import os
 import time
 import math
 import re
+import warnings
 import tkinter as tk
 from collections import deque
 from concurrent.futures import ThreadPoolExecutor, Future
@@ -974,8 +975,8 @@ class ClickOverlay(tk.Toplevel):
         except Exception:
             pass
         if not self._has_colorkey and not self._colorkey_warning_shown:
-            print(
-                "warning: transparency color key unavailable; using fallback alpha"
+            warnings.warn(
+                "transparency color key unavailable; using fallback alpha"
             )
             self._colorkey_warning_shown = True
 

--- a/tests/test_click_overlay.py
+++ b/tests/test_click_overlay.py
@@ -188,6 +188,18 @@ class TestClickOverlay(unittest.TestCase):
         root.destroy()
 
     @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_overlay_warns_when_colorkey_missing(self) -> None:
+        root = tk.Tk()
+        with (
+            patch("src.views.click_overlay.is_supported", return_value=False),
+            patch("src.views.click_overlay.set_window_colorkey", return_value=False),
+            self.assertWarnsRegex(UserWarning, "transparency color key unavailable"),
+        ):
+            overlay = ClickOverlay(root)
+        overlay.destroy()
+        root.destroy()
+
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
     def test_overlay_normalizes_named_bg_to_hex(self) -> None:
         root = tk.Tk()
         root.configure(bg="red")


### PR DESCRIPTION
## Summary
- warn via `warnings.warn` when transparent color key can't be set
- add regression test for color key warning
- bump version to 1.3.16

## Testing
- `pytest tests/test_click_overlay.py::TestClickOverlay::test_overlay_warns_when_colorkey_missing -q`
- `pytest` *(fails: Terminated)*

------
https://chatgpt.com/codex/tasks/task_e_688fe66974e0832b90e6be603e4b0b01