### PR TITLE
feat: smarter offline handling

### DIFF
--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -42,6 +42,7 @@ def test_pip_invokes_run(monkeypatch):
 
     monkeypatch.setattr(setup, "NeonPulseBorder", DummyBorder)
     monkeypatch.setattr(setup, "_run", fake_run)
+    setup.set_offline(False)
 
     setup._pip(["install", "pkg"], python=sys.executable)
 
@@ -62,3 +63,13 @@ def test_pip_offline_skips(monkeypatch):
     setup._pip(["install", "pkg"], python=sys.executable)
 
     assert run_calls == []
+
+
+def test_cli_offline_flag(monkeypatch):
+    monkeypatch.delenv("COOLBOX_OFFLINE", raising=False)
+    importlib.reload(setup)
+    setup.set_offline(False)
+    monkeypatch.setattr(setup, "show_info", lambda: None)
+
+    setup.main(["--offline", "info"])
+    assert setup.is_offline() is True


### PR DESCRIPTION
## Summary
- add lazy offline detection with `set_offline`/`is_offline` helpers and env propagation
- ensure git updates, pip installs, and diagnostics honor offline mode
- prime offline detection early in CLI and adapt tests for new API

## Testing
- `pytest tests/test_setup.py -q`
- `pytest -q` *(fails: Terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68a222cefc5083258f081d1950c67c78