### PR TITLE
Handle errors in mouse listener callbacks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "1.3.66"
+__version__ = "1.3.67"
 
 import argparse
 import os

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.3.66"
+__version__ = "1.3.67"
 
 import os
 

--- a/src/utils/mouse_listener.py
+++ b/src/utils/mouse_listener.py
@@ -21,7 +21,11 @@ import threading
 from contextlib import contextmanager
 from typing import Callable, Optional
 
+import logging
+
 from .helpers import log
+
+logger = logging.getLogger(__name__)
 
 _JOIN_TIMEOUT = 0.2  # seconds
 
@@ -251,8 +255,8 @@ class GlobalMouseListener:
         def _on_move(x: int, y: int) -> None:
             try:
                 cb(x, y)
-            except Exception as e:
-                log(f"move callback error: {e}")
+            except Exception:
+                logger.exception("move callback error")
 
         return _on_move
 
@@ -264,8 +268,8 @@ class GlobalMouseListener:
             try:
                 if button == getattr(mouse, "Button", object()).left:
                     cb(x, y, pressed)
-            except Exception as e:
-                log(f"click callback error: {e}")
+            except Exception:
+                logger.exception("click callback error")
 
         return _on_click
 
@@ -276,8 +280,8 @@ class GlobalMouseListener:
         def _on_press(key) -> None:
             try:
                 cb(getattr(key, "vk", getattr(getattr(key, "value", key), "vk", 0)), True)
-            except Exception as e:
-                log(f"key callback error: {e}")
+            except Exception:
+                logger.exception("key callback error")
 
         return _on_press
 


### PR DESCRIPTION
## Summary
- log exceptions in mouse listener callbacks
- bump version to 1.3.67

## Testing
- `flake8 src/utils/mouse_listener.py src/__init__.py setup.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'Pillow')*

------
https://chatgpt.com/codex/tasks/task_e_68962125e5f4832ba263deaf80f01ceb