### PR TITLE
feat: extend main window height

### DIFF
--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -55,7 +55,7 @@ class CoolBoxApp:
         self.window = ctk.CTk()
         self.window.title("CoolBox - Modern Desktop App")
         self.window.geometry(
-            f"{self.config.get('window_width', 1200)}x{self.config.get('window_height', 900)}"
+            f"{self.config.get('window_width', 1200)}x{self.config.get('window_height', 1000)}"
         )
 
         # Global error handler for uncaught Tk callbacks
@@ -70,7 +70,10 @@ class CoolBoxApp:
             self._temp_icon = None
 
         # Set minimum window size
-        self.window.minsize(800, 700)
+        self.window.minsize(
+            self.config.get("window_min_width", 800),
+            self.config.get("window_min_height", 800),
+        )
 
         # Theme manager
         self.theme = ThemeManager(config=self.config)

--- a/src/config.py
+++ b/src/config.py
@@ -30,7 +30,7 @@ class Config:
             "appearance_mode": "dark",
             "color_theme": "blue",
             "window_width": 1200,
-            "window_height": 900,
+            "window_height": 1000,
             "auto_save": True,
             "recent_files": [],
             "max_recent_files": 10,
@@ -132,8 +132,8 @@ class Config:
             "kill_by_click_auto_interval": True,
             "kill_by_click_kf_process_noise": 1.0,
             "kill_by_click_kf_measurement_noise": 5.0,
-            "window_min_width": 0,
-            "window_min_height": 700,
+            "window_min_width": 800,
+            "window_min_height": 800,
         }
 
         # Load configuration


### PR DESCRIPTION
## Summary
- increase default window height and minimum dimensions so console area remains visible
- tie window minimum size to config settings

## Testing
- `pytest tests/test_config.py tests/test_app.py -q`
- `pytest tests/test_window_utils.py -q`
- `pytest -q` *(fails: terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68a4297aff288325a95c5fb7d8df8a67