### PR TITLE
Log window support failures

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "1.3.69"
+__version__ = "1.3.70"
 
 import argparse
 import os

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.3.69"
+__version__ = "1.3.70"
 
 import os
 

--- a/tests/test_window_utils.py
+++ b/tests/test_window_utils.py
@@ -171,6 +171,13 @@ class TestWindowUtils(unittest.TestCase):
         ):
             self.assertTrue(wu.has_cursor_window_support())
 
+    def test_has_cursor_window_support_warns(self):
+        from src.utils import window_utils as wu
+
+        with mock.patch.object(wu.sys, "platform", "darwin"):
+            with self.assertWarns(RuntimeWarning):
+                self.assertFalse(wu.has_cursor_window_support(warn=True))
+
     def test_list_windows_at(self):
         from src.utils.window_utils import list_windows_at
 


### PR DESCRIPTION
## Summary
- log and optionally warn on platform-specific window utility failures
- bump version to 1.3.70

## Testing
- `pytest tests/test_window_utils.py`
- `pytest` *(fails: Command terminated after partial progress)*

------
https://chatgpt.com/codex/tasks/task_e_68962d2f3ce8832bafccf77e1da135e9