### PR TITLE
Implement centralized rich logging

### DIFF
--- a/src/app/icon.py
+++ b/src/app/icon.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import sys
 import tempfile
 import ctypes
+import logging
 
 try:
     from PIL import Image, ImageTk
@@ -14,7 +15,7 @@ except ImportError:  # pragma: no cover - runtime dependency check
     Image = pil.Image  # type: ignore[attr-defined]
     ImageTk = pil.ImageTk  # type: ignore[attr-defined]
 
-from ..utils.system_utils import log
+logger = logging.getLogger(__name__)
 
 
 def set_app_icon(window):
@@ -29,7 +30,7 @@ def set_app_icon(window):
     )
     if not icon_path.is_file():
         msg = f"Icon file not found: {icon_path}"
-        log(msg)
+        logger.error(msg)
         raise RuntimeError(msg)
 
     temp_icon: str | None = None
@@ -50,10 +51,10 @@ def set_app_icon(window):
                     pass
                 temp_icon = tmp.name
             except Exception as exc:
-                log(f"Failed to set taskbar icon: {exc}")
+                logger.warning("Failed to set taskbar icon: %s", exc)
                 raise RuntimeError(f"Failed to set taskbar icon: {exc}") from exc
     except Exception as exc:
-        log(f"Failed to set window icon: {exc}")
+        logger.error("Failed to set window icon: %s", exc)
         raise RuntimeError(f"Failed to set window icon: {exc}") from exc
 
     if sys.platform == "darwin":
@@ -63,7 +64,7 @@ def set_app_icon(window):
             ns_image = NSImage.alloc().initByReferencingFile_(str(icon_path))
             NSApplication.sharedApplication().setApplicationIconImage_(ns_image)
         except Exception as exc:
-            log(f"Failed to set dock icon: {exc}")
+            logger.warning("Failed to set dock icon: %s", exc)
             raise RuntimeError(f"Failed to set dock icon: {exc}") from exc
 
     return photo, temp_icon

--- a/src/app/layout.py
+++ b/src/app/layout.py
@@ -15,7 +15,9 @@ from ..views.home_view import HomeView
 from ..views.tools_view import ToolsView
 from ..views.settings_view import SettingsView
 from ..views.about_view import AboutView
-from ..utils.system_utils import log
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def setup_ui(app) -> None:
@@ -66,5 +68,5 @@ def setup_ui(app) -> None:
         app.update_fonts()
         app.update_theme()
     except Exception as exc:
-        log(f"Failed to set up UI: {exc}")
+        logger.error("Failed to set up UI: %s", exc)
         raise RuntimeError(f"Failed to set up UI: {exc}") from exc

--- a/src/ensure_deps.py
+++ b/src/ensure_deps.py
@@ -3,21 +3,13 @@
 from __future__ import annotations
 
 import importlib
+import logging
 import subprocess
 import sys
 from types import ModuleType
 from typing import Optional
 
-try:  # Avoid circular imports when utils.helpers requires ensure_deps
-    from .utils.system_utils import log
-except Exception:  # pragma: no cover - fallback logger
-    import logging
-
-    logging.basicConfig(level=logging.INFO)
-
-    def log(message: str) -> None:
-        """Fallback logger used during early imports."""
-        logging.info(message)
+logger = logging.getLogger(__name__)
 
 
 _DEF_VERSION = "5.2.2"
@@ -48,13 +40,13 @@ def require_package(name: str, version: Optional[str] = None) -> ModuleType:
         return importlib.import_module(name)
     except ImportError:
         pkg = f"{name}=={version}" if version else name
-        log(f"Package '{name}' missing, attempting install of {pkg}...")
+        logger.info("Package '%s' missing, attempting install of %s...", name, pkg)
         cmd = [sys.executable, "-m", "pip", "install", pkg]
         try:
             subprocess.check_call(cmd)
         except Exception as exc:
             if version:
