### PR TITLE
refactor: expose watchdog reset helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.3.56 - 2025-08-08
+
+- **Refactor:** Add watchdog heartbeat reset helper and expose misses counter.
+
 ## 1.3.55 - 2025-08-08
 
 - **Fix:** Stop the global listener only when it successfully starts to avoid erroneous stop calls.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "1.3.55"
+__version__ = "1.3.56"
 
 import argparse
 import os

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.3.55"
+__version__ = "1.3.56"
 
 import os
 

--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -589,6 +589,7 @@ class ClickOverlay(tk.Toplevel):
         self.backend = "canvas"
         self._closed = tk.BooleanVar(value=False)
         self._last_ping = time.monotonic()
+        self._watchdog_misses = 0
         env = os.getenv("KILL_BY_CLICK_CROSSHAIR")
         if env in ("0", "false", "no"):
             show_crosshair = False
@@ -1708,6 +1709,11 @@ class ClickOverlay(tk.Toplevel):
             self.delay_scale = tuning.delay_scale
         env = os.getenv("KILL_BY_CLICK_SKIP_CONFIRM")
         self.skip_confirm = env not in (None, "0", "false", "no")
+
+    def reset_watchdog(self) -> None:
+        """Record a heartbeat for the external watchdog."""
+        self._last_ping = time.monotonic()
+        self._watchdog_misses = 0
 
     def reset(self) -> None:
         """Hide the overlay and clear runtime state."""

--- a/src/views/force_quit_dialog.py
+++ b/src/views/force_quit_dialog.py
@@ -2316,8 +2316,7 @@ class ForceQuitDialog(BaseDialog):
             if self._overlay_thread:
                 self.after(0, lambda: self._finish_kill_by_click(ctx, result))
 
-        overlay._last_ping = time.monotonic()
-        overlay._watchdog_misses = 0
+        overlay.reset_watchdog()
         self._overlay_thread = threading.Thread(target=run, daemon=True)
         self._overlay_thread.start()
         if self.app.config.get("developer_mode", False):

--- a/tests/test_kill_by_click.py
+++ b/tests/test_kill_by_click.py
@@ -715,6 +715,10 @@ def test_kill_by_click_watchdog_reports_timeout() -> None:
     overlay.reset = mock.Mock()
     overlay.apply_defaults = mock.Mock()
     overlay.close = mock.Mock()
+    def _reset() -> None:
+        overlay._last_ping = time.monotonic()
+        overlay._watchdog_misses = 0
+    overlay.reset_watchdog = mock.Mock(side_effect=_reset)
     overlay.choose.side_effect = lambda: time.sleep(0.5) or (None, None)
 
     dialog._overlay = overlay
@@ -761,11 +765,14 @@ def test_kill_by_click_watchdog_ignores_recent_activity() -> None:
     overlay.reset = mock.Mock()
     overlay.apply_defaults = mock.Mock()
     overlay.close = mock.Mock()
-    overlay._last_ping = time.monotonic()
+    def _reset() -> None:
+        overlay._last_ping = time.monotonic()
+        overlay._watchdog_misses = 0
+    overlay.reset_watchdog = mock.Mock(side_effect=_reset)
 
     def choose() -> tuple[int | None, str | None]:
         for _ in range(5):
-            overlay._last_ping = time.monotonic()
+            overlay.reset_watchdog()
             time.sleep(0.02)
         return (None, None)
 
@@ -814,6 +821,10 @@ def test_kill_by_click_watchdog_requires_multiple_misses() -> None:
     overlay.reset = mock.Mock()
     overlay.apply_defaults = mock.Mock()
     overlay.close = mock.Mock()
+    def _reset() -> None:
+        overlay._last_ping = time.monotonic()
+        overlay._watchdog_misses = 0
+    overlay.reset_watchdog = mock.Mock(side_effect=_reset)
     overlay.choose.side_effect = lambda: time.sleep(0.5) or (None, None)
 
     dialog._overlay = overlay
@@ -857,6 +868,10 @@ def test_kill_by_click_watchdog_separate_process() -> None:
     overlay.reset = mock.Mock()
     overlay.apply_defaults = mock.Mock()
     overlay.close = mock.Mock()
+    def _reset() -> None:
+        overlay._last_ping = time.monotonic()
+        overlay._watchdog_misses = 0
+    overlay.reset_watchdog = mock.Mock(side_effect=_reset)
     overlay.choose.side_effect = lambda: time.sleep(0.5) or (None, None)
 
     dialog._overlay = overlay
@@ -896,6 +911,10 @@ def test_kill_by_click_watchdog_disabled_without_developer_mode() -> None:
     overlay.label = object()
     overlay.reset = mock.Mock()
     overlay.apply_defaults = mock.Mock()
+    def _reset() -> None:
+        overlay._last_ping = time.monotonic()
+        overlay._watchdog_misses = 0
+    overlay.reset_watchdog = mock.Mock(side_effect=_reset)
     overlay.choose.return_value = (None, None)
 
     dialog._overlay = overlay


### PR DESCRIPTION
## Summary
- add `_watchdog_misses` field and `reset_watchdog` helper to `ClickOverlay`
- use new helper in `ForceQuitDialog._kill_by_click`
- update tests for new watchdog interface
- bump version to 1.3.56

## Testing
- `pytest` *(fails: tests/test_app.py, tests/test_auto_setup.py during collection)*
- `pytest tests/test_kill_by_click.py`

------
https://chatgpt.com/codex/tasks/task_e_6896072c9fec832b824ca0bd4ceb7278