### PR TITLE
Fix missing setup banner and version check

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -199,6 +199,19 @@ console = LockingConsole(_helper_console or Console(soft_wrap=False, highlight=F
 def log(msg: str) -> None:
     console.print(f"[dim]»[/] {msg}")
 
+
+def show_setup_banner() -> None:
+    """Display a simple setup banner for CoolBox."""
+    console.print(f"[bold cyan]CoolBox[/] setup v{__version__}")
+
+
+def check_python_version() -> None:
+    """Verify the current Python version meets requirements."""
+    if sys.version_info < MIN_PYTHON:
+        raise RuntimeError(
+            f"Python {MIN_PYTHON[0]}.{MIN_PYTHON[1]}+ required"
+        )
+
 # ---------- summary ----------
 class RunSummary:
     def __init__(self) -> None:


### PR DESCRIPTION
## Summary
- add `show_setup_banner` to display setup information
- add `check_python_version` to verify interpreter compatibility
- adjust `_pip` test to stub out command execution and prevent pip warnings

## Testing
- `pytest tests/test_auto_setup.py tests/test_setup.py -q`
- `pytest tests/test_auto_setup.py tests/test_setup.py -W error -q`


------
https://chatgpt.com/codex/tasks/task_e_68a201fb54388325a2569dc820a60987