### PR TITLE
feat: reference-count mouse listener

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "1.3.68"
+__version__ = "1.3.69"
 
 import argparse
 import os

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.3.68"
+__version__ = "1.3.69"
 
 import os
 

--- a/src/utils/mouse_listener.py
+++ b/src/utils/mouse_listener.py
@@ -399,13 +399,20 @@ class GlobalMouseListener:
                 self._keyboard_listener = None
 
     def stop(self, force: bool = False) -> None:
+        """Decrease the reference count and stop hooks when it hits zero."""
+
         if self._ref_count > 0:
             self._ref_count -= 1
-        if self._ref_count == 0 or force:
-            self._ref_count = 0
+            if self._ref_count == 0 or force:
+                self._ref_count = 0
+                self._stop_listeners()
+        elif force:
+            # Allow forcibly stopping even when the count is already zero.
             self._stop_listeners()
 
     def release(self) -> None:
+        """Backward-compatible alias for :meth:`stop`."""
+
         self.stop()
 
 
@@ -423,7 +430,7 @@ def capture_mouse(
         yield listener if started else None
     finally:
         if started:
-            listener.release()
+            listener.stop()
 
 
 _GLOBAL_LISTENER = GlobalMouseListener()

--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -1872,6 +1872,5 @@ class ClickOverlay(tk.Toplevel):
             try:
                 if started:
                     listener.stop()
-                listener.release()
             finally:
                 self.reset()

--- a/tests/test_click_overlay.py
+++ b/tests/test_click_overlay.py
@@ -1124,9 +1124,6 @@ class TestClickOverlay(unittest.TestCase):
             def start(self, on_move=None, on_click=None):
                 return True
 
-            def release(self):
-                pass
-
             def stop(self):
                 pass
 
@@ -1161,9 +1158,6 @@ class TestClickOverlay(unittest.TestCase):
         class DummyListener:
             def start(self, on_move=None, on_click=None):
                 return True
-
-            def release(self):
-                pass
 
             def stop(self):
                 pass
@@ -1242,9 +1236,6 @@ class TestClickOverlay(unittest.TestCase):
             def start(self, on_move=None, on_click=None):
                 return False if on_move or on_click else True
 
-            def release(self):
-                pass
-
             def stop(self):
                 pass
 
@@ -1311,7 +1302,6 @@ class TestClickOverlay(unittest.TestCase):
 
         listener = Mock()
         listener.start.return_value = True
-        listener.release = Mock()
 
         with (
             patch(
@@ -1353,7 +1343,7 @@ class TestClickOverlay(unittest.TestCase):
             return True
 
         listener.start.side_effect = start_side_effect
-        listener.release = Mock()
+        listener.stop = Mock()
 
         with (
             patch("src.views.click_overlay.get_global_listener", return_value=listener),
@@ -1363,7 +1353,7 @@ class TestClickOverlay(unittest.TestCase):
             with self.assertRaises(RuntimeError):
                 overlay.choose()
 
-        listener.release.assert_called_once()
+        listener.stop.assert_called_once()
         self.assertTrue(unbind_mock.called)
 
         overlay.destroy()
@@ -1381,9 +1371,6 @@ class TestClickOverlay(unittest.TestCase):
         class DummyListener:
             def start(self, on_move=None, on_click=None):
                 return True
-
-            def release(self):
-                pass
 
             def stop(self):
                 pass
@@ -1439,13 +1426,10 @@ class TestClickOverlay(unittest.TestCase):
                 self.ref += 1
                 return True
 
-            def release(self):
+            def stop(self):
                 self.ref -= 1
                 if self.ref == 0:
                     self.stops += 1
-
-            def stop(self):
-                pass
 
         listener = DummyListener()
 

--- a/tests/test_mouse_listener.py
+++ b/tests/test_mouse_listener.py
@@ -1,3 +1,5 @@
+import types
+
 from src.utils import mouse_listener
 
 
@@ -83,7 +85,11 @@ def test_keyboard_listener(monkeypatch):
 
 def test_wrap_callbacks_log_exceptions(monkeypatch):
     messages = []
-    monkeypatch.setattr(mouse_listener, "log", lambda msg: messages.append(msg))
+    monkeypatch.setattr(
+        mouse_listener,
+        "logger",
+        types.SimpleNamespace(exception=lambda msg, *a, **k: messages.append(msg)),
+    )
     listener = mouse_listener.GlobalMouseListener()
 
     def boom(*args, **kwargs):


### PR DESCRIPTION
## Summary
- ensure GlobalMouseListener uses reference-counted stop semantics
- stop using release in ClickOverlay, relying on ref counting
- bump version to 1.3.69

## Testing
- `COOLBOX_LIGHTWEIGHT=1 pytest tests/test_mouse_listener.py tests/test_click_overlay.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68962a9d28e4832baf0fa82423b3759c