### PR TITLE
Add join timeouts for global listener shutdown

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "1.3.65"
+__version__ = "1.3.66"
 
 import argparse
 import os

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.3.65"
+__version__ = "1.3.66"
 
 import os
 

--- a/src/utils/mouse_listener.py
+++ b/src/utils/mouse_listener.py
@@ -23,6 +23,8 @@ from typing import Callable, Optional
 
 from .helpers import log
 
+_JOIN_TIMEOUT = 0.2  # seconds
+
 # -- Optional dependencies -------------------------------------------------
 
 try:  # pragma: no cover - optional dependency may be missing
@@ -369,7 +371,11 @@ class GlobalMouseListener:
         if self._mouse_listener is not None:
             try:
                 self._mouse_listener.stop()
-                self._mouse_listener.join()
+                self._mouse_listener.join(timeout=_JOIN_TIMEOUT)
+                if getattr(self._mouse_listener, "is_alive", lambda: False)():
+                    log(
+                        f"mouse listener thread failed to stop within {_JOIN_TIMEOUT}s"
+                    )
             except Exception:  # pragma: no cover - defensive
                 pass
             finally:
@@ -378,7 +384,11 @@ class GlobalMouseListener:
         if self._keyboard_listener is not None:
             try:
                 self._keyboard_listener.stop()
-                self._keyboard_listener.join()
+                self._keyboard_listener.join(timeout=_JOIN_TIMEOUT)
+                if getattr(self._keyboard_listener, "is_alive", lambda: False)():
+                    log(
+                        f"keyboard listener thread failed to stop within {_JOIN_TIMEOUT}s"
+                    )
             except Exception:  # pragma: no cover - defensive
                 pass
             finally:
@@ -422,4 +432,3 @@ def get_global_listener() -> GlobalMouseListener:
 
 
 atexit.register(_GLOBAL_LISTENER.stop, True)
-


### PR DESCRIPTION
## Summary
- ensure global mouse and keyboard listener threads join with a short timeout
- log when listener threads fail to stop within the timeout
- bump version to 1.3.66

## Testing
- `pytest` *(fails: ERROR tests/test_app.py, tests/test_auto_setup.py: Interrupted: 2 errors during collection)*
- `pytest tests/test_mouse_listener.py`
- `python -m flake8 src/utils/mouse_listener.py tests/test_mouse_listener.py`

------
https://chatgpt.com/codex/tasks/task_e_68961f08a9b8832baed73c636e5006b4