### PR TITLE
log mouse listener callback errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.3.59 - 2025-08-08
+
+- **Fix:** Log exceptions from mouse and keyboard listener callbacks.
+
 ## 1.3.58 - 2025-08-08
 
 - **Fix:** Load process icons within a context manager to ensure files close promptly.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "1.3.58"
+__version__ = "1.3.59"
 
 import argparse
 import os

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.3.58"
+__version__ = "1.3.59"
 
 import os
 

--- a/src/utils/mouse_listener.py
+++ b/src/utils/mouse_listener.py
@@ -21,6 +21,8 @@ import threading
 from contextlib import contextmanager
 from typing import Callable, Optional
 
+from .helpers import log
+
 # -- Optional dependencies -------------------------------------------------
 
 try:  # pragma: no cover - optional dependency may be missing
@@ -247,8 +249,8 @@ class GlobalMouseListener:
         def _on_move(x: int, y: int) -> None:
             try:
                 cb(x, y)
-            except Exception:
-                pass
+            except Exception as e:
+                log(f"move callback error: {e}")
 
         return _on_move
 
@@ -260,8 +262,8 @@ class GlobalMouseListener:
             try:
                 if button == getattr(mouse, "Button", object()).left:
                     cb(x, y, pressed)
-            except Exception:
-                pass
+            except Exception as e:
+                log(f"click callback error: {e}")
 
         return _on_click
 
@@ -272,8 +274,8 @@ class GlobalMouseListener:
         def _on_press(key) -> None:
             try:
                 cb(getattr(key, "vk", getattr(getattr(key, "value", key), "vk", 0)), True)
-            except Exception:
-                pass
+            except Exception as e:
+                log(f"key callback error: {e}")
 
         return _on_press
 


### PR DESCRIPTION
## Summary
- log mouse/keyboard listener callback errors instead of silently ignoring
- bump version to 1.3.59
- test callback wrappers logging via monkeypatched logger

## Testing
- `pytest tests/test_mouse_listener.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68960d45a6f8832b82b677476baba93d