### PR TITLE
feat: reference counted global mouse listener

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "1.3.53"
+__version__ = "1.3.54"
 
 import argparse
 import os

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.3.53"
+__version__ = "1.3.54"
 
 import os
 

--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -1856,6 +1856,6 @@ class ClickOverlay(tk.Toplevel):
             return self.pid, self.title_text
         finally:
             try:
-                listener.stop()
+                listener.release()
             finally:
                 self.reset()


### PR DESCRIPTION
## Summary
- implement reference counted GlobalMouseListener and release-based API
- use release in ClickOverlay to avoid interfering listeners
- add regression test for multiple overlays and bump patch version

## Testing
- `pytest tests/test_click_overlay.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689600a52548832b8c7c903ecb185f0f