### PR TITLE
fix: add Qt widget type alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.3.72 - 2025-08-08
+
+- **Fix:** Define Qt widget type aliases for Pylance-friendly annotations.
+
 ## 1.3.71 - 2025-08-08
 
 - **Fix:** Guard optional PyQt5 imports and annotate Qt types to satisfy linters.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "1.3.71"
+__version__ = "1.3.72"
 
 import argparse
 import os

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.3.71"
+__version__ = "1.3.72"
 
 import os
 

--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -15,7 +15,7 @@ import re
 import tkinter as tk
 from collections import deque
 from concurrent.futures import ThreadPoolExecutor, Future
-from typing import Optional, Callable, Any, Protocol
+from typing import Optional, Callable, Any, Protocol, TYPE_CHECKING
 from enum import Enum, auto
 from threading import Lock
 import atexit
@@ -41,16 +41,15 @@ from src.utils import get_screen_refresh_rate
 from src.utils.helpers import log
 from src.config import Config
 
-QtCore: Any
-QtWidgets: Any
-QtQuick: Any
-QtOpenGL: Any
-QtGui: Any
-
 try:  # pragma: no cover - optional dependency
     from PyQt5 import QtCore, QtWidgets, QtQuick, QtOpenGL, QtGui  # type: ignore[import]
 except Exception:  # pragma: no cover - optional dependency
     QtCore = QtWidgets = QtQuick = QtOpenGL = QtGui = None
+
+if TYPE_CHECKING:  # pragma: no cover - type hint helpers
+    from PyQt5.QtWidgets import QWidget
+else:  # pragma: no cover - runtime fallback
+    QWidget = Any
 
 QT_AVAILABLE = QtWidgets is not None
 QT_QUICK_AVAILABLE = QtQuick is not None
@@ -389,7 +388,7 @@ if QT_AVAILABLE:
     class QtCanvas(CanvasAPI):  # pragma: no cover - GUI heavy
         """``CanvasAPI`` implementation using ``QGraphicsScene``."""
 
-        def __init__(self, parent: QtWidgets.QWidget) -> None:
+        def __init__(self, parent: QWidget) -> None:
             scene = QtWidgets.QGraphicsScene(parent)
             view = QtWidgets.QGraphicsView(scene, parent)
             view.setStyleSheet("background: transparent")
@@ -404,7 +403,7 @@ if QT_AVAILABLE:
             self._view = view
             self._scene = scene
 
-        def widget(self) -> QtWidgets.QWidget:
+        def widget(self) -> QWidget:
             return self._view
 
         def create_rectangle(


### PR DESCRIPTION
## Summary
- define Qt widget alias to avoid invalid type expressions for Pylance
- bump version to 1.3.72

## Testing
- `flake8 src/views/click_overlay.py`
- `pytest tests/test_click_overlay.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689636a0dc94832b9e35df5a74b6053d