### PR TITLE
Use context manager for process icon loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.3.58 - 2025-08-08
+
+- **Fix:** Load process icons within a context manager to ensure files close promptly.
+
 ## 1.3.57 - 2025-08-08
 
 - **Fix:** Restore configured refresh intervals after reset by reapplying defaults.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "1.3.57"
+__version__ = "1.3.58"
 
 import argparse
 import os

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.3.57"
+__version__ = "1.3.58"
 
 import os
 

--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -112,8 +112,8 @@ def _process_details(pid: int) -> tuple[str, ImageTk.PhotoImage | None]:
         name = proc.name()
         exe = proc.exe()
         if exe and exe.lower().endswith((".ico", ".png")):
-            img = Image.open(exe).resize((16, 16))
-            icon_img = ImageTk.PhotoImage(img)
+            with Image.open(exe) as img:
+                icon_img = ImageTk.PhotoImage(img.resize((16, 16)))
     except Exception:
         pass
     _PROCESS_CACHE[pid] = (name, icon_img)


### PR DESCRIPTION
## Summary
- close process icon files with a context manager
- bump version to 1.3.58

## Testing
- `python -m pytest tests/test_click_overlay.py`

------
https://chatgpt.com/codex/tasks/task_e_68960c1f9f08832b95c4cbaeea2a9f62