### PR TITLE
Refactor app icon and layout into dedicated modules

### DIFF
--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -7,41 +7,29 @@ from __future__ import annotations
 try:
     import customtkinter as ctk
 except ImportError:  # pragma: no cover - runtime dependency check
-    from .ensure_deps import ensure_customtkinter
+    from ..ensure_deps import ensure_customtkinter
 
     ctk = ensure_customtkinter()
 from typing import Dict, Optional, TYPE_CHECKING
 from pathlib import Path
-try:
-    from PIL import Image, ImageTk
-except ImportError:  # pragma: no cover - runtime dependency check
-    from .ensure_deps import ensure_pillow
-
-    pil = ensure_pillow()
-    Image = pil.Image  # type: ignore[attr-defined]
-    ImageTk = pil.ImageTk  # type: ignore[attr-defined]
 import sys
-import tempfile
-import ctypes
 
-from .config import Config
-from .components.sidebar import Sidebar
-from .components.toolbar import Toolbar
-from .components.status_bar import StatusBar
-from .components.menubar import MenuBar
-from .views.home_view import HomeView
-from .views.tools_view import ToolsView
-from .views.settings_view import SettingsView
-from .views.about_view import AboutView
-from .models.app_state import AppState
-from .utils.theme import ThemeManager
-from .utils.helpers import log
-from .utils.thread_manager import ThreadManager
+from ..config import Config
+from ..components.toolbar import Toolbar
+from ..components.status_bar import StatusBar
+from ..components.menubar import MenuBar
+from ..models.app_state import AppState
+from ..utils.theme import ThemeManager
+from ..utils.helpers import log
+from ..utils.thread_manager import ThreadManager
+
+from .icon import set_app_icon
+from .layout import setup_ui
 
 if TYPE_CHECKING:  # pragma: no cover - used for type hints only
-    from .views.quick_settings import QuickSettingsDialog
-    from .views.force_quit_dialog import ForceQuitDialog
-    from .views.security_dialog import SecurityDialog
+    from ..views.quick_settings import QuickSettingsDialog
+    from ..views.force_quit_dialog import ForceQuitDialog
+    from ..views.security_dialog import SecurityDialog
 
 
 class CoolBoxApp:
@@ -63,10 +51,17 @@ class CoolBoxApp:
         # Create main window
         self.window = ctk.CTk()
         self.window.title("CoolBox - Modern Desktop App")
-        self.window.geometry(f"{self.config.get('window_width', 1200)}x{self.config.get('window_height', 900)}")
+        self.window.geometry(
+            f"{self.config.get('window_width', 1200)}x{self.config.get('window_height', 900)}"
+        )
 
         # Set application icon
-        self._set_app_icon()
+        try:
+            self._icon_photo, self._temp_icon = set_app_icon(self.window)
+        except Exception as exc:  # pragma: no cover - best effort
+            log(f"Icon setup failed: {exc}")
+            self._icon_photo = None
+            self._temp_icon = None
 
         # Set minimum window size
         self.window.minsize(800, 700)
@@ -85,7 +80,11 @@ class CoolBoxApp:
         self.dialogs: list[object] = []
 
         # Setup UI
-        self._setup_ui()
+        try:
+            setup_ui(self)
+        except Exception as exc:  # pragma: no cover - critical failure
+            log(f"UI setup failed: {exc}")
+            raise
 
         # Bind events
         self._bind_events()
@@ -93,89 +92,9 @@ class CoolBoxApp:
         # Load initial view
         self.switch_view("home")
 
-    def _set_app_icon(self) -> None:
-        """Set the window and dock icon to the CoolBox logo."""
-        icon_path = Path(__file__).resolve().parent.parent / "assets" / "images" / "Coolbox_logo.png"
-        try:
-            image = Image.open(icon_path)
-            self._icon_photo = ImageTk.PhotoImage(image)
-            self.window.iconphoto(True, self._icon_photo)
-
-            if sys.platform.startswith("win"):
-                try:
-                    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".ico")
-                    image.save(tmp, format="ICO")
-                    tmp.close()
-                    self.window.iconbitmap(tmp.name)
-                    try:
-                        ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID("CoolBox")
-                    except Exception:  # pragma: no cover - best effort
-                        pass
-                    self._temp_icon = tmp.name
-                except Exception as exc:  # pragma: no cover - optional feature
-                    log(f"Failed to set taskbar icon: {exc}")
-        except Exception as exc:  # pragma: no cover - best effort
-            log(f"Failed to set window icon: {exc}")
-
-        if sys.platform == "darwin":
-            try:
-                from AppKit import NSApplication, NSImage
-
-                ns_image = NSImage.alloc().initByReferencingFile_(str(icon_path))
-                NSApplication.sharedApplication().setApplicationIconImage_(ns_image)
-            except Exception as exc:  # pragma: no cover - optional feature
-                log(f"Failed to set dock icon: {exc}")
-
     def get_icon_photo(self):
         """Return the cached application icon if available."""
         return getattr(self, "_icon_photo", None)
