### PR TITLE
Sanitize click overlay interval bounds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "1.3.52"
+__version__ = "1.3.53"
 
 import argparse
 import os

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.3.52"
+__version__ = "1.3.53"
 
 import os
 

--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -686,25 +686,32 @@ class ClickOverlay(tk.Toplevel):
                 True,
             )
         self.adaptive_interval = adaptive_interval
-        self.interval = interval
+        self.interval = max(interval, 0.0)
         if min_interval is None:
-            self.min_interval = _load_calibrated(
-                "KILL_BY_CLICK_MIN_INTERVAL",
-                "kill_by_click_min_interval",
-                tuning.min_interval,
+            self.min_interval = max(
+                _load_calibrated(
+                    "KILL_BY_CLICK_MIN_INTERVAL",
+                    "kill_by_click_min_interval",
+                    tuning.min_interval,
+                ),
+                0.0,
             )
         else:
-            self.min_interval = min_interval
+            self.min_interval = max(min_interval, 0.0)
         if max_interval is None:
-            self.max_interval = _load_calibrated(
-                "KILL_BY_CLICK_MAX_INTERVAL",
-                "kill_by_click_max_interval",
-                tuning.max_interval,
+            self.max_interval = max(
+                _load_calibrated(
+                    "KILL_BY_CLICK_MAX_INTERVAL",
+                    "kill_by_click_max_interval",
+                    tuning.max_interval,
+                ),
+                0.0,
             )
         else:
-            self.max_interval = max_interval
+            self.max_interval = max(max_interval, 0.0)
         if self.min_interval > self.max_interval:
             self.min_interval, self.max_interval = self.max_interval, self.min_interval
+        self.interval = min(max(self.interval, self.min_interval), self.max_interval)
         if delay_scale is None:
             try:
                 self.delay_scale = float(

--- a/tests/test_click_overlay.py
+++ b/tests/test_click_overlay.py
@@ -116,6 +116,30 @@ class TestClickOverlay(unittest.TestCase):
             root.destroy()
 
     @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_interval_clamping(self) -> None:
+        root = tk.Tk()
+        with patch("src.views.click_overlay.is_supported", return_value=False):
+            overlay = ClickOverlay(root, interval=-1, min_interval=-5, max_interval=-2)
+        self.assertEqual(overlay.interval, 0)
+        self.assertEqual(overlay.min_interval, 0)
+        self.assertEqual(overlay.max_interval, 0)
+        overlay.destroy()
+        root.destroy()
+
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_interval_bounds_enforced(self) -> None:
+        root = tk.Tk()
+        with patch("src.views.click_overlay.is_supported", return_value=False):
+            overlay = ClickOverlay(root, interval=10, min_interval=1, max_interval=5)
+        self.assertEqual(overlay.interval, 5)
+        overlay.destroy()
+        with patch("src.views.click_overlay.is_supported", return_value=False):
+            overlay = ClickOverlay(root, interval=0.5, min_interval=1, max_interval=5)
+        self.assertEqual(overlay.interval, 1)
+        overlay.destroy()
+        root.destroy()
+
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
     def test_enriched_label_uses_process_name(self) -> None:
         root = tk.Tk()
         with patch("src.views.click_overlay.is_supported", return_value=False):


### PR DESCRIPTION
## Summary
- Clamp click overlay interval values to positive and enforce min/max bounds
- Add unit tests validating interval clamping behavior
- Bump patch version to 1.3.53

## Testing
- `pytest tests/test_click_overlay.py::TestClickOverlay::test_interval_clamping tests/test_click_overlay.py::TestClickOverlay::test_interval_bounds_enforced -q`

------
https://chatgpt.com/codex/tasks/task_e_6895fe8a4428832baf6fc766e8153085