### PR TITLE
fix: guard Kill by Click from invalid targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+## 1.3.47 - 2025-08-08
+
+- **Fix:** Warn and refresh Force Quit when Kill by Click selects no process.
+
+## 1.3.46 - 2025-08-08
+
+- **Fix:** Prevent Kill by Click from terminating the application itself, avoiding crashes when the Force Quit window is selected.
+
 ## 1.3.45 - 2025-08-08
 
 - **Perf:** Update Force Quit watchdog to sync via file modification times, reducing I/O overhead.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "1.3.45"
+__version__ = "1.3.47"
 
 import argparse
 import os

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.3.45"
+__version__ = "1.3.47"
 
 import os
 


### PR DESCRIPTION
## Summary
- prevent Kill by Click from terminating the Force Quit dialog itself
- warn and refresh Force Quit when no process is selected
- add regression tests for self selection and missing target
- bump version to 1.3.47

## Testing
- `pytest tests/test_kill_by_click.py::test_kill_by_click_handles_no_selection -q`
- `pytest tests/test_kill_by_click.py::test_kill_by_click_skips_self -q`
- `pytest tests/test_kill_by_click.py::test_kill_by_click_selects_and_kills_pid -q`
- `pytest tests/test_force_quit.py::TestForceQuit::test_kill_by_click_skip_confirm -q`
- `pytest tests/test_force_quit.py::TestForceQuit::test_force_kill_handles_vanished_process -q`


------
https://chatgpt.com/codex/tasks/task_e_6895a83104f0832b9a3e7426e0688825