### PR TITLE
fix: guard PyQt5 QWidget import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.3.73 - 2025-08-08
+
+- **Fix:** Handle missing PyQt5 imports in click overlay type hints to silence Pylance warnings.
+
 ## 1.3.72 - 2025-08-08
 
 - **Fix:** Define Qt widget type aliases for Pylance-friendly annotations.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "1.3.72"
+__version__ = "1.3.73"
 
 import argparse
 import os

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.3.72"
+__version__ = "1.3.73"
 
 import os
 

--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -47,7 +47,10 @@ except Exception:  # pragma: no cover - optional dependency
     QtCore = QtWidgets = QtQuick = QtOpenGL = QtGui = None
 
 if TYPE_CHECKING:  # pragma: no cover - type hint helpers
-    from PyQt5.QtWidgets import QWidget
+    try:
+        from PyQt5.QtWidgets import QWidget  # type: ignore[import]
+    except Exception:  # pragma: no cover - fallback when PyQt5 is unavailable
+        from typing import Any as QWidget
 else:  # pragma: no cover - runtime fallback
     QWidget = Any
 


### PR DESCRIPTION
## Summary
- guard optional PyQt5 QWidget import to silence Pylance
- bump version to 1.3.73

## Testing
- `COOLBOX_LIGHTWEIGHT=1 pytest tests/test_click_overlay.py -q` *(fails: Failed building wheel for matplotlib)*

------
https://chatgpt.com/codex/tasks/task_e_6896398cc3a0832b95ffb5fe1c1294ce