### PR TITLE
fix: fall back when hooks stall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+## 1.3.50 - 2025-08-08
+
+- **Fix:** Detect stalled mouse hooks and fall back to polling to keep the Kill by Click overlay responsive.
+
+## 1.3.49 - 2025-08-08
+
+- **Fix:** Start the global listener only once so the Kill by Click overlay stays responsive when hooks fail to initialize.
+
+## 1.3.48 - 2025-08-08
+
+- **Fix:** Delay click-through activation until hooks start so the Kill by Click overlay remains interactive when hook initialization fails.
+
 ## 1.3.47 - 2025-08-08
 
 - **Fix:** Warn and refresh Force Quit when Kill by Click selects no process.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "1.3.47"
+__version__ = "1.3.50"
 
 import argparse
 import os

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.3.47"
+__version__ = "1.3.50"
 
 import os
 


### PR DESCRIPTION
## Summary
- monitor global mouse hooks and revert to event bindings when they stop emitting events
- add regression test covering fallback from stalled hooks
- bump version to 1.3.50

## Testing
- `pytest tests/test_click_overlay.py::TestClickOverlay::test_hooks_fail_without_clickthrough -q`
- `pytest tests/test_click_overlay.py::TestClickOverlay::test_unresponsive_hooks_fall_back_to_polling -q`


------
https://chatgpt.com/codex/tasks/task_e_6895e6802af4832bb2c07723297f1142