### PR TITLE
feat: centralize tool execution and upgrade watchdog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## Unreleased
 
+## 1.3.21 - 2025-08-03
+
+- **Enhance:** Capture Python warnings from tools and surface them through the
+  watchdog console and status bar.
+- **Improve:** Log tool execution duration to aid production debugging.
+
+## 1.3.20 - 2025-08-03
+
+- **Improve:** Centralize tool execution in ``ThreadManager.run_tool`` with full
+  traceback logging and UI-safe error reporting.
+- **Enhance:** Watchdog console shows log levels alongside timestamps and
+  displays warnings.
+
+## 1.3.19 - 2025-08-03
+
+- **Fix:** Isolate tools in background threads so crashes don't take down the Home view.
+- **Enhance:** Watchdog console now timestamps entries and trims to the latest 200 lines.
+
+## 1.3.18 - 2025-08-03
+
+- **Feat:** Add watchdog console to Home view and centralized tool error handling.
+
 ## 1.3.17 - 2025-08-03
 
 - **Fix:** Handle Force Quit dialog errors without exiting the application.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "1.3.17"
+__version__ = "1.3.21"
 
 import argparse
 import os

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.3.17"
+__version__ = "1.3.21"
 
 import os
 

--- a/src/views/tools_view.py
+++ b/src/views/tools_view.py
@@ -12,7 +12,6 @@ import json
 import base64
 from pathlib import Path
 import re
-import threading
 import sys
 try:
     from PIL import ImageGrab
@@ -233,7 +232,13 @@ class ToolsView(BaseView):
         default_desc_color = desc_label.cget("text_color")
 
         button = self.grid_button(
-            tool_frame, "Launch", command, 0, column=1, columnspan=1, width=100
+            tool_frame,
+            "Launch",
+            lambda cmd=command, name=name: self._safe_launch(name, cmd),
+            0,
+            column=1,
+            columnspan=1,
+            width=100,
         )
         self.add_tooltip(button, f"Open {name}")
         self._tool_items.append(
@@ -247,6 +252,16 @@ class ToolsView(BaseView):
                 default_name_color,
                 default_desc_color,
             )
+        )
+
+    def _safe_launch(self, name: str, func: callable) -> None:
+        """Run *func* in a background thread and surface errors gracefully."""
+
+        self.app.thread_manager.run_tool(
+            name,
+            func,
+            window=self.app.window,
+            status_bar=self.app.status_bar,
         )
 
     # Tool implementations

--- a/tests/test_home_watchdog.py
+++ b/tests/test_home_watchdog.py
@@ -1,0 +1,46 @@
+import os
+import time
+import unittest
+os.environ["COOLBOX_LIGHTWEIGHT"] = "1"
+import customtkinter as ctk
+
+from src.views.home_view import HomeView
+from src.utils.thread_manager import ThreadManager
+
+
+class DummyTheme:
+    def get_theme(self):
+        return {"accent_color": "#1faaff"}
+
+
+class DummyApp:
+    def __init__(self):
+        self.thread_manager = ThreadManager()
+        self.thread_manager.start()
+        self.theme = DummyTheme()
+        self.config = {}
+        self.status_bar = None
+        self.window = ctk.CTk()
+
+    def destroy(self):
+        self.thread_manager.stop()
+        self.window.destroy()
+
+
+class TestHomeWatchdog(unittest.TestCase):
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_watchdog_displays_log(self) -> None:
+        app = DummyApp()
+        view = HomeView(app.window, app)
+        app.thread_manager.log_queue.put("ERROR:boom")
+        app.thread_manager.log_queue.put("WARNING:uh oh")
+        time.sleep(0.2)
+        view._flush_logs()
+        content = view.console.get("1.0", "end")
+        self.assertIn("boom", content)
+        self.assertIn("[WARNING] uh oh", content)
+        app.destroy()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tool_error_handling.py
+++ b/tests/test_tool_error_handling.py
@@ -1,0 +1,88 @@
+import os
+import time
+import unittest
+from tkinter import messagebox
+from unittest.mock import patch
+os.environ["COOLBOX_LIGHTWEIGHT"] = "1"
+import customtkinter as ctk
+
+from src.views.tools_view import ToolsView
+from src.utils.thread_manager import ThreadManager
+
+
+class DummyTheme:
+    def get_theme(self):
+        return {"accent_color": "#1faaff"}
+
+
+class DummyStatus:
+    def __init__(self):
+        self.last = ""
+
+    def set_message(self, msg: str, _type: str = "info") -> None:
+        self.last = msg
+
+
+class DummyApp:
+    def __init__(self):
+        self.thread_manager = ThreadManager()
+        self.thread_manager.start()
+        self.status_bar = DummyStatus()
+        self.theme = DummyTheme()
+        self.config = {}
+        self.window = ctk.CTk()
+
+    def destroy(self):
+        self.thread_manager.stop()
+        self.window.destroy()
+
+
+class TestToolErrorHandling(unittest.TestCase):
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_safe_launch_logs_errors(self) -> None:
+        app = DummyApp()
+        view = ToolsView(app.window, app)
+
+        def boom():
+            raise RuntimeError("kaboom")
+
+        with patch.object(messagebox, "showerror") as showerror:
+            view._safe_launch("Boom", boom)
+            deadline = time.time() + 0.5
+            while time.time() < deadline:
+                app.window.update()
+                time.sleep(0.05)
+            self.assertTrue(showerror.called)
+            self.assertTrue(
+                any("Boom failed" in log for log in app.thread_manager.logs)
+            )
+            self.assertTrue(
+                any("RuntimeError" in log for log in app.thread_manager.logs)
+            )
+            self.assertTrue(app.window.winfo_exists())
+        app.destroy()
+
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_safe_launch_logs_warnings(self) -> None:
+        app = DummyApp()
+        view = ToolsView(app.window, app)
+
+        def warn() -> None:
+            import warnings
+
+            warnings.warn("be careful")
+
+        view._safe_launch("Warn", warn)
+        deadline = time.time() + 0.5
+        while time.time() < deadline:
+            app.window.update()
+            time.sleep(0.05)
+        self.assertTrue(
+            any("WARNING:be careful" in log for log in app.thread_manager.logs)
+        )
+        app.destroy()
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- centralize tool execution in ThreadManager with traceback logging, warning capture, and UI-safe error reporting
- show log levels in the Home watchdog console and surface warnings
- bump version to 1.3.21

## Testing
- `pip install customtkinter`
- `pytest tests/test_home_watchdog.py tests/test_tool_error_handling.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688ff014615c832bbddb16e908731987