### PR TITLE
Fix console lock type check in rainbow utility

### DIFF
--- a/src/utils/rainbow.py
+++ b/src/utils/rainbow.py
@@ -34,10 +34,16 @@ class LockingConsole(Console):
         with self._lock:
             return super().control(*args, **kwargs)
 
+# `threading.RLock` is a factory function which returns an instance of the
+# underlying `_thread.RLock` type.  Using it directly with `isinstance`
+# therefore raises ``TypeError`` because it's not a class.  Capture the actual
+# lock type once so we can make safe ``isinstance`` checks later.
+_RLOCK_TYPE = type(threading.RLock())
+
 @contextmanager
 def _console_lock_ctx(console: Console):
     lock = getattr(console, "_lock", None)
-    if isinstance(lock, threading.RLock):
+    if isinstance(lock, _RLOCK_TYPE):
         lock.acquire()
         try:
             yield


### PR DESCRIPTION
## Summary
- prevent TypeError when checking console lock by capturing the actual RLock type

## Testing
- `pytest tests/test_rainbow.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a1bb0fcc788325816dd7a44240f5a0