-
-    def _setup_ui(self):
-        """Setup the main UI layout"""
-        # Create main container
-        self.main_container = ctk.CTkFrame(self.window, corner_radius=0)
-        self.main_container.pack(fill="both", expand=True)
-
-        # Create menu bar if enabled
-        self.menu_bar: MenuBar | None = None
-        if self.config.get("show_menu", True):
-            self.menu_bar = MenuBar(self.window, self)
-
-        # Create toolbar if enabled in config
-        self.toolbar: Toolbar | None = None
-        if self.config.get("show_toolbar", True):
-            self.toolbar = Toolbar(self.main_container, self)
-            self.toolbar.pack(fill="x", padx=0, pady=0)
-
-        # Create content area with sidebar
-        self.content_area = ctk.CTkFrame(self.main_container, corner_radius=0)
-        self.content_area.pack(fill="both", expand=True)
-
-        # Configure grid
-        self.content_area.grid_rowconfigure(0, weight=1)
-        self.content_area.grid_columnconfigure(1, weight=1)
-
-        # Create sidebar
-        self.sidebar = Sidebar(self.content_area, self)
-        self.sidebar.grid(row=0, column=0, sticky="nsew", padx=0, pady=0)
-
-        # Create view container
-        self.view_container = ctk.CTkFrame(self.content_area, corner_radius=0)
-        self.view_container.grid(row=0, column=1, sticky="nsew", padx=0, pady=0)
-
-        # Create status bar if enabled
-        self.status_bar: StatusBar | None = None
-        if self.config.get("show_statusbar", True):
-            self.status_bar = StatusBar(self.main_container, self)
-            self.status_bar.pack(fill="x", side="bottom")
-
-        # Initialize views
-        self._init_views()
-        self.refresh_recent_files()
-        if self.menu_bar is not None:
-            self.menu_bar.refresh_toggles()
-        self.update_fonts()
-        self.update_theme()
 
     def update_ui_visibility(self) -> None:
         """Show or hide optional UI elements based on config."""
@@ -211,13 +130,6 @@ class CoolBoxApp:
             self.toolbar.update_recent_files()
         if self.menu_bar is not None:
             self.menu_bar.update_recent_files()
-
-    def _init_views(self):
-        """Initialize all application views"""
-        self.views["home"] = HomeView(self.view_container, self)
-        self.views["tools"] = ToolsView(self.view_container, self)
-        self.views["settings"] = SettingsView(self.view_container, self)
-        self.views["about"] = AboutView(self.view_container, self)
 
     def _bind_events(self):
         """Bind window events"""
@@ -270,7 +182,7 @@ class CoolBoxApp:
 
     def open_quick_settings(self) -> None:
         """Launch the Quick Settings dialog or focus the existing one."""
-        from .views.quick_settings import QuickSettingsDialog
+        from ..views.quick_settings import QuickSettingsDialog
 
         if self.quick_settings_window is not None and self.quick_settings_window.winfo_exists():
             self.quick_settings_window.focus()
@@ -286,7 +198,7 @@ class CoolBoxApp:
         from tkinter import messagebox
 
         try:
-            from .views.force_quit_dialog import ForceQuitDialog
+            from ..views.force_quit_dialog import ForceQuitDialog
         except Exception as exc:  # pragma: no cover - runtime import error
             log(f"Failed to import ForceQuitDialog: {exc}")
             messagebox.showerror("Force Quit", f"Failed to open dialog: {exc}")
@@ -308,7 +220,7 @@ class CoolBoxApp:
 
     def open_security_center(self) -> None:
         """Launch the Security Center dialog with elevation when needed."""
-        from .views.security_dialog import SecurityDialog
+        from ..views.security_dialog import SecurityDialog
         from .utils.security import is_admin, launch_security_center
         from tkinter import messagebox
 

