### PR TITLE
Handle OS errors in file utilities with logging

### DIFF
--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -26,6 +26,7 @@ from .color_utils import (
 from .rainbow import RainbowBorder, NeonPulseBorder
 from .vm import launch_vm_debug
 from .file_manager import (
+    FileManagerError,
     read_text,
     write_text,
     read_lines,
@@ -137,6 +138,7 @@ from .gpu import benchmark_gpu_usage
 from . import file_manager
 
 __all__ = [
+    "FileManagerError",
     "read_text",
     "write_text",
     "read_lines",


### PR DESCRIPTION
## Summary
- add `FileManagerError` and logger to `file_manager`
- wrap file operations (read_text, write_text, copy_file, move_file, etc.) in `try/except` that log and re-raise `FileManagerError`
- expose `FileManagerError` via `src.utils`

## Testing
- `pytest tests/test_file_manager.py -q`
- `pytest` *(fails: terminated early in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68a374c84518832592fc3e6303bf4719