### PR TITLE
Handle missing display in kill_by_click

### DIFF
--- a/scripts/kill_by_click.py
+++ b/scripts/kill_by_click.py
@@ -2,6 +2,7 @@
 """Select a window by clicking it and print the PID and title."""
 
 import argparse
+import sys
 import tkinter as tk
 from src.views.click_overlay import ClickOverlay, KILL_BY_CLICK_INTERVAL
 
@@ -49,7 +50,11 @@ def main(argv: list[str] | None = None) -> None:
         print(f"Calibrated: interval={interval:.4f} min={min_i:.4f} max={max_i:.4f}")
         return
 
-    root = tk.Tk()
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        print("No display available")
+        sys.exit(1)
     root.withdraw()
     kwargs = {"skip_confirm": args.skip_confirm, "interval": args.interval}
     if args.min_interval is not None:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "1.3.50"
+__version__ = "1.3.51"
 
 import argparse
 import os

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.3.50"
+__version__ = "1.3.51"
 
 import os
 

--- a/tests/test_kill_by_click_cli.py
+++ b/tests/test_kill_by_click_cli.py
@@ -1,3 +1,22 @@
+import os
+import sys
+from types import SimpleNamespace
+from unittest import mock
+import pytest
+
+os.environ.setdefault("COOLBOX_LIGHTWEIGHT", "1")
+psutil_stub = SimpleNamespace(net_if_addrs=lambda: {}, Process=object, pid_exists=lambda pid: True)
+sys.modules.setdefault("psutil", psutil_stub)
+sys.modules.setdefault("PIL", mock.Mock())
+sys.modules.setdefault("PIL.Image", mock.Mock())
+sys.modules.setdefault("PIL.ImageTk", mock.Mock())
+sys.modules.setdefault("pyperclip", mock.Mock())
+sys.modules.setdefault("matplotlib", mock.Mock())
+sys.modules.setdefault("matplotlib.pyplot", mock.Mock())
+sys.modules.setdefault("matplotlib.backends", mock.Mock())
+sys.modules.setdefault("matplotlib.backends.backend_tkagg", mock.Mock())
+sys.modules.setdefault("matplotlib.figure", mock.Mock())
+
 import scripts.kill_by_click as kbc
 
 
@@ -57,3 +76,14 @@ def test_calibrate_flag(monkeypatch, capsys):
     kbc.main(['--calibrate'])
     out = capsys.readouterr().out
     assert 'Calibrated' in out
+
+
+def test_main_no_display(monkeypatch, capsys):
+    def raise_err():
+        raise kbc.tk.TclError('no display')
+
+    monkeypatch.setattr(kbc.tk, 'Tk', raise_err)
+    with pytest.raises(SystemExit) as e:
+        kbc.main([])
+    assert e.value.code != 0
+    assert 'No display available' in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- handle missing displays in `kill_by_click` with a clear message and exit code
- add unit test for missing display behavior
- bump version to 1.3.51

## Testing
- `pytest tests/test_kill_by_click_cli.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6895fa04c444832bba88bf2866b4f0f3