### PR TITLE
Enhance setup animation with rainbow spinner and banner

### DIFF
--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -47,3 +47,18 @@ def test_pip_invokes_run(monkeypatch):
 
     assert border_calls == []
     assert run_calls and run_calls[0][:4] == [sys.executable, "-m", "pip", "install"]
+
+
+def test_pip_offline_skips(monkeypatch):
+    monkeypatch.setenv("COOLBOX_OFFLINE", "1")
+    importlib.reload(setup)
+
+    run_calls = []
+
+    def fake_run(cmd, **kw):
+        run_calls.append(cmd)
+
+    monkeypatch.setattr(setup, "_run", fake_run)
+    setup._pip(["install", "pkg"], python=sys.executable)
+
+    assert run_calls == []


### PR DESCRIPTION
## Summary
- add rainbow helpers with spinner and gradient text
- display a colorful setup banner and default rainbow border
- animate progress with rainbow spinner and wider bar
- detect project roots via common markers and show path in banner
- install dev requirements file when present and wrap tests with spinner
- skip pip operations when offline and add coverage

## Testing
- `python -m py_compile setup.py`
- `pytest tests/test_setup.py -q`
- `pytest tests/test_auto_setup.py -q`
- `pytest -q` *(fails: Terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68a21946d0b4832583cd1eebd4d06149