### PR TITLE
Fix overlay state serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.3.74 - 2025-08-08
+
+- **Fix:** Serialize overlay state in Kill by Click error logs to avoid JSON failures.
+
 ## 1.3.73 - 2025-08-08
 
 - **Fix:** Handle missing PyQt5 imports in click overlay type hints to silence Pylance warnings.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "1.3.73"
+__version__ = "1.3.74"
 
 import argparse
 import os

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Public package interface for CoolBox."""
 
-__version__ = "1.3.73"
+__version__ = "1.3.74"
 
 import os
 

--- a/src/views/force_quit_dialog.py
+++ b/src/views/force_quit_dialog.py
@@ -2407,7 +2407,7 @@ class ForceQuitDialog(BaseDialog):
                 "stack": traceback.format_stack(limit=5),
             }
             print("Kill by Click timed out", file=sys.stderr)
-            print(json.dumps(info, indent=2), file=sys.stderr)
+            print(json.dumps(info, indent=2, default=str), file=sys.stderr)
             try:
                 overlay.close()
             except Exception:
@@ -2479,7 +2479,7 @@ class ForceQuitDialog(BaseDialog):
                 "stack": traceback.format_exception(type(result), result, result.__traceback__),
             }
             print("Kill by Click raised an exception", file=sys.stderr)
-            print(json.dumps(info, indent=2), file=sys.stderr)
+            print(json.dumps(info, indent=2, default=str), file=sys.stderr)
             return
         pid, title, ctime, cmd, exe = result
         ctx.__exit__(None, None, None)
@@ -2512,7 +2512,7 @@ class ForceQuitDialog(BaseDialog):
                 "stack": traceback.format_stack(limit=5),
             }
             print("Kill by Click failed to return a process", file=sys.stderr)
-            print(json.dumps(info, indent=2), file=sys.stderr)
+            print(json.dumps(info, indent=2, default=str), file=sys.stderr)
             messagebox.showwarning(
                 "Force Quit", "No process was selected", parent=self
             )
@@ -2543,7 +2543,7 @@ class ForceQuitDialog(BaseDialog):
                 "stack": traceback.format_stack(limit=5),
             }
             print("Kill by Click refused to terminate self", file=sys.stderr)
-            print(json.dumps(info, indent=2), file=sys.stderr)
+            print(json.dumps(info, indent=2, default=str), file=sys.stderr)
             messagebox.showwarning(
                 "Force Quit", "Cannot terminate this application", parent=self
             )
@@ -2578,7 +2578,7 @@ class ForceQuitDialog(BaseDialog):
                 "stack": traceback.format_stack(limit=5),
             }
             print("Kill by Click target vanished", file=sys.stderr)
-            print(json.dumps(info, indent=2), file=sys.stderr)
+            print(json.dumps(info, indent=2, default=str), file=sys.stderr)
             messagebox.showwarning(
                 "Force Quit", f"Process {pid} no longer exists", parent=self
             )
@@ -2635,7 +2635,7 @@ class ForceQuitDialog(BaseDialog):
                         "stack": traceback.format_stack(limit=5),
                     }
                     print("Kill by Click target changed", file=sys.stderr)
-                    print(json.dumps(info, indent=2), file=sys.stderr)
+                    print(json.dumps(info, indent=2, default=str), file=sys.stderr)
                     messagebox.showwarning(
                         "Force Quit", f"Process {pid} changed", parent=self
                     )
@@ -2675,7 +2675,7 @@ class ForceQuitDialog(BaseDialog):
                 "stack": traceback.format_stack(limit=5),
             }
             print("Kill by Click could not terminate process", file=sys.stderr)
-            print(json.dumps(info, indent=2), file=sys.stderr)
+            print(json.dumps(info, indent=2, default=str), file=sys.stderr)
             messagebox.showerror(
                 "Force Quit", f"Failed to terminate process {pid}", parent=self
             )

--- a/tests/test_force_quit_serialization.py
+++ b/tests/test_force_quit_serialization.py
@@ -1,0 +1,35 @@
+import json
+from types import SimpleNamespace
+
+import os
+
+os.environ.setdefault("COOLBOX_LIGHTWEIGHT", "1")
+
+from src.views.force_quit_dialog import ForceQuitDialog
+from src.views.click_overlay import OverlayState
+
+
+def test_finish_kill_by_click_serializes_overlay_state(capsys):
+    dialog = ForceQuitDialog.__new__(ForceQuitDialog)
+    overlay = SimpleNamespace(
+        state=OverlayState.INIT,
+        _cursor_x=0,
+        _cursor_y=0,
+        pid=None,
+        title_text=None,
+        _last_ping=0.0,
+        _watchdog_misses=0,
+    )
+    dialog._overlay = overlay
+    dialog._overlay_ctx = SimpleNamespace(__exit__=lambda *args: None)
+    dialog._overlay_thread = None
+    dialog._overlay_watchdog_proc = None
+    dialog._overlay_sync = None
+    dialog._overlay_poller = None
+    dialog._overlay_last_ping_file = None
+
+    dialog._finish_kill_by_click(dialog._overlay_ctx, Exception("boom"))
+    err = capsys.readouterr().err.strip().splitlines()
+    assert err[0] == "Kill by Click raised an exception"
+    info = json.loads("\n".join(err[1:]))
+    assert info["state"] == "OverlayState.INIT"


### PR DESCRIPTION
## Summary
- avoid JSON serialization errors when logging Kill by Click diagnostics
- bump version to 1.3.74
- test Kill by Click overlay state serialization

## Testing
- `pytest tests/test_force_quit_serialization.py -q`
- `pytest -q` *(fails: Terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68963ca74978832b86ef73cb9e794f39