### PR TITLE
refactor: split helpers into focused modules

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,7 +12,7 @@ import importlib.util
 from concurrent.futures import ThreadPoolExecutor
 
 from src.utils import launch_vm_debug
-from src.utils.helpers import log
+from src.utils.system_utils import log
 
 # Ensure package imports work when running as a script before other imports.
 sys.path.insert(0, str(Path(__file__).parent))

--- a/scripts/exe_inspector.py
+++ b/scripts/exe_inspector.py
@@ -38,7 +38,7 @@ except ModuleNotFoundError:  # pragma: no cover - textual is optional
     TEXTUAL_AVAILABLE = False
 import psutil  # noqa: E402
 
-from src.utils.helpers import calc_hash  # noqa: E402
+from src.utils.hash_utils import calc_hash  # noqa: E402
 from src.utils.process_utils import run_command, run_command_ex  # noqa: E402
 from src.utils.security import ensure_admin, is_admin, list_open_ports  # noqa: E402
 import shutil  # noqa: E402

--- a/setup.py
+++ b/setup.py
@@ -177,7 +177,7 @@ except Exception as exc:  # pragma: no cover
             raise ImportError(msg) from np_exc
 
 try:
-    from src.utils.helpers import (  # type: ignore
+    from src.utils.system_utils import (  # type: ignore
         get_system_info,
         console as _helper_console,
     )

--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -20,7 +20,7 @@ from ..components.status_bar import StatusBar
 from ..components.menubar import MenuBar
 from ..models.app_state import AppState
 from ..utils.theme import ThemeManager
-from ..utils.helpers import log
+from ..utils.system_utils import log
 from ..utils.thread_manager import ThreadManager
 
 from .icon import set_app_icon

--- a/src/app/icon.py
+++ b/src/app/icon.py
@@ -14,7 +14,7 @@ except ImportError:  # pragma: no cover - runtime dependency check
     Image = pil.Image  # type: ignore[attr-defined]
     ImageTk = pil.ImageTk  # type: ignore[attr-defined]
 
-from ..utils.helpers import log
+from ..utils.system_utils import log
 
 
 def set_app_icon(window):

--- a/src/app/layout.py
+++ b/src/app/layout.py
@@ -15,7 +15,7 @@ from ..views.home_view import HomeView
 from ..views.tools_view import ToolsView
 from ..views.settings_view import SettingsView
 from ..views.about_view import AboutView
-from ..utils.helpers import log
+from ..utils.system_utils import log
 
 
 def setup_ui(app) -> None:

--- a/src/components/menubar.py
+++ b/src/components/menubar.py
@@ -128,7 +128,7 @@ class MenuBar:
 
     def _open_recent(self, path: str) -> None:
         """Open a recently used file."""
-        from ..utils.helpers import open_path
+        from ..utils.system_utils import open_path
 
         open_path(path)
         self.app.config.add_recent_file(path)

--- a/src/components/toolbar.py
+++ b/src/components/toolbar.py
@@ -5,7 +5,8 @@ Toolbar component with common actions
 import customtkinter as ctk
 from tkinter import filedialog
 
-from ..utils import file_manager, open_path
+from ..utils import file_manager
+from ..utils.system_utils import open_path
 from ..utils.ui import center_window
 try:
     import pyperclip

--- a/src/config.py
+++ b/src/config.py
@@ -6,7 +6,7 @@ import shutil
 from pathlib import Path
 from typing import Any, Dict
 
-from .utils.helpers import log
+from .utils.system_utils import log
 
 
 class Config:

--- a/src/ensure_deps.py
+++ b/src/ensure_deps.py
@@ -9,7 +9,7 @@ from types import ModuleType
 from typing import Optional
 
 try:  # Avoid circular imports when utils.helpers requires ensure_deps
-    from .utils.helpers import log
+    from .utils.system_utils import log
 except Exception:  # pragma: no cover - fallback logger
     import logging
 

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -2,23 +2,27 @@
 
 import os
 
-from .helpers import (
+from .system_utils import (
     log,
     open_path,
     slugify,
     strip_ansi,
+    get_system_info,
+    get_system_metrics,
+    run_with_spinner,
+    console,
+)
+from .hash_utils import (
     calc_data_hash,
     calc_hash,
     calc_hash_cached,
     calc_hashes,
-    get_system_info,
-    get_system_metrics,
+)
+from .color_utils import (
     lighten_color,
     darken_color,
     adjust_color,
     hex_brightness,
-    run_with_spinner,
-    console,
 )
 from .rainbow import RainbowBorder, NeonPulseBorder
 from .vm import launch_vm_debug

--- a/src/utils/color_utils.py
+++ b/src/utils/color_utils.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+
+def adjust_color(color: str, factor: float) -> str:
+    """Return *color* adjusted by *factor*."""
+    color = color.lstrip("#")
+    if len(color) == 3:
+        color = "".join(c * 2 for c in color)
+    if len(color) != 6:
+        raise ValueError("invalid color format")
+
+    r = int(color[0:2], 16)
+    g = int(color[2:4], 16)
+    b = int(color[4:6], 16)
+
+    factor = max(-1.0, min(1.0, factor))
+    if factor >= 0:
+        r = round(r + (255 - r) * factor)
+        g = round(g + (255 - g) * factor)
+        b = round(b + (255 - b) * factor)
+    else:
+        r = round(r * (1 + factor))
+        g = round(g * (1 + factor))
+        b = round(b * (1 + factor))
+
+    return f"#{r:02x}{g:02x}{b:02x}"
+
+
+def hex_brightness(color: str) -> float:
+    """Return the perceptual brightness of *color* between 0 and 1."""
+    color = color.lstrip("#")
+    if len(color) == 3:
+        color = "".join(c * 2 for c in color)
+    if len(color) != 6:
+        raise ValueError("invalid color format")
+
+    r = int(color[0:2], 16)
+    g = int(color[2:4], 16)
+    b = int(color[4:6], 16)
+    return (0.299 * r + 0.587 * g + 0.114 * b) / 255
+
+
+def lighten_color(color: str, factor: float) -> str:
+    """Return *color* lightened by *factor* in the range ``0``-``1``."""
+    return adjust_color(color, max(0.0, min(1.0, factor)))
+
+
+def darken_color(color: str, factor: float) -> str:
+    """Return *color* darkened by *factor* in the range ``0``-``1``."""
+    return adjust_color(color, -max(0.0, min(1.0, factor)))
+
+
+__all__ = [
+    "adjust_color",
+    "hex_brightness",
+    "lighten_color",
+    "darken_color",
+]

--- a/src/utils/hash_utils.py
+++ b/src/utils/hash_utils.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import hashlib
+import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, Literal
+
+from .cache import CacheManager
+
+
+def calc_data_hash(
+    data: bytes | str, algo: Literal["md5", "sha1", "sha256"] = "md5"
+) -> str:
+    """Return the hexadecimal hash of *data* using *algo*."""
+    if isinstance(data, str):
+        data = data.encode()
+    hash_func = getattr(hashlib, algo)()
+    hash_func.update(data)
+    return hash_func.hexdigest()
+
+
+def calc_hash(path: str, algo: Literal["md5", "sha1", "sha256"] = "md5") -> str:
+    """Return the hexadecimal hash of ``path`` using *algo*."""
+    hash_func = getattr(hashlib, algo)()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            hash_func.update(chunk)
+    return hash_func.hexdigest()
+
+
+def calc_hash_cached(
+    path: str,
+    algo: Literal["md5", "sha1", "sha256"] = "md5",
+    cache: CacheManager[Dict[str, Any]] | None = None,
+    *,
+    ttl: float = 365 * 24 * 60 * 60,
+    refresh_cache: bool = True,
+) -> str:
+    """Return hash of ``path`` using *algo* with optional disk caching."""
+    if cache is None:
+        return calc_hash(path, algo)
+
+    p = Path(path)
+    key = f"{path}:{algo}"
+    if refresh_cache:
+        cache.refresh()
+    entry = cache.get(key)
+    mtime = p.stat().st_mtime
+    if entry:
+        stored_mtime = float(entry.get("mtime", 0.0))
+        if abs(stored_mtime - mtime) < 1e-6:
+            return str(entry.get("digest"))
+
+    digest = calc_hash(path, algo)
+    cache.set(key, {"mtime": mtime, "digest": digest}, ttl)
+    return digest
+
+
+def calc_hashes(
+    paths: Iterable[str],
+    algo: Literal["md5", "sha1", "sha256"] = "md5",
+    cache: CacheManager[Dict[str, Any]] | None = None,
+    *,
+    workers: int | None = None,
+    ttl: float = 365 * 24 * 60 * 60,
+    progress: Callable[[float | None], None] | None = None,
+) -> Dict[str, str]:
+    """Return a mapping of path->digest for many files concurrently."""
+    paths = list(paths)
+    if not paths:
+        if progress is not None:
+            progress(None)
+        return {}
+
+    if workers is None:
+        workers = min(32, os.cpu_count() or 1)
+
+    if cache is not None:
+        cache.refresh()
+
+    total = len(paths)
+    completed = 0
+    results: Dict[str, str] = {}
+
+    def worker(p: str) -> tuple[str, str]:
+        mtime = Path(p).stat().st_mtime
+        key = f"{p}:{algo}"
+        digest: str
+        if cache is not None:
+            entry = cache.get(key)
+            if entry and abs(float(entry.get("mtime", 0.0)) - mtime) < 1e-6:
+                return p, str(entry.get("digest", ""))
+        digest = calc_hash(p, algo)
+        if cache is not None:
+            cache.set(key, {"mtime": mtime, "digest": digest}, ttl)
+        return p, digest
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        future_map = {executor.submit(worker, p): p for p in paths}
+        for fut in as_completed(future_map):
+            path, digest = fut.result()
+            results[path] = digest
+            completed += 1
+            if progress is not None:
+                progress(completed / total)
+
+    if progress is not None:
+        progress(None)
+    return results
+
+__all__ = [
+    "calc_data_hash",
+    "calc_hash",
+    "calc_hash_cached",
+    "calc_hashes",
+]

--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -1,346 +1,45 @@
 from __future__ import annotations
 
-import hashlib
-import os
-import platform
-import re
-import subprocess
-import sys
-import time
-from concurrent.futures import ThreadPoolExecutor, as_completed
-from pathlib import Path
-from typing import Any, Callable, Dict, Iterable, Literal
-
-from .cache import CacheManager
-
-try:  # pragma: no cover - runtime dependency check
-    import psutil  # type: ignore
-except ImportError:  # pragma: no cover
-    from ..ensure_deps import ensure_psutil
-
-    psutil = ensure_psutil()
-
-from rich.console import Console
-from rich.progress import (
-    Progress,
-    SpinnerColumn,
-    TextColumn,
-    TimeElapsedColumn,
+from .hash_utils import (
+    calc_data_hash,
+    calc_hash,
+    calc_hash_cached,
+    calc_hashes,
+)
+from .color_utils import (
+    adjust_color,
+    hex_brightness,
+    lighten_color,
+    darken_color,
+)
+from .system_utils import (
+    log,
+    get_system_info,
+    run_with_spinner,
+    open_path,
+    slugify,
+    strip_ansi,
+    get_system_metrics,
+    console,
+    plain_console,
 )
 
-console = Console()
-plain_console = Console(no_color=True, force_terminal=False)
-
-
-def log(message: str) -> None:
-    """Log a message with rich formatting."""
-    console.log(message)
-
-
-def get_system_info() -> str:
-    """Return a concise multi-line system info string."""
-    lines = [
-        f"Python:   {sys.version.split()[0]} ({sys.executable})",
-        f"Platform: {platform.system()} {platform.release()} ({platform.machine()})",
-        f"Processor:{platform.processor() or 'unknown'}",
-        f"Prefix:   {getattr(sys, 'prefix', '')}",
-        f"TTY:      {console.is_terminal}",
-    ]
-    return "\n".join(lines)
-
-
-def run_with_spinner(
-    cmd: Iterable[str],
-    *,
-    message: str = "Working",
-    timeout: float | None = None,
-    capture_output: bool = False,
-    env: dict[str, str] | None = None,
-    cwd: str | None = None,
-) -> str | None:
-    """Run *cmd* while displaying a spinner and streaming output.
-
-    - Streams STDOUT live.
-    - Kills on timeout.
-    - Returns captured output if requested.
-    - Falls back to plain output if not a TTY.
-    """
-    proc = subprocess.Popen(
-        list(cmd),
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-        bufsize=1,
-        env=env,
-        cwd=cwd,
-    )
-    start = time.time()
-    captured: list[str] = []
-
-    if not console.is_terminal:
-        # Plain fallback
-        assert proc.stdout is not None
-        for line in proc.stdout:
-            print(line.rstrip())
-            if capture_output:
-                captured.append(line)
-            if timeout is not None and (time.time() - start) > timeout:
-                proc.kill()
-                raise subprocess.TimeoutExpired(proc.args, timeout)
-        code = proc.wait(timeout=timeout)
-        if code:
-            raise subprocess.CalledProcessError(code, list(cmd))
-        return "".join(captured) if capture_output else None
-
-    with Progress(
-        SpinnerColumn(style="bold blue"),
-        TextColumn("{task.description}"),
-        TimeElapsedColumn(),
-        console=console,
-        transient=True,
-    ) as progress:
-        task_id = progress.add_task(message, start=True)
-        assert proc.stdout is not None
-        try:
-            for line in proc.stdout:
-                progress.console.print(line.rstrip())
-                if capture_output:
-                    captured.append(line)
-                if timeout is not None and (time.time() - start) > timeout:
-                    proc.kill()
-                    raise subprocess.TimeoutExpired(proc.args, timeout)
-            code = proc.wait(timeout=0.2 if timeout is None else max(0.2, timeout))
-            if code:
-                raise subprocess.CalledProcessError(code, list(cmd))
-        finally:
-            progress.update(task_id, completed=1)
-
-    return "".join(captured) if capture_output else None
-
-
-def open_path(path: str) -> None:
-    """Open *path* with the default application for the platform."""
-    if platform.system() == "Windows":
-        os.startfile(path)  # type: ignore[attr-defined]
-    elif platform.system() == "Darwin":
-        subprocess.Popen(["open", path])
-    else:
-        subprocess.Popen(["xdg-open", path])
-
-
-_SLUG_RE = re.compile(r"[^a-z0-9]+")
-_ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
-
-
-def slugify(text: str, sep: str = "_") -> str:
-    """Return *text* normalized for filenames or URLs."""
-    text = text.lower()
-    text = _SLUG_RE.sub(sep, text)
-    return text.strip(sep)
-
-
-def strip_ansi(text: str) -> str:
-    """Return *text* without ANSI escape sequences."""
-    return _ANSI_RE.sub("", text)
-
-
-def calc_data_hash(
-    data: bytes | str, algo: Literal["md5", "sha1", "sha256"] = "md5"
-) -> str:
-    """Return the hexadecimal hash of *data* using *algo*."""
-    if isinstance(data, str):
-        data = data.encode()
-    hash_func = getattr(hashlib, algo)()
-    hash_func.update(data)
-    return hash_func.hexdigest()
-
-
-def calc_hash(path: str, algo: Literal["md5", "sha1", "sha256"] = "md5") -> str:
-    """Return the hexadecimal hash of ``path`` using *algo*."""
-    hash_func = getattr(hashlib, algo)()
-    with open(path, "rb") as f:
-        for chunk in iter(lambda: f.read(8192), b""):
-            hash_func.update(chunk)
-    return hash_func.hexdigest()
-
-
-def calc_hash_cached(
-    path: str,
-    algo: Literal["md5", "sha1", "sha256"] = "md5",
-    cache: CacheManager[Dict[str, Any]] | None = None,
-    *,
-    ttl: float = 365 * 24 * 60 * 60,
-    refresh_cache: bool = True,
-) -> str:
-    """Return hash of ``path`` using *algo* with optional disk caching."""
-    if cache is None:
-        return calc_hash(path, algo)
-
-    p = Path(path)
-    key = f"{path}:{algo}"
-    if refresh_cache:
-        cache.refresh()
-    entry = cache.get(key)
-    mtime = p.stat().st_mtime
-    if entry:
-        stored_mtime = float(entry.get("mtime", 0.0))
-        if abs(stored_mtime - mtime) < 1e-6:
-            return str(entry.get("digest"))
-
-    digest = calc_hash(path, algo)
-    cache.set(key, {"mtime": mtime, "digest": digest}, ttl)
-    return digest
-
-
-def calc_hashes(
-    paths: Iterable[str],
-    algo: Literal["md5", "sha1", "sha256"] = "md5",
-    cache: CacheManager[Dict[str, Any]] | None = None,
-    *,
-    workers: int | None = None,
-    ttl: float = 365 * 24 * 60 * 60,
-    progress: Callable[[float | None], None] | None = None,
-) -> Dict[str, str]:
-    """Return a mapping of path->digest for many files concurrently."""
-    paths = list(paths)
-    if not paths:
-        if progress is not None:
-            progress(None)
-        return {}
-
-    if workers is None:
-        workers = min(32, os.cpu_count() or 1)
-
-    if cache is not None:
-        cache.refresh()
-
-    total = len(paths)
-    completed = 0
-    results: Dict[str, str] = {}
-
-    def worker(p: str) -> tuple[str, str]:
-        mtime = Path(p).stat().st_mtime
-        key = f"{p}:{algo}"
-        digest: str
-        if cache is not None:
-            entry = cache.get(key)
-            if entry and abs(float(entry.get("mtime", 0.0)) - mtime) < 1e-6:
-                return p, str(entry.get("digest", ""))
-        digest = calc_hash(p, algo)
-        if cache is not None:
-            cache.set(key, {"mtime": mtime, "digest": digest}, ttl)
-        return p, digest
-
-    with ThreadPoolExecutor(max_workers=workers) as executor:
-        future_map = {executor.submit(worker, p): p for p in paths}
-        for fut in as_completed(future_map):
-            path, digest = fut.result()
-            results[path] = digest
-            completed += 1
-            if progress is not None:
-                progress(completed / total)
-
-    if progress is not None:
-        progress(None)
-    return results
-
-
-def get_system_metrics() -> Dict[str, Any]:
-    """Return live system metrics for UI dashboards."""
-    cpu_per_core = psutil.cpu_percent(interval=None, percpu=True)
-    cpu = sum(cpu_per_core) / len(cpu_per_core) if cpu_per_core else 0.0
-    mem = psutil.virtual_memory()
-    disk = psutil.disk_usage("/")
-    net = psutil.net_io_counters()
-    disk_io = psutil.disk_io_counters()
-    freq = psutil.cpu_freq()
-    per_core_freq: list[float] = []
-    try:
-        per_core_freq = [f.current for f in psutil.cpu_freq(percpu=True)]
-    except Exception:
-        pass
-    temp: float | None = None
-    try:
-        temps = psutil.sensors_temperatures()
-        if temps:
-            for entries in temps.values():
-                if entries:
-                    temp = float(entries[0].current)
-                    break
-    except Exception:
-        temp = None
-    battery = None
-    try:
-        bat = psutil.sensors_battery()
-        if bat is not None:
-            battery = bat.percent
-    except Exception:
-        battery = None
-    return {
-        "cpu": cpu,
-        "cpu_per_core": cpu_per_core,
-        "memory": mem.percent,
-        "memory_used": mem.used / (1024**3),
-        "memory_total": mem.total / (1024**3),
-        "disk": disk.percent,
-        "disk_used": disk.used / (1024**3),
-        "disk_total": disk.total / (1024**3),
-        "sent": net.bytes_sent,
-        "recv": net.bytes_recv,
-        "read_bytes": disk_io.read_bytes,
-        "write_bytes": disk_io.write_bytes,
-        "cpu_freq": freq.current if freq else None,
-        "cpu_freq_per_core": per_core_freq,
-        "cpu_temp": temp,
-        "battery": battery,
-    }
-
-
-def adjust_color(color: str, factor: float) -> str:
-    """Return *color* adjusted by *factor*."""
-    color = color.lstrip("#")
-    if len(color) == 3:
-        color = "".join(c * 2 for c in color)
-    if len(color) != 6:
-        raise ValueError("invalid color format")
-
-    r = int(color[0:2], 16)
-    g = int(color[2:4], 16)
-    b = int(color[4:6], 16)
-
-    factor = max(-1.0, min(1.0, factor))
-    if factor >= 0:
-        r = round(r + (255 - r) * factor)
-        g = round(g + (255 - g) * factor)
-        b = round(b + (255 - b) * factor)
-    else:
-        r = round(r * (1 + factor))
-        g = round(g * (1 + factor))
-        b = round(b * (1 + factor))
-
-    return f"#{r:02x}{g:02x}{b:02x}"
-
-
-def hex_brightness(color: str) -> float:
-    """Return the perceptual brightness of *color* between 0 and 1."""
-    color = color.lstrip("#")
-    if len(color) == 3:
-        color = "".join(c * 2 for c in color)
-    if len(color) != 6:
-        raise ValueError("invalid color format")
-
-    r = int(color[0:2], 16)
-    g = int(color[2:4], 16)
-    b = int(color[4:6], 16)
-    return (0.299 * r + 0.587 * g + 0.114 * b) / 255
-
-
-def lighten_color(color: str, factor: float) -> str:
-    """Return *color* lightened by *factor* in the range ``0``-``1``."""
-    return adjust_color(color, max(0.0, min(1.0, factor)))
-
-
-def darken_color(color: str, factor: float) -> str:
-    """Return *color* darkened by *factor* in the range ``0``-``1``."""
-    return adjust_color(color, -max(0.0, min(1.0, factor)))
-
+__all__ = [
+    "calc_data_hash",
+    "calc_hash",
+    "calc_hash_cached",
+    "calc_hashes",
+    "adjust_color",
+    "hex_brightness",
+    "lighten_color",
+    "darken_color",
+    "log",
+    "get_system_info",
+    "run_with_spinner",
+    "open_path",
+    "slugify",
+    "strip_ansi",
+    "get_system_metrics",
+    "console",
+    "plain_console",
+]

--- a/src/utils/kill_utils.py
+++ b/src/utils/kill_utils.py
@@ -15,7 +15,7 @@ except ImportError:  # pragma: no cover - runtime dependency check
 
     psutil = ensure_psutil()
 _psutil_process = psutil.Process
-from .helpers import log, console
+from .system_utils import log, console
 from rich.progress import (
     Progress,
     SpinnerColumn,

--- a/src/utils/mouse_listener.py
+++ b/src/utils/mouse_listener.py
@@ -23,7 +23,7 @@ from typing import Callable, Optional
 
 import logging
 
-from .helpers import log
+from .system_utils import log
 
 logger = logging.getLogger(__name__)
 

--- a/src/utils/system_utils.py
+++ b/src/utils/system_utils.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import os
+import platform
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, Iterable
+
+from rich.console import Console
+from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
+
+try:  # pragma: no cover - runtime dependency check
+    import psutil  # type: ignore
+except ImportError:  # pragma: no cover
+    from ..ensure_deps import ensure_psutil
+
+    psutil = ensure_psutil()
+
+console = Console()
+plain_console = Console(no_color=True, force_terminal=False)
+
+
+def log(message: str) -> None:
+    """Log a message with rich formatting."""
+    console.log(message)
+
+
+def get_system_info() -> str:
+    """Return a concise multi-line system info string."""
+    lines = [
+        f"Python:   {sys.version.split()[0]} ({sys.executable})",
+        f"Platform: {platform.system()} {platform.release()} ({platform.machine()})",
+        f"Processor:{platform.processor() or 'unknown'}",
+        f"Prefix:   {getattr(sys, 'prefix', '')}",
+        f"TTY:      {console.is_terminal}",
+    ]
+    return "\n".join(lines)
+
+
+def run_with_spinner(
+    cmd: Iterable[str],
+    *,
+    message: str = "Working",
+    timeout: float | None = None,
+    capture_output: bool = False,
+    env: dict[str, str] | None = None,
+    cwd: str | None = None,
+) -> str | None:
+    """Run *cmd* while displaying a spinner and streaming output."""
+    proc = subprocess.Popen(
+        list(cmd),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+        env=env,
+        cwd=cwd,
+    )
+    start = time.time()
+    captured: list[str] = []
+
+    if not console.is_terminal:
+        # Plain fallback
+        assert proc.stdout is not None
+        for line in proc.stdout:
+            print(line.rstrip())
+            if capture_output:
+                captured.append(line)
+            if timeout is not None and (time.time() - start) > timeout:
+                proc.kill()
+                raise subprocess.TimeoutExpired(proc.args, timeout)
+        code = proc.wait(timeout=timeout)
+        if code:
+            raise subprocess.CalledProcessError(code, list(cmd))
+        return "".join(captured) if capture_output else None
+
+    with Progress(
+        SpinnerColumn(style="bold blue"),
+        TextColumn("{task.description}"),
+        TimeElapsedColumn(),
+        console=console,
+        transient=True,
+    ) as progress:
+        task_id = progress.add_task(message, start=True)
+        assert proc.stdout is not None
+        try:
+            for line in proc.stdout:
+                progress.console.print(line.rstrip())
+                if capture_output:
+                    captured.append(line)
+                if timeout is not None and (time.time() - start) > timeout:
+                    proc.kill()
+                    raise subprocess.TimeoutExpired(proc.args, timeout)
+            code = proc.wait(timeout=0.2 if timeout is None else max(0.2, timeout))
+            if code:
+                raise subprocess.CalledProcessError(code, list(cmd))
+        finally:
+            progress.update(task_id, completed=1)
+
+    return "".join(captured) if capture_output else None
+
+
+def open_path(path: str) -> None:
+    """Open *path* with the default application for the platform."""
+    if platform.system() == "Windows":
+        os.startfile(path)  # type: ignore[attr-defined]
+    elif platform.system() == "Darwin":
+        subprocess.Popen(["open", path])
+    else:
+        subprocess.Popen(["xdg-open", path])
+
+
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+_ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+
+
+def slugify(text: str, sep: str = "_") -> str:
+    """Return *text* normalized for filenames or URLs."""
+    text = text.lower()
+    text = _SLUG_RE.sub(sep, text)
+    return text.strip(sep)
+
+
+def strip_ansi(text: str) -> str:
+    """Return *text* without ANSI escape sequences."""
+    return _ANSI_RE.sub("", text)
+
+
+def get_system_metrics() -> Dict[str, Any]:
+    """Return live system metrics for UI dashboards."""
+    cpu_per_core = psutil.cpu_percent(interval=None, percpu=True)
+    cpu = sum(cpu_per_core) / len(cpu_per_core) if cpu_per_core else 0.0
+    mem = psutil.virtual_memory()
+    disk = psutil.disk_usage("/")
+    net = psutil.net_io_counters()
+    disk_io = psutil.disk_io_counters()
+    freq = psutil.cpu_freq()
+    per_core_freq: list[float] = []
+    try:
+        per_core_freq = [f.current for f in psutil.cpu_freq(percpu=True)]
+    except Exception:
+        pass
+    temp: float | None = None
+    try:
+        temps = psutil.sensors_temperatures()
+        if temps:
+            for entries in temps.values():
+                if entries:
+                    temp = float(entries[0].current)
+                    break
+    except Exception:
+        temp = None
+    battery = None
+    try:
+        bat = psutil.sensors_battery()
+        if bat is not None:
+            battery = bat.percent
+    except Exception:
+        battery = None
+    return {
+        "cpu": cpu,
+        "cpu_per_core": cpu_per_core,
+        "memory": mem.percent,
+        "memory_used": mem.used / (1024**3),
+        "memory_total": mem.total / (1024**3),
+        "disk": disk.percent,
+        "disk_used": disk.used / (1024**3),
+        "disk_total": disk.total / (1024**3),
+        "sent": net.bytes_sent,
+        "recv": net.bytes_recv,
+        "read_bytes": disk_io.read_bytes,
+        "write_bytes": disk_io.write_bytes,
+        "cpu_freq": freq.current if freq else None,
+        "cpu_freq_per_core": per_core_freq,
+        "cpu_temp": temp,
+        "battery": battery,
+    }
+
+
+__all__ = [
+    "log",
+    "get_system_info",
+    "run_with_spinner",
+    "open_path",
+    "slugify",
+    "strip_ansi",
+    "get_system_metrics",
+    "console",
+    "plain_console",
+]

--- a/src/views/about_view.py
+++ b/src/views/about_view.py
@@ -2,7 +2,7 @@
 About view - Application info
 """
 from ..components.widgets import info_label
-from ..utils import open_path
+from ..utils.system_utils import open_path
 from .base_view import BaseView
 
 

--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -38,7 +38,7 @@ from src.utils.scoring_engine import ScoringEngine, tuning
 from src.utils.hover_tracker import HoverTracker
 from ._fast_confidence import weighted_confidence as _weighted_confidence_np
 from src.utils import get_screen_refresh_rate
-from src.utils.helpers import log
+from src.utils.system_utils import log
 from src.config import Config
 
 try:  # pragma: no cover - optional dependency

--- a/src/views/force_quit_dialog.py
+++ b/src/views/force_quit_dialog.py
@@ -45,7 +45,7 @@ except ImportError:  # pragma: no cover - runtime dependency check
     psutil = ensure_psutil()
 from src.utils.process_monitor import ProcessEntry, ProcessWatcher
 from .base_dialog import BaseDialog
-from src.utils.helpers import (
+from src.utils.color_utils import (
     hex_brightness,
     lighten_color,
     darken_color,

--- a/src/views/home_view.py
+++ b/src/views/home_view.py
@@ -3,7 +3,7 @@ Home view - Main dashboard
 """
 import customtkinter as ctk
 from datetime import datetime
-from src.utils import open_path
+from src.utils.system_utils import open_path
 from .base_view import BaseView
 from ..components.widgets import info_label
 

--- a/src/views/recent_files_dialog.py
+++ b/src/views/recent_files_dialog.py
@@ -3,7 +3,7 @@
 import customtkinter as ctk
 
 from pathlib import Path
-from ..utils import open_path
+from ..utils.system_utils import open_path
 from .base_dialog import BaseDialog
 
 

--- a/src/views/settings_view.py
+++ b/src/views/settings_view.py
@@ -4,7 +4,7 @@ Settings view - Application preferences
 import customtkinter as ctk
 from tkinter import messagebox, colorchooser
 import json
-from src.utils import slugify
+from src.utils.system_utils import slugify
 from .base_view import BaseView
 
 
@@ -517,19 +517,19 @@ class SettingsView(BaseView):
 
     def _open_cache_folder(self) -> None:
         """Open the cache directory in the system file manager."""
-        from src.utils import open_path
+        from src.utils.system_utils import open_path
 
         open_path(str(self.app.config.cache_dir))
 
     def _open_config_folder(self) -> None:
         """Open the configuration directory in the system file manager."""
-        from src.utils import open_path
+        from src.utils.system_utils import open_path
 
         open_path(str(self.app.config.config_dir))
 
     def _open_config_file_external(self) -> None:
         """Open the configuration file using the system default editor."""
-        from src.utils import open_path
+        from src.utils.system_utils import open_path
 
         open_path(str(self.app.config.config_file))
 

--- a/src/views/system_info_dialog.py
+++ b/src/views/system_info_dialog.py
@@ -22,7 +22,7 @@ except ImportError:  # pragma: no cover - runtime dependency check
     ensure_matplotlib()
     from matplotlib.backends.backend_tkagg import NavigationToolbar2Tk
 
-from ..utils import get_system_info, get_system_metrics
+from ..utils.system_utils import get_system_info, get_system_metrics
 from ..components import LineChart, Gauge, BarChart
 from .base_dialog import BaseDialog
 

--- a/src/views/tools_view.py
+++ b/src/views/tools_view.py
@@ -333,7 +333,7 @@ class ToolsView(BaseView):
         duplicates: dict[str, list[Path]] = {}
 
         from src.utils.cache import CacheManager
-        from src.utils.helpers import calc_hashes
+        from src.utils.hash_utils import calc_hashes
 
         cache_file = self.app.config.cache_dir / "hash_cache.json"
         hash_cache = CacheManager[dict](cache_file)
@@ -878,7 +878,7 @@ class ToolsView(BaseView):
         output.pack(padx=10, pady=10, fill="both", expand=True)
 
         def compute() -> None:
-            from src.utils import calc_hash
+            from src.utils.hash_utils import calc_hash
 
             path = file_var.get()
             if not path:

--- a/tests/test_exe_inspector.py
+++ b/tests/test_exe_inspector.py
@@ -12,10 +12,10 @@ import types
 
 src = types.ModuleType("src")
 utils = types.ModuleType("src.utils")
-helpers = types.ModuleType("src.utils.helpers")
+hash_utils = types.ModuleType("src.utils.hash_utils")
 process_utils = types.ModuleType("src.utils.process_utils")
 security = types.ModuleType("src.utils.security")
-helpers.calc_hash = lambda p, algo="sha256": hashlib.sha256(
+hash_utils.calc_hash = lambda p, algo="sha256": hashlib.sha256(
     Path(p).read_bytes()
 ).hexdigest()
 process_utils.run_command = lambda *a, **kw: ""
@@ -23,13 +23,13 @@ process_utils.run_command_ex = lambda *a, **kw: ("", 0)
 security.ensure_admin = lambda *a, **kw: True
 security.is_admin = lambda: True
 security.list_open_ports = lambda: {}
-utils.helpers = helpers
+utils.hash_utils = hash_utils
 utils.process_utils = process_utils
 utils.security = security
 src.utils = utils
 sys.modules.setdefault("src", src)
 sys.modules.setdefault("src.utils", utils)
-sys.modules.setdefault("src.utils.helpers", helpers)
+sys.modules.setdefault("src.utils.hash_utils", hash_utils)
 sys.modules.setdefault("src.utils.process_utils", process_utils)
 sys.modules.setdefault("src.utils.security", security)
 

--- a/tests/test_force_quit_highlight.py
+++ b/tests/test_force_quit_highlight.py
@@ -41,7 +41,7 @@ class TestForceQuitHighlight(unittest.TestCase):
                 ProcessEntry=object, ProcessWatcher=object
             ),
             "src.views.base_dialog": types.SimpleNamespace(BaseDialog=object),
-            "src.utils.helpers": types.SimpleNamespace(
+            "src.utils.color_utils": types.SimpleNamespace(
                 hex_brightness=lambda c: c,
                 lighten_color=lambda c, *_a: c,
                 darken_color=lambda c, *_a: c,

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,22 +1,26 @@
 import sys
 import subprocess
 from types import SimpleNamespace
-from src.utils import (
+from src.utils.system_utils import (
     open_path,
-    calc_hash,
-    calc_hashes,
     get_system_info,
     get_system_metrics,
-)
-from src.utils.cache import CacheManager
-from src.utils.helpers import adjust_color, hex_brightness, lighten_color
-from src.utils.helpers import (
-    darken_color,
     run_with_spinner,
     slugify,
     strip_ansi,
+)
+from src.utils.hash_utils import (
+    calc_hash,
+    calc_hashes,
     calc_data_hash,
 )
+from src.utils.color_utils import (
+    adjust_color,
+    hex_brightness,
+    lighten_color,
+    darken_color,
+)
+from src.utils.cache import CacheManager
 import io
 
 
@@ -225,7 +229,7 @@ def test_run_with_spinner(monkeypatch):
             pass
 
     monkeypatch.setattr(subprocess, "Popen", fake_popen)
-    monkeypatch.setattr("src.utils.helpers.Progress", DummyProgress)
+    monkeypatch.setattr("src.utils.system_utils.Progress", DummyProgress)
 
     result = run_with_spinner(
         ["echo", "hi"], message="test", timeout=5, capture_output=True, env={"F": "1"}, cwd="/tmp"


### PR DESCRIPTION
## Summary
- add dedicated `hash_utils`, `color_utils`, and `system_utils` modules
- keep `helpers.py` as a thin wrapper re-exporting utility functions
- update imports across the project to use new utility modules

## Testing
- `pytest tests/test_helpers.py tests/test_exe_inspector.py tests/test_force_quit_highlight.py`
- `pytest` *(fails: Terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68a2d95d74d08325a6031765ed31ad68