--- a/src/app/icon.py
+++ b/src/app/icon.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import tempfile
+import ctypes
+
+try:
+    from PIL import Image, ImageTk
+except ImportError:  # pragma: no cover - runtime dependency check
+    from ..ensure_deps import ensure_pillow
+
+    pil = ensure_pillow()
+    Image = pil.Image  # type: ignore[attr-defined]
+    ImageTk = pil.ImageTk  # type: ignore[attr-defined]
+
+from ..utils.helpers import log
+
+
+def set_app_icon(window):
+    """Set the application icon for *window* and return icon data.
+
+    Returns a tuple ``(photo_image, temp_icon_path)`` where ``photo_image`` is
+    the Tk photo image used for the window icon and ``temp_icon_path`` is the
+    path to a temporary ``.ico`` file on Windows (``None`` otherwise).
+    """
+    icon_path = Path(__file__).resolve().parent.parent / "assets" / "images" / "Coolbox_logo.png"
+    temp_icon: str | None = None
+    try:
+        image = Image.open(icon_path)
+        photo = ImageTk.PhotoImage(image)
+        window.iconphoto(True, photo)
+
+        if sys.platform.startswith("win"):
+            try:
+                tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".ico")
+                image.save(tmp, format="ICO")
+                tmp.close()
+                window.iconbitmap(tmp.name)
+                try:  # pragma: no cover - best effort
+                    ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID("CoolBox")
+                except Exception:
+                    pass
+                temp_icon = tmp.name
+            except Exception as exc:
+                log(f"Failed to set taskbar icon: {exc}")
+                raise RuntimeError(f"Failed to set taskbar icon: {exc}") from exc
+    except Exception as exc:
+        log(f"Failed to set window icon: {exc}")
+        raise RuntimeError(f"Failed to set window icon: {exc}") from exc
+
+    if sys.platform == "darwin":
+        try:
+            from AppKit import NSApplication, NSImage  # type: ignore
+
+            ns_image = NSImage.alloc().initByReferencingFile_(str(icon_path))
+            NSApplication.sharedApplication().setApplicationIconImage_(ns_image)
+        except Exception as exc:
+            log(f"Failed to set dock icon: {exc}")
+            raise RuntimeError(f"Failed to set dock icon: {exc}") from exc
+
+    return photo, temp_icon

--- a/src/app/layout.py
+++ b/src/app/layout.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+try:
+    import customtkinter as ctk
+except ImportError:  # pragma: no cover - runtime dependency check
+    from ..ensure_deps import ensure_customtkinter
+
+    ctk = ensure_customtkinter()
+
+from ..components.sidebar import Sidebar
+from ..components.toolbar import Toolbar
+from ..components.status_bar import StatusBar
+from ..components.menubar import MenuBar
+from ..views.home_view import HomeView
+from ..views.tools_view import ToolsView
+from ..views.settings_view import SettingsView
+from ..views.about_view import AboutView
+from ..utils.helpers import log
+
+
+def setup_ui(app) -> None:
+    """Configure the main user interface for *app*.
+
+    Raises:
+        RuntimeError: If any part of the layout initialization fails.
+    """
+    try:
+        app.main_container = ctk.CTkFrame(app.window, corner_radius=0)
+        app.main_container.pack(fill="both", expand=True)
+
+        app.menu_bar = None
+        if app.config.get("show_menu", True):
+            app.menu_bar = MenuBar(app.window, app)
+
+        app.toolbar = None
+        if app.config.get("show_toolbar", True):
+            app.toolbar = Toolbar(app.main_container, app)
+            app.toolbar.pack(fill="x", padx=0, pady=0)
+
+        app.content_area = ctk.CTkFrame(app.main_container, corner_radius=0)
+        app.content_area.pack(fill="both", expand=True)
+
+        app.content_area.grid_rowconfigure(0, weight=1)
+        app.content_area.grid_columnconfigure(1, weight=1)
+
+        app.sidebar = Sidebar(app.content_area, app)
+        app.sidebar.grid(row=0, column=0, sticky="nsew", padx=0, pady=0)
+
+        app.view_container = ctk.CTkFrame(app.content_area, corner_radius=0)
+        app.view_container.grid(row=0, column=1, sticky="nsew", padx=0, pady=0)
+
+        app.status_bar = None
+        if app.config.get("show_statusbar", True):
+            app.status_bar = StatusBar(app.main_container, app)
+            app.status_bar.pack(fill="x", side="bottom")
+
+        app.views = {
+            "home": HomeView(app.view_container, app),
+            "tools": ToolsView(app.view_container, app),
+            "settings": SettingsView(app.view_container, app),
+            "about": AboutView(app.view_container, app),
+        }
+        app.refresh_recent_files()
+        if app.menu_bar is not None:
+            app.menu_bar.refresh_toggles()
+        app.update_fonts()
+        app.update_theme()
+    except Exception as exc:
+        log(f"Failed to set up UI: {exc}")
+        raise RuntimeError(f"Failed to set up UI: {exc}") from exc


### PR DESCRIPTION
## Summary
- Extract icon setup into `app/icon.py` with logging and explicit errors
- Move UI layout initialization into `app/layout.py`
- Update application initialization to use new icon and layout helpers

## Testing
- `python -m py_compile src/app/__init__.py src/app/icon.py src/app/layout.py`
- `pytest -q` *(terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68a24a023db4832583f386b158caa709