### PR TITLE
Avoid duplicate setup logging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -204,6 +204,11 @@ if os.environ.get("COOLBOX_LOG_FILE"):
 else:
     logger.addHandler(logging.NullHandler())
 
+# Prevent messages from propagating to the root logger.
+# This avoids duplicate output when other parts of the application
+# configure root logging.
+logger.propagate = False
+
 # ---------- configuration ----------
 
 DEFAULT_RAINBOW = (


### PR DESCRIPTION
## Summary
- Prevent setup logger from propagating to the root logger to avoid duplicate "Done" output

## Testing
- `python -c "import logging; logging.basicConfig(format='%(levelname)s:%(message)s'); from setup import log; log('Once more')"`
- `pytest` *(fails: terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68a42f5b8dec832586d8869c0f1670c1