### PR TITLE
fix: avoid killing vanished or replaced processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,61 @@
 
 ## Unreleased
 
+## 1.3.36 - 2025-08-08
+
+- **Enhance:** Record a target's executable path in addition to start time and
+  command line so Kill by Click avoids terminating a PID reused by a different
+  program.
+
+## 1.3.35 - 2025-08-08
+
+- **Enhance:** Capture a target's command line and verify it alongside start
+  time before killing to avoid terminating a new process that reused the PID.
+
+## 1.3.34 - 2025-08-08
+
+- **Enhance:** Verify a selected process's start time before killing to avoid terminating a new process that reused the PID.
+
+## 1.3.33 - 2025-08-07
+
+- **Fix:** Treat targets that vanish during `force_kill` as already terminated, preventing spurious failure diagnostics.
+
+## 1.3.32 - 2025-08-07
+
+- **Fix:** Skip Kill by Click targets that vanish before termination, logging details instead of reporting a failure.
+
+## 1.3.31 - 2025-08-07
+
+- **Enhance:** Gate the Kill by Click watchdog behind a developer mode toggle to avoid runtime overhead.
+
+## 1.3.30 - 2025-08-07
+
+- **Enhance:** Probe the Kill by Click overlay before counting a watchdog miss so only unresponsive sessions are aborted.
+
+## 1.3.29 - 2025-08-07
+
+- **Enhance:** Require multiple missed heartbeats before aborting Kill by Click and report stall duration and miss count.
+
+## 1.3.28 - 2025-08-07
+
+- **Enhance:** Watchdog monitors Kill by Click overlay heartbeats and only aborts when the UI stops responding, logging diagnostics on timeout.
+
+## 1.3.27 - 2025-08-07
+
+- **Enhance:** Add watchdog that aborts hung Kill by Click sessions and logs overlay state.
+
+## 1.3.26 - 2025-08-07
+
+- **Enhance:** Add safety diagnostics and fallback logging when Kill by Click or force kill fails.
+
+## 1.3.25 - 2025-08-07
+
+- **Enhance:** Emit structured JSON diagnostics when Kill by Click makes no selection.
+
+## 1.3.24 - 2025-08-07
+
+- **Fix:** Log diagnostic details when Kill by Click fails to select a process.
+
 ## 1.3.23 - 2025-08-07
 
 - **Enhance:** Increase default window height for better console visibility.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "1.3.23"
+__version__ = "1.3.36"
 
 import argparse
 import os

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.3.23"
+__version__ = "1.3.36"
 
 import os
 

--- a/src/components/menubar.py
+++ b/src/components/menubar.py
@@ -47,6 +47,9 @@ class MenuBar:
         self.fullscreen_var = tk.BooleanVar(
             value=self.app.window.attributes("-fullscreen")
         )
+        self.developer_var = tk.BooleanVar(
+            value=self.app.config.get("developer_mode", False)
+        )
 
         view_menu.add_checkbutton(
             label="Toolbar", variable=self.toolbar_var, command=self._toggle_toolbar
@@ -56,6 +59,11 @@ class MenuBar:
         )
         view_menu.add_checkbutton(
             label="Full Screen", variable=self.fullscreen_var, command=self._toggle_fullscreen
+        )
+        view_menu.add_checkbutton(
+            label="Developer Mode",
+            variable=self.developer_var,
+            command=self._toggle_developer_mode,
         )
         self.menu.add_cascade(label="View", menu=view_menu)
         self.menus.append(view_menu)
@@ -76,6 +84,7 @@ class MenuBar:
         self.toolbar_var.set(self.app.config.get("show_toolbar", True))
         self.status_var.set(self.app.config.get("show_statusbar", True))
         self.fullscreen_var.set(self.app.window.attributes("-fullscreen"))
+        self.developer_var.set(self.app.config.get("developer_mode", False))
 
     # ------------------------------------------------------------------
     def _call_toolbar(self, name: str) -> None:
@@ -96,6 +105,13 @@ class MenuBar:
     def _toggle_statusbar(self) -> None:
         self.app.config.set("show_statusbar", self.status_var.get())
         self.app.update_ui_visibility()
+
+    def _toggle_developer_mode(self) -> None:
+        self.app.config.set("developer_mode", self.developer_var.get())
+        try:
+            self.app.config.save()
+        except Exception:
+            pass
 
     # ------------------------------------------------------------------
     def update_recent_files(self) -> None:

--- a/src/config.py
+++ b/src/config.py
@@ -33,6 +33,7 @@ class Config:
             "show_toolbar": True,
             "show_statusbar": True,
             "show_menu": True,
+            "developer_mode": False,
             "basic_rendering": False,
             "section_states": {},
             "force_quit_cpu_alert": 80.0,


### PR DESCRIPTION
## Summary
- capture command line, start time, and executable path for selected process so Kill by Click confirms the PID still refers to the same program before termination
- add regression test ensuring Kill by Click skips termination when the executable path changes
- bump version to 1.3.36 and document the smarter PID verification

## Testing
- `pytest tests/test_kill_by_click.py::test_kill_by_click_selects_and_kills_pid tests/test_kill_by_click.py::test_kill_by_click_reports_when_no_selection tests/test_kill_by_click.py::test_kill_by_click_skips_vanished_process tests/test_kill_by_click.py::test_kill_by_click_reports_when_kill_fails tests/test_kill_by_click.py::test_kill_by_click_skips_pid_reuse tests/test_kill_by_click.py::test_kill_by_click_skips_cmdline_change tests/test_kill_by_click.py::test_kill_by_click_skips_exe_change -q`


------
https://chatgpt.com/codex/tasks/task_e_689527f50f74832ba5c368b9ec351e44