### PR TITLE
Replace deprecated numpy row_stack usage

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -4,6 +4,17 @@ __version__ = "1.3.76"
 
 import os
 
+# NumPy 2.0 deprecates ``row_stack`` and emits a warning each time it is
+# used.  Matplotlib still calls this alias internally, so we replace it with
+# ``vstack`` to silence the warning without altering behaviour.
+try:  # pragma: no cover - optional dependency
+    import numpy as _np
+
+    if hasattr(_np, "row_stack"):
+        _np.row_stack = _np.vstack  # type: ignore[attr-defined]
+except Exception:
+    pass
+
 if not os.environ.get("COOLBOX_LIGHTWEIGHT"):
     from .app import CoolBoxApp  # noqa: F401
     from .ensure_deps import ensure_customtkinter  # noqa: F401


### PR DESCRIPTION
## Summary
- replace numpy `row_stack` alias with `vstack` to avoid deprecation warning

## Testing
- `python - <<'PY'
import warnings
warnings.filterwarnings('default')
import src  # triggers patch
import matplotlib.pyplot as plt
fig, ax = plt.subplots()
ax.stackplot([0,1], [[1,2]])
print('done')
PY`
- `flake8` *(fails: E402 module level import not at top of file, F401 'io' imported but unused, E302 expected 2 blank lines, E305 expected 2 blank lines after class or function definition, E306 expected 1 blank line before a nested definition, W391 blank line at end of file)*
- `pytest -q` *(terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68a43456c4ec83259a53220c1a785f69