### PR TITLE
feat: increase default window height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.3.23 - 2025-08-07
+
+- **Enhance:** Increase default window height for better console visibility.
+
 ## 1.3.22 - 2025-08-07
 
 - **Fix:** Prevent overlay update crash when cursor coordinates are unavailable.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "1.3.22"
+__version__ = "1.3.23"
 
 import argparse
 import os

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.3.22"
+__version__ = "1.3.23"
 
 import os
 

--- a/src/app.py
+++ b/src/app.py
@@ -63,13 +63,13 @@ class CoolBoxApp:
         # Create main window
         self.window = ctk.CTk()
         self.window.title("CoolBox - Modern Desktop App")
-        self.window.geometry(f"{self.config.get('window_width', 1200)}x{self.config.get('window_height', 800)}")
+        self.window.geometry(f"{self.config.get('window_width', 1200)}x{self.config.get('window_height', 900)}")
 
         # Set application icon
         self._set_app_icon()
 
         # Set minimum window size
-        self.window.minsize(800, 600)
+        self.window.minsize(800, 700)
 
         # Theme manager
         self.theme = ThemeManager(config=self.config)

--- a/src/config.py
+++ b/src/config.py
@@ -25,7 +25,7 @@ class Config:
             "appearance_mode": "dark",
             "color_theme": "blue",
             "window_width": 1200,
-            "window_height": 800,
+            "window_height": 900,
             "auto_save": True,
             "recent_files": [],
             "max_recent_files": 10,
@@ -127,7 +127,7 @@ class Config:
             "kill_by_click_kf_process_noise": 1.0,
             "kill_by_click_kf_measurement_noise": 5.0,
             "window_min_width": 0,
-            "window_min_height": 0,
+            "window_min_height": 700,
         }
 
         # Load configuration


### PR DESCRIPTION
## Summary
- make main window taller and raise minimum height
- bump version to 1.3.23
- document default window height change

## Testing
- `pytest` *(fails: terminated early after partial run)*

------
https://chatgpt.com/codex/tasks/task_e_6895254f6ffc832b95d848299bca9a51