### PR TITLE
Guard global listener stop in click overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.3.55 - 2025-08-08
+
+- **Fix:** Stop the global listener only when it successfully starts to avoid erroneous stop calls.
+
 ## 1.3.50 - 2025-08-08
 
 - **Fix:** Detect stalled mouse hooks and fall back to polling to keep the Kill by Click overlay responsive.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "1.3.54"
+__version__ = "1.3.55"
 
 import argparse
 import os

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.3.54"
+__version__ = "1.3.55"
 
 import os
 

--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -1831,8 +1831,11 @@ class ClickOverlay(tk.Toplevel):
             except Exception:
                 pass
         use_hooks = is_supported()
+        started = False
         try:
-            if use_hooks and listener.start(on_move=self._on_move, on_click=self._click):
+            if use_hooks:
+                started = listener.start(on_move=self._on_move, on_click=self._click)
+            if use_hooks and started:
                 self._clickthrough = make_window_clickthrough(self)
                 self._using_hooks = True
                 self.state = OverlayState.HOOKED
@@ -1856,6 +1859,8 @@ class ClickOverlay(tk.Toplevel):
             return self.pid, self.title_text
         finally:
             try:
+                if started:
+                    listener.stop()
                 listener.release()
             finally:
                 self.reset()

--- a/tests/test_click_overlay.py
+++ b/tests/test_click_overlay.py
@@ -1104,6 +1104,9 @@ class TestClickOverlay(unittest.TestCase):
             def release(self):
                 pass
 
+            def stop(self):
+                pass
+
         with (
             patch(
                 "src.views.click_overlay.get_global_listener",
@@ -1137,6 +1140,9 @@ class TestClickOverlay(unittest.TestCase):
                 return True
 
             def release(self):
+                pass
+
+            def stop(self):
                 pass
 
         with (
@@ -1214,6 +1220,9 @@ class TestClickOverlay(unittest.TestCase):
                 return False if on_move or on_click else True
 
             def release(self):
+                pass
+
+            def stop(self):
                 pass
 
         with (
@@ -1353,6 +1362,9 @@ class TestClickOverlay(unittest.TestCase):
             def release(self):
                 pass
 
+            def stop(self):
+                pass
+
         with (
             patch(
                 "src.views.click_overlay.get_global_listener",
@@ -1408,6 +1420,9 @@ class TestClickOverlay(unittest.TestCase):
                 self.ref -= 1
                 if self.ref == 0:
                     self.stops += 1
+
+            def stop(self):
+                pass
 
         listener = DummyListener()
 

--- a/tests/test_mouse_listener.py
+++ b/tests/test_mouse_listener.py
@@ -39,6 +39,8 @@ def test_global_listener_singleton(monkeypatch):
     assert events["start"] == 1  # no new Listener started
 
     listener.stop()
+    assert events["stop"] == 0
+    listener.stop()
     assert events["stop"] == 1
     listener.stop()
     assert events["stop"] == 1  # stop only once


### PR DESCRIPTION
## Summary
- call stop on the global listener only when hooks successfully start
- update tests for dummy listeners and mouse listener reference counting
- bump version to 1.3.55

## Testing
- `pre-commit run --files src/views/click_overlay.py tests/test_click_overlay.py setup.py src/__init__.py CHANGELOG.md` *(fails: InvalidConfigError: .pre-commit-config.yaml is not a file)*
- `pytest` *(terminated: progress 38%)*
- `pytest tests/test_click_overlay.py`
- `pytest tests/test_mouse_listener.py`


------
https://chatgpt.com/codex/tasks/task_e_689603eb5dc8832bb353da1a44dc23aa