### PR TITLE
Run overlay.choose on UI thread

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "1.3.51"
+__version__ = "1.3.52"
 
 import argparse
 import os

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.3.51"
+__version__ = "1.3.52"
 
 import os
 


### PR DESCRIPTION
## Summary
- schedule the kill-by-click overlay chooser on the Tk main thread and keep psutil work in a worker
- test scheduling behavior for kill-by-click operations
- bump version to 1.3.52

## Testing
- `pytest tests/test_kill_by_click.py tests/test_force_quit.py`

------
https://chatgpt.com/codex/tasks/task_e_6895fc107324832badf3563e365e5acd