### PR TITLE
Gracefully handle Force Quit dialog import errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.3.17 - 2025-08-03
+
+- **Fix:** Handle Force Quit dialog errors without exiting the application.
+
 ## 1.3.16 - 2025-08-03
 
 - **Fix:** Keep Force Quit dialog open by letting it manage its own close handler.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "1.3.16"
+__version__ = "1.3.17"
 
 import argparse
 import os

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.3.16"
+__version__ = "1.3.17"
 
 import os
 

--- a/src/app.py
+++ b/src/app.py
@@ -283,16 +283,28 @@ class CoolBoxApp:
 
     def open_force_quit(self) -> None:
         """Launch the Force Quit dialog or focus the existing one."""
-        from .views.force_quit_dialog import ForceQuitDialog
+        from tkinter import messagebox
+
+        try:
+            from .views.force_quit_dialog import ForceQuitDialog
+        except Exception as exc:  # pragma: no cover - runtime import error
+            log(f"Failed to import ForceQuitDialog: {exc}")
+            messagebox.showerror("Force Quit", f"Failed to open dialog: {exc}")
+            return
 
         if self.force_quit_window is not None and self.force_quit_window.winfo_exists():
             self.force_quit_window.focus()
             return
 
-        self.force_quit_window = ForceQuitDialog(self)
-        self.force_quit_window.bind(
-            "<Destroy>", lambda _e: setattr(self, "force_quit_window", None)
-        )
+        try:
+            self.force_quit_window = ForceQuitDialog(self)
+            self.force_quit_window.bind(
+                "<Destroy>", lambda _e: setattr(self, "force_quit_window", None)
+            )
+        except Exception as exc:  # pragma: no cover - runtime init error
+            log(f"Failed to create ForceQuitDialog: {exc}")
+            messagebox.showerror("Force Quit", f"Failed to open dialog: {exc}")
+            self.force_quit_window = None
 
     def open_security_center(self) -> None:
         """Launch the Security Center dialog with elevation when needed."""

--- a/tests/test_force_quit_error.py
+++ b/tests/test_force_quit_error.py
@@ -1,0 +1,39 @@
+import types
+import sys
+
+from src.app import CoolBoxApp
+
+
+def test_open_force_quit_handles_errors(monkeypatch):
+    class DummyApp:
+        def __init__(self):
+            self.force_quit_window = None
+
+    app = DummyApp()
+
+    # Stub messagebox.showerror to avoid GUI dependency
+    errors = {}
+
+    def fake_showerror(title, message):
+        errors["title"] = title
+        errors["message"] = message
+
+    monkeypatch.setattr(
+        "src.app.messagebox", types.SimpleNamespace(showerror=fake_showerror), raising=False
+    )
+
+    class BoomDialog:
+        def __init__(self, _app):
+            raise RuntimeError("boom")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "src.views.force_quit_dialog",
+        types.SimpleNamespace(ForceQuitDialog=BoomDialog),
+    )
+
+    CoolBoxApp.open_force_quit(app)  # type: ignore[arg-type]
+
+    assert app.force_quit_window is None
+    assert errors["title"] == "Force Quit"
+    assert "boom" in errors["message"]


### PR DESCRIPTION
## Summary
- prevent unhandled exceptions from closing the app when opening Force Quit
- add regression test for Force Quit error handling
- bump version to 1.3.17

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'customtkinter'; matplotlib build cancelled)*
- `pytest tests/test_force_quit_error.py -q` *(fails: matplotlib build cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_688fe951a7dc832ba5b5de37a0fdadba