### PR TITLE
Add global error handler and thread exception reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,6 +650,14 @@ CoolBox/
 
 Contributions are welcome! Please feel free to submit a Pull Request.
 
+### Global Error Handling
+
+CoolBox installs a Tk ``report_callback_exception`` handler that logs
+uncaught exceptions and displays a friendly error dialog. Background threads
+should forward exceptions to the main thread using
+``ThreadManager.post_exception`` so they are processed by this handler.
+This keeps error reporting consistent across the application.
+
 ## 📄 License
 
 This project is licensed under the MIT License.

--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -25,6 +25,7 @@ from ..utils.thread_manager import ThreadManager
 
 from .icon import set_app_icon
 from .layout import setup_ui
+from .error_handler import handle_exception
 
 logger = logging.getLogger(__name__)
 
@@ -56,6 +57,9 @@ class CoolBoxApp:
         self.window.geometry(
             f"{self.config.get('window_width', 1200)}x{self.config.get('window_height', 900)}"
         )
+
+        # Global error handler for uncaught Tk callbacks
+        self.window.report_callback_exception = handle_exception
 
         # Set application icon
         try:

--- a/src/app/error_handler.py
+++ b/src/app/error_handler.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import logging
+from tkinter import messagebox
+from typing import Type
+
+logger = logging.getLogger(__name__)
+
+
+def handle_exception(exc: Type[BaseException], value: BaseException, tb) -> None:
+    """Log *value* with traceback and show a friendly error dialog.
+
+    This function is installed as ``window.report_callback_exception`` so any
+    uncaught exceptions raised in Tkinter callbacks are routed here.
+    """
+    logger.error("Unhandled exception", exc_info=(exc, value, tb))
+    messagebox.showerror("Unexpected Error", str(value))


### PR DESCRIPTION
## Summary
- centralize Tk callback errors in `error_handler.handle_exception`
- wire CoolBoxApp to use the global handler and document usage
- post exceptions from worker threads via `ThreadManager.post_exception`

## Testing
- `pytest tests/test_thread_manager.py tests/test_tool_error_handling.py`
- `flake8 src/app/__init__.py src/utils/thread_manager.py src/app/error_handler.py`
- `pytest` *(terminated early: tests/test_force_quit.py)*


------
https://chatgpt.com/codex/tasks/task_e_68a2e49bbda48325a26cff53dea42e3f