### PR TITLE
Check DISPLAY for Linux cursor window support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.3.65 - 2025-08-08
+
+- **Fix:** Require a non-empty DISPLAY variable when detecting cursor window support on Linux.
+
 ## 1.3.64 - 2025-08-08
 
 - **Fix:** Guard asynchronous window queries to prevent callback exceptions.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "1.3.64"
+__version__ = "1.3.65"
 
 import argparse
 import os

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.3.64"
+__version__ = "1.3.65"
 
 import os
 

--- a/src/utils/window_utils.py
+++ b/src/utils/window_utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 """Helpers for retrieving information about desktop windows."""
 
 import ctypes
+import os
 import re
 import shutil
 import subprocess
@@ -168,6 +169,8 @@ def has_cursor_window_support() -> bool:
         except Exception:
             return False
         return True
+    if not os.environ.get("DISPLAY"):
+        return False
     return bool(
         shutil.which("xdotool") and shutil.which("xprop") and shutil.which("xwininfo")
     )

--- a/tests/test_window_utils.py
+++ b/tests/test_window_utils.py
@@ -151,6 +151,26 @@ class TestWindowUtils(unittest.TestCase):
         self.assertIsInstance(has_active_window_support(), bool)
         self.assertIsInstance(has_cursor_window_support(), bool)
 
+    def test_has_cursor_window_support_display_missing(self):
+        from src.utils import window_utils as wu
+
+        with (
+            mock.patch.object(wu.sys, "platform", "linux"),
+            mock.patch.dict(wu.os.environ, {}, clear=True),
+            mock.patch.object(wu.shutil, "which", return_value="/usr/bin/true"),
+        ):
+            self.assertFalse(wu.has_cursor_window_support())
+
+    def test_has_cursor_window_support_display_present(self):
+        from src.utils import window_utils as wu
+
+        with (
+            mock.patch.object(wu.sys, "platform", "linux"),
+            mock.patch.dict(wu.os.environ, {"DISPLAY": ":0"}, clear=True),
+            mock.patch.object(wu.shutil, "which", return_value="/usr/bin/true"),
+        ):
+            self.assertTrue(wu.has_cursor_window_support())
+
     def test_list_windows_at(self):
         from src.utils.window_utils import list_windows_at
 


### PR DESCRIPTION
## Summary
- verify DISPLAY env var before enabling cursor window detection on Linux
- test Linux cursor window support behavior with and without DISPLAY
- bump version to 1.3.65

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'customtkinter', ModuleNotFoundError: No module named 'Pillow')*
- `python -m flake8 src/utils/window_utils.py tests/test_window_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_689617293b7c832b8eae28b3d8f62ef6