### PR TITLE
fix: annotate optional Qt imports and add missing threading import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 1.3.71 - 2025-08-08
+
+- **Fix:** Guard optional PyQt5 imports and annotate Qt types to satisfy linters.
+- **Fix:** Import `threading` for asynchronous VM debug launching.
+
 ## 1.3.65 - 2025-08-08
 
 - **Fix:** Require a non-empty DISPLAY variable when detecting cursor window support on Linux.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "1.3.70"
+__version__ = "1.3.71"
 
 import argparse
 import os

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.3.70"
+__version__ = "1.3.71"
 
 import os
 

--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -21,12 +21,6 @@ from threading import Lock
 import atexit
 import psutil
 from PIL import Image, ImageTk
-
-try:  # pragma: no cover - optional dependency
-    from PyQt5 import QtCore, QtWidgets, QtQuick, QtOpenGL, QtGui
-except Exception:  # pragma: no cover - optional dependency
-    QtCore = QtWidgets = QtQuick = QtOpenGL = QtGui = None
-
 from src.utils.window_utils import (
     get_active_window,
     get_window_at,
@@ -46,6 +40,17 @@ from ._fast_confidence import weighted_confidence as _weighted_confidence_np
 from src.utils import get_screen_refresh_rate
 from src.utils.helpers import log
 from src.config import Config
+
+QtCore: Any
+QtWidgets: Any
+QtQuick: Any
+QtOpenGL: Any
+QtGui: Any
+
+try:  # pragma: no cover - optional dependency
+    from PyQt5 import QtCore, QtWidgets, QtQuick, QtOpenGL, QtGui  # type: ignore[import]
+except Exception:  # pragma: no cover - optional dependency
+    QtCore = QtWidgets = QtQuick = QtOpenGL = QtGui = None
 
 QT_AVAILABLE = QtWidgets is not None
 QT_QUICK_AVAILABLE = QtQuick is not None

--- a/src/views/tools_view.py
+++ b/src/views/tools_view.py
@@ -12,7 +12,7 @@ import json
 import base64
 from pathlib import Path
 import re
-import sys
+import threading
 try:
     from PIL import ImageGrab
 except ImportError:  # pragma: no cover - runtime dependency check


### PR DESCRIPTION
## Summary
- annotate optional PyQt5 imports to avoid type checker errors
- import `threading` in ToolsView to enable async debug tasks
- bump version to 1.3.71

## Testing
- `COOLBOX_LIGHTWEIGHT=1 pytest tests/test_click_overlay_executor.py`
- `COOLBOX_LIGHTWEIGHT=1 pytest tests/test_tool_error_handling.py`
- `COOLBOX_LIGHTWEIGHT=1 pytest` *(terminated)*


------
https://chatgpt.com/codex/tasks/task_e_689631edf584832b8cb69a5d94bcf2b0