### PR TITLE
fix: keep force quit actions clickable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.3.37 - 2025-08-08
+
+- **Fix:** Keep Force Quit actions enabled after the first refresh so Kill by Click remains clickable.
+
 ## 1.3.36 - 2025-08-08
 
 - **Enhance:** Record a target's executable path in addition to start time and

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.3.36"
+__version__ = "1.3.37"
 
 import os
 

--- a/src/views/force_quit_dialog.py
+++ b/src/views/force_quit_dialog.py
@@ -957,14 +957,12 @@ class ForceQuitDialog(BaseDialog):
             self._snapshot_changed = True
 
     def _update_kill_actions(self) -> None:
-        enable = self._enum_progress >= 1.0
-        if enable == self._actions_enabled:
+        if self._actions_enabled or self._enum_progress < 1.0:
             return
-        state = tk.NORMAL if enable else tk.DISABLED
-        self.kill_selected_btn.configure(state=state)
+        self.kill_selected_btn.configure(state=tk.NORMAL)
         for btn in self._action_buttons:
-            btn.configure(state=state)
-        self._actions_enabled = enable
+            btn.configure(state=tk.NORMAL)
+        self._actions_enabled = True
 
     @staticmethod
     def _find_over_threshold(

--- a/tests/test_force_quit_actions.py
+++ b/tests/test_force_quit_actions.py
@@ -1,0 +1,33 @@
+import tkinter as tk
+from types import SimpleNamespace
+
+from src.views.force_quit_dialog import ForceQuitDialog
+
+
+class Dummy:
+    def __init__(self) -> None:
+        self.state = tk.DISABLED
+
+    def configure(self, *, state: str) -> None:
+        self.state = state
+
+
+def test_kill_actions_enable_once() -> None:
+    dialog = SimpleNamespace(
+        _enum_progress=0.0,
+        _actions_enabled=False,
+        kill_selected_btn=Dummy(),
+        _action_buttons=[Dummy(), Dummy()],
+    )
+
+    ForceQuitDialog._update_kill_actions(dialog)
+    assert dialog.kill_selected_btn.state == tk.DISABLED
+
+    dialog._enum_progress = 1.0
+    ForceQuitDialog._update_kill_actions(dialog)
+    assert dialog.kill_selected_btn.state == tk.NORMAL
+
+    dialog._enum_progress = 0.0
+    ForceQuitDialog._update_kill_actions(dialog)
+    assert dialog.kill_selected_btn.state == tk.NORMAL
+


### PR DESCRIPTION
## Summary
- keep Force Quit dialog actions enabled after initial process scan
- add regression test for Force Quit action enablement

## Testing
- `pytest tests/test_force_quit_actions.py -q`
- `pytest` *(fails: short test summary info ... Interrupted: 2 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68954c209a38832b8d26f6bab9d6bd21