-                log(f"Failed to install {pkg}, trying latest version...")
+                logger.warning("Failed to install %s, trying latest version...", pkg)
                 try:
                     subprocess.check_call([sys.executable, "-m", "pip", "install", name])
                 except Exception as exc2:  # pragma: no cover - install step may fail

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -3,7 +3,6 @@
 import os
 
 from .system_utils import (
-    log,
     open_path,
     slugify,
     strip_ansi,
@@ -138,7 +137,6 @@ from .gpu import benchmark_gpu_usage
 from . import file_manager
 
 __all__ = [
-    "log",
     "read_text",
     "write_text",
     "read_lines",

--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -13,7 +13,6 @@ from .color_utils import (
     darken_color,
 )
 from .system_utils import (
-    log,
     get_system_info,
     run_with_spinner,
     open_path,
@@ -33,7 +32,6 @@ __all__ = [
     "hex_brightness",
     "lighten_color",
     "darken_color",
-    "log",
     "get_system_info",
     "run_with_spinner",
     "open_path",

--- a/src/utils/kill_utils.py
+++ b/src/utils/kill_utils.py
@@ -2,20 +2,22 @@ from __future__ import annotations
 
 """Robust cross-platform process termination helpers."""
 
+import logging
 import os
-import time
 import signal
+import time
 from contextlib import contextmanager
 from threading import Event, Thread
 from typing import Callable
+
 try:
     import psutil
 except ImportError:  # pragma: no cover - runtime dependency check
     from ..ensure_deps import ensure_psutil
 
     psutil = ensure_psutil()
+
 _psutil_process = psutil.Process
-from .system_utils import log, console
 from rich.progress import (
     Progress,
     SpinnerColumn,
@@ -23,6 +25,15 @@ from rich.progress import (
     TextColumn,
     TimeElapsedColumn,
 )
+from .system_utils import console
+
+
+logger = logging.getLogger(__name__)
+
+
+def log(message: str) -> None:
+    """Backward compatible log function."""
+    logger.info(message)
 
 
 def _kill_cmd(pid: int) -> bool:

--- a/src/utils/logging_config.py
+++ b/src/utils/logging_config.py
@@ -1,0 +1,46 @@
+"""Application-wide logging configuration using rich handlers."""
+from __future__ import annotations
+
+import logging
+import os
+from logging.handlers import RotatingFileHandler
+
+from rich.logging import RichHandler
+
+
+def setup_logging(level: int = logging.INFO, log_file: str | None = None) -> None:
+    """Configure standard logging with RichHandler and optional file output.
+
+    Parameters
+    ----------
+    level:
+        Minimum logging severity. Defaults to ``logging.INFO``.
+    log_file:
+        Optional path to a log file. If provided, a ``RotatingFileHandler``
+        will be attached writing plain text logs suitable for diagnostics.
+        If ``None``, the environment variable ``COOLBOX_LOG_FILE`` is
+        consulted. When neither are provided no file logging is configured.
+    """
+    if log_file is None:
+        log_file = os.getenv("COOLBOX_LOG_FILE")
+
+    handlers: list[logging.Handler] = [
+        RichHandler(rich_tracebacks=True, markup=True)
+    ]
+
+    if log_file:
+        file_handler = RotatingFileHandler(log_file, maxBytes=5_000_000, backupCount=5)
+        file_handler.setFormatter(
+            logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+        )
+        handlers.append(file_handler)
+
+    logging.basicConfig(
+        level=level,
+        handlers=handlers,
+        format="%(message)s",
+        force=True,
+    )
+
+
+__all__ = ["setup_logging"]

--- a/src/utils/mouse_listener.py
+++ b/src/utils/mouse_listener.py
@@ -23,9 +23,12 @@ from typing import Callable, Optional
 
 import logging
 
-from .system_utils import log
-
 logger = logging.getLogger(__name__)
+
+
+def log(message: str) -> None:
+    """Backward compatible log function."""
+    logger.info(message)
 
 _JOIN_TIMEOUT = 0.2  # seconds
 

--- a/src/utils/system_utils.py
+++ b/src/utils/system_utils.py
@@ -9,6 +9,8 @@ import time
 from pathlib import Path
 from typing import Any, Dict, Iterable
 
+import logging
+
 from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
 
@@ -23,9 +25,7 @@ console = Console()
 plain_console = Console(no_color=True, force_terminal=False)
 
 
-def log(message: str) -> None:
-    """Log a message with rich formatting."""
-    console.log(message)
+logger = logging.getLogger(__name__)
 
 
 def get_system_info() -> str:
@@ -66,7 +66,7 @@ def run_with_spinner(
         # Plain fallback
         assert proc.stdout is not None
         for line in proc.stdout:
-            print(line.rstrip())
+            logger.info(line.rstrip())
             if capture_output:
                 captured.append(line)
             if timeout is not None and (time.time() - start) > timeout:
@@ -181,7 +181,6 @@ def get_system_metrics() -> Dict[str, Any]:
 
 
 __all__ = [
-    "log",
     "get_system_info",
     "run_with_spinner",
     "open_path",

--- a/src/views/force_quit_dialog.py
+++ b/src/views/force_quit_dialog.py
@@ -1015,8 +1015,7 @@ class ForceQuitDialog(BaseDialog):
             info.update({"name": proc.name(), "status": proc.status()})
         except Exception as exc:  # pragma: no cover - diagnostic path
             info["error"] = repr(exc)
-        print("force_kill failed", file=sys.stderr)
-        print(json.dumps(info, indent=2, default=str), file=sys.stderr)
+        logger.error("force_kill failed: %s", json.dumps(info, indent=2, default=str))
         return False
 
     @classmethod
@@ -2409,8 +2408,10 @@ class ForceQuitDialog(BaseDialog):
                 "stalled_for": round(elapsed, 3),
                 "stack": traceback.format_stack(limit=5),
             }
-            print("Kill by Click timed out", file=sys.stderr)
-            print(json.dumps(info, indent=2, default=str), file=sys.stderr)
+            logger.warning(
+                "Kill by Click timed out: %s",
+                json.dumps(info, indent=2, default=str),
+            )
             try:
                 overlay.close()
             except Exception:
@@ -2485,8 +2486,10 @@ class ForceQuitDialog(BaseDialog):
                 "stalled_for": round(time.monotonic() - last, 3),
                 "stack": traceback.format_exception(type(result), result, result.__traceback__),
             }
-            print("Kill by Click raised an exception", file=sys.stderr)
-            print(json.dumps(info, indent=2, default=str), file=sys.stderr)
+            logger.error(
+                "Kill by Click raised an exception: %s",
+                json.dumps(info, indent=2, default=str),
+            )
             return
         pid, title, ctime, cmd, exe = result
         ctx.__exit__(None, None, None)
@@ -2523,8 +2526,10 @@ class ForceQuitDialog(BaseDialog):
                 "stalled_for": round(time.monotonic() - last, 3),
                 "stack": traceback.format_stack(limit=5),
             }
-            print("Kill by Click failed to return a process", file=sys.stderr)
-            print(json.dumps(info, indent=2, default=str), file=sys.stderr)
+            logger.warning(
+                "Kill by Click failed to return a process: %s",
+                json.dumps(info, indent=2, default=str),
+            )
             messagebox.showwarning(
                 "Force Quit", "No process was selected", parent=self
             )
@@ -2554,8 +2559,10 @@ class ForceQuitDialog(BaseDialog):
                 "stalled_for": round(time.monotonic() - last, 3),
                 "stack": traceback.format_stack(limit=5),
             }
-            print("Kill by Click refused to terminate self", file=sys.stderr)
-            print(json.dumps(info, indent=2, default=str), file=sys.stderr)
+            logger.warning(
+                "Kill by Click refused to terminate self: %s",
+                json.dumps(info, indent=2, default=str),
+            )
             messagebox.showwarning(
                 "Force Quit", "Cannot terminate this application", parent=self
             )
@@ -2589,8 +2596,10 @@ class ForceQuitDialog(BaseDialog):
                 "stalled_for": round(time.monotonic() - last, 3),
                 "stack": traceback.format_stack(limit=5),
             }
-            print("Kill by Click target vanished", file=sys.stderr)
-            print(json.dumps(info, indent=2, default=str), file=sys.stderr)
+            logger.warning(
+                "Kill by Click target vanished: %s",
+                json.dumps(info, indent=2, default=str),
+            )
             messagebox.showwarning(
                 "Force Quit", f"Process {pid} no longer exists", parent=self
             )
@@ -2646,8 +2655,10 @@ class ForceQuitDialog(BaseDialog):
                         "stalled_for": round(time.monotonic() - last, 3),
                         "stack": traceback.format_stack(limit=5),
                     }
-                    print("Kill by Click target changed", file=sys.stderr)
-                    print(json.dumps(info, indent=2, default=str), file=sys.stderr)
+                    logger.warning(
+                        "Kill by Click target changed: %s",
+                        json.dumps(info, indent=2, default=str),
+                    )
                     messagebox.showwarning(
                         "Force Quit", f"Process {pid} changed", parent=self
                     )
@@ -2686,8 +2697,10 @@ class ForceQuitDialog(BaseDialog):
                 "stalled_for": round(time.monotonic() - last, 3),
                 "stack": traceback.format_stack(limit=5),
             }
-            print("Kill by Click could not terminate process", file=sys.stderr)
-            print(json.dumps(info, indent=2, default=str), file=sys.stderr)
+            logger.error(
+                "Kill by Click could not terminate process: %s",
+                json.dumps(info, indent=2, default=str),
+            )
             messagebox.showerror(
                 "Force Quit", f"Failed to terminate process {pid}", parent=self
             )


### PR DESCRIPTION
## Summary
- Add `setup_logging` using RichHandler with optional rotating file logs
- Replace helper log usage with `logging.getLogger`
- Swap prints for structured logging across modules and keep backward-compatible `log` wrappers

## Testing
- `pytest tests/test_config.py tests/test_kill_utils.py tests/test_vm.py tests/test_mouse_listener.py -q`
- `pytest -q` *(fails: terminated after partial run)*

------
https://chatgpt.com/codex/tasks/task_e_68a2e23270d88325a713ba9aafe18f3e