### PR TITLE
Improve process command error handling

### DIFF
--- a/scripts/exe_inspector.py
+++ b/scripts/exe_inspector.py
@@ -39,8 +39,13 @@ except ModuleNotFoundError:  # pragma: no cover - textual is optional
 import psutil  # noqa: E402
 
 from src.utils.hash_utils import calc_hash  # noqa: E402
-from src.utils.process_utils import run_command, run_command_ex  # noqa: E402
+from src.utils.process_utils import run_command as _run_cmd, run_command_ex  # noqa: E402
 from src.utils.security import ensure_admin, is_admin, list_open_ports  # noqa: E402
+
+
+def run_command(cmd: Sequence[str], **kwargs) -> str:
+    out, _err = _run_cmd(cmd, **kwargs)
+    return out or ""
 import shutil  # noqa: E402
 import hashlib
 import ctypes

--- a/src/utils/network.py
+++ b/src/utils/network.py
@@ -23,7 +23,7 @@ from typing import (
 )
 import platform
 from .process_utils import (
-    run_command as _run,
+    run_command as _run_cmd,
     run_command_ex as _run_ex,
     run_command_async_ex as _run_async_ex,
 )
@@ -36,6 +36,11 @@ except ImportError:  # pragma: no cover - runtime dependency check
 
     psutil = ensure_psutil()
 from .cache import CacheManager
+
+
+def _run(cmd, **kwargs):
+    out, _err = _run_cmd(cmd, **kwargs)
+    return out
 
 # Default worker and timeout values can be tuned via environment variables so
 # large scans can be optimized without code changes.

--- a/src/utils/security.py
+++ b/src/utils/security.py
@@ -21,7 +21,7 @@ except ImportError:  # pragma: no cover - runtime dependency check
 
     psutil = ensure_psutil()
 from .win_console import hidden_creation_flags
-from .process_utils import run_command as _run, run_command_background
+from .process_utils import run_command, run_command_background
 from .kill_utils import kill_process, kill_process_tree
 
 
@@ -49,6 +49,11 @@ def _unix_firewall_tool() -> str:
 # ---------------------------------------------------------------------------
 # Firewall helpers
 # ---------------------------------------------------------------------------
+
+def _run(cmd, **kwargs):
+    out, _err = run_command(cmd, **kwargs)
+    return out
+
 
 def is_firewall_enabled() -> Optional[bool]:
     """Return ``True`` if the system firewall is enabled."""
@@ -382,7 +387,8 @@ def launch_security_center(*, hide_console: bool = False) -> bool:
     kwargs["env"] = os.environ.copy()
 
     if is_admin():
-        return run_command_background([str(python), str(script)], **kwargs)
+        ok, _err = run_command_background([str(python), str(script)], **kwargs)
+        return ok
 
     system = platform.system()
 
@@ -396,6 +402,7 @@ def launch_security_center(*, hide_console: bool = False) -> bool:
         except Exception:
             return False
     elif system in {"Linux", "Darwin"}:
-        return run_command_background(["sudo", str(python), str(script)], **kwargs)
+        ok, _err = run_command_background(["sudo", str(python), str(script)], **kwargs)
+        return ok
 
     return False

--- a/tests/test_exe_inspector.py
+++ b/tests/test_exe_inspector.py
@@ -18,7 +18,7 @@ security = types.ModuleType("src.utils.security")
 hash_utils.calc_hash = lambda p, algo="sha256": hashlib.sha256(
     Path(p).read_bytes()
 ).hexdigest()
-process_utils.run_command = lambda *a, **kw: ""
+process_utils.run_command = lambda *a, **kw: ("", None)
 process_utils.run_command_ex = lambda *a, **kw: ("", 0)
 security.ensure_admin = lambda *a, **kw: True
 security.is_admin = lambda: True

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -225,7 +225,7 @@ def test_launch_security_center_admin(monkeypatch):
     def fake_bg(args, **kwargs):
         called["args"] = args
         called.update(kwargs)
-        return True
+        return True, None
 
     monkeypatch.setattr(security, "run_command_background", fake_bg)
     assert security.launch_security_center() is True
@@ -244,7 +244,7 @@ def test_launch_security_center_sudo(monkeypatch):
     def fake_bg(args, **kwargs):
         called["args"] = args
         called.update(kwargs)
-        return True
+        return True, None
 
     monkeypatch.setattr(security, "run_command_background", fake_bg)
     assert security.launch_security_center() is True
@@ -266,7 +266,7 @@ def test_launch_security_center_hidden(monkeypatch):
     def fake_bg(args, **kwargs):
         called["args"] = args
         called.update(kwargs)
-        return True
+        return True, None
 
     monkeypatch.setattr(security, "run_command_background", fake_bg)
 
@@ -322,7 +322,7 @@ def test_launch_security_center_hidden_unix(monkeypatch):
     def fake_bg(args, **kwargs):
         called["args"] = args
         called.update(kwargs)
-        return True
+        return True, None
 
     monkeypatch.setattr(security, "run_command_background", fake_bg)
 

--- a/tests/test_vm.py
+++ b/tests/test_vm.py
@@ -105,7 +105,7 @@ def test_launch_vm_open_code(monkeypatch):
 
     def bg(args, **kwargs):
         calls.append("code")
-        return True
+        return True, None
 
     monkeypatch.setattr(shutil, "which", which)
     monkeypatch.setattr(vm, "run_command_background", bg)
@@ -127,7 +127,7 @@ def test_launch_vm_open_code_missing(monkeypatch, capsys):
         return "/usr/bin/vagrant" if cmd == "vagrant" else None
 
     monkeypatch.setattr(shutil, "which", which)
-    monkeypatch.setattr(vm, "run_command_background", lambda *a, **k: None)
+    monkeypatch.setattr(vm, "run_command_background", lambda *a, **k: (False, None))
     monkeypatch.setattr(vm, "run_command_ex", lambda *a, **k: ("", 0))
     launch_vm_debug(open_code=True)
     out = capsys.readouterr().out


### PR DESCRIPTION
## Summary
- handle specific subprocess errors and log before returning
- expose error details for command helpers
- extend process utility tests for success and failure cases

## Testing
- `pytest tests/test_process_utils.py tests/test_security.py tests/test_vm.py`


------
https://chatgpt.com/codex/tasks/task_e_68a2dc9e8b808325a791c16e9783da7a