### PR TITLE
fix: restore overlay interval defaults on reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.3.57 - 2025-08-08
+
+- **Fix:** Restore configured refresh intervals after reset by reapplying defaults.
+
 ## 1.3.56 - 2025-08-08
 
 - **Refactor:** Add watchdog heartbeat reset helper and expose misses counter.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "1.3.56"
+__version__ = "1.3.57"
 
 import argparse
 import os

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.3.56"
+__version__ = "1.3.57"
 
 import os
 

--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -1755,9 +1755,7 @@ class ClickOverlay(tk.Toplevel):
         self._closed.set(False)
         self.update_state = UpdateState.IDLE
         self.state = OverlayState.INIT
-        self.interval = tuning.interval
-        self.min_interval = tuning.min_interval
-        self.max_interval = tuning.max_interval
+        self.apply_defaults()
 
     def close(self, _e: object | None = None) -> None:
         if self._after_id is not None:

--- a/tests/test_click_overlay.py
+++ b/tests/test_click_overlay.py
@@ -140,6 +140,29 @@ class TestClickOverlay(unittest.TestCase):
         root.destroy()
 
     @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_reset_applies_defaults(self) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                "KILL_BY_CLICK_INTERVAL": "0.2",
+                "KILL_BY_CLICK_MIN_INTERVAL": "0.1",
+                "KILL_BY_CLICK_MAX_INTERVAL": "0.3",
+            },
+        ):
+            root = tk.Tk()
+            with patch("src.views.click_overlay.is_supported", return_value=False):
+                overlay = ClickOverlay(root)
+            overlay.interval = 5
+            overlay.min_interval = 6
+            overlay.max_interval = 7
+            overlay.reset()
+            self.assertAlmostEqual(overlay.interval, 0.2)
+            self.assertAlmostEqual(overlay.min_interval, 0.1)
+            self.assertAlmostEqual(overlay.max_interval, 0.3)
+            overlay.destroy()
+            root.destroy()
+
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
     def test_enriched_label_uses_process_name(self) -> None:
         root = tk.Tk()
         with patch("src.views.click_overlay.is_supported", return_value=False):


### PR DESCRIPTION
## Summary
- ensure `ClickOverlay.reset` reapplies configured refresh intervals
- cover interval restore behavior with regression test
- bump version to 1.3.57

## Testing
- `pytest tests/test_click_overlay.py::TestClickOverlay::test_reset_applies_defaults tests/test_force_quit_interval.py::TestForceQuitInterval::test_auto_tune_called_and_cached tests/test_force_quit_interval.py::TestForceQuitInterval::test_auto_tune_skipped_when_cached -q`


------
https://chatgpt.com/codex/tasks/task_e_689609d66974832ba7d38cc3bdc34cfc