### PR TITLE
fix: keep force quit dialog open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.3.16 - 2025-08-03
+
+- **Fix:** Keep Force Quit dialog open by letting it manage its own close handler.
+
 ## 1.3.15 - 2025-08-03
 
 - **Fix:** Prevent Force Quit executable kills from terminating parent processes.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "1.3.15"
+__version__ = "1.3.16"
 
 import argparse
 import os

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.3.15"
+__version__ = "1.3.16"
 
 import os
 

--- a/src/app.py
+++ b/src/app.py
@@ -290,8 +290,8 @@ class CoolBoxApp:
             return
 
         self.force_quit_window = ForceQuitDialog(self)
-        self.force_quit_window.protocol(
-            "WM_DELETE_WINDOW", self._on_force_quit_closed
+        self.force_quit_window.bind(
+            "<Destroy>", lambda _e: setattr(self, "force_quit_window", None)
         )
 
     def open_security_center(self) -> None:
@@ -366,11 +366,6 @@ class CoolBoxApp:
                 dlg.refresh_theme()
             elif not dlg.winfo_exists():
                 self.dialogs.remove(dlg)
-
-    def _on_force_quit_closed(self) -> None:
-        if self.force_quit_window is not None and self.force_quit_window.winfo_exists():
-            self.force_quit_window.destroy()
-        self.force_quit_window = None
 
     def _on_quick_settings_closed(self) -> None:
         if self.quick_settings_window is not None and self.quick_settings_window.winfo_exists():

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -129,6 +129,17 @@ class TestCoolBoxApp(unittest.TestCase):
         app.destroy()
 
     @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_force_quit_clears_reference(self) -> None:
+        app = CoolBoxApp()
+        app.open_force_quit()
+        window = app.force_quit_window
+        self.assertIsNotNone(window)
+        if window is not None:
+            window.destroy()
+        self.assertIsNone(app.force_quit_window)
+        app.destroy()
+
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
     def test_open_security_center_method(self) -> None:
         app = CoolBoxApp()
         patches = [


### PR DESCRIPTION
## Summary
- keep Force Quit dialog open by letting it handle its own close logic
- add regression test for clearing Force Quit window reference
- bump version to 1.3.16

## Testing
- `flake8 src/app.py tests/test_app.py`
- `pytest tests/test_app.py::TestCoolBoxApp::test_force_quit_clears_reference`

------
https://chatgpt.com/codex/tasks/task_e_688fe66974e0832b90e6be603e4b0b01