### PR TITLE
fix: guard window query callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- **Fix:** Guard asynchronous window queries to prevent callback exceptions.
+
 ## 1.3.59 - 2025-08-08
 
 - **Fix:** Log exceptions from mouse and keyboard listener callbacks.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "1.3.61"
+__version__ = "1.3.62"
 
 import argparse
 import os

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.3.61"
+__version__ = "1.3.62"
 
 import os
 

--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -1389,7 +1389,14 @@ class ClickOverlay(tk.Toplevel):
 
         def _on_done(fut: Future[WindowInfo]) -> None:
             self._query_future = None
-            self.after(0, lambda: callback(fut.result()))
+            try:
+                result = fut.result()
+            except Exception as exc:  # pragma: no cover - best effort logging
+                if not fut.cancelled():
+                    log(f"_query_window_async failed: {exc}")
+                    self.after(0, lambda: callback(WindowInfo(None)))
+            else:
+                self.after(0, lambda: callback(result))
 
         future.add_done_callback(_on_done)
 


### PR DESCRIPTION
## Summary
- handle exceptions from async window query to avoid crashes
- bump version to 1.3.62

## Testing
- `pytest` *(terminated)*

------
https://chatgpt.com/codex/tasks/task_e_689612bea210832bb56af551b600d7d1