### PR TITLE
Improve error dialog with expandable details

### DIFF
--- a/tests/test_error_handler.py
+++ b/tests/test_error_handler.py
@@ -43,3 +43,23 @@ def test_warning_and_unraisable_capture(tmp_path, monkeypatch):
     sys.unraisablehook(info)
     assert any("boom" in e for e in eh.RECENT_ERRORS)
 
+
+def test_handle_exception_uses_dialog(monkeypatch):
+    """``handle_exception`` should invoke the error dialog helper."""
+
+    called = {}
+
+    def fake_dialog(msg: str, details: str) -> None:
+        called["msg"] = msg
+        called["details"] = details
+
+    monkeypatch.setattr(eh, "_show_error_dialog", fake_dialog)
+
+    try:
+        raise RuntimeError("kaboom")
+    except RuntimeError as exc:
+        eh.handle_exception(RuntimeError, exc, None)
+
+    assert "kaboom" in called["msg"]
+    assert "RuntimeError" in called["details"]
+


### PR DESCRIPTION
## Summary
- Add custom error dialog with expandable details and option to open log file
- Integrate new dialog into global error handler
- Test that the error handler invokes the dialog helper

## Testing
- `pytest tests/test_error_handler.py -q`
- `pytest -q` *(fails: Terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68a49512e43083258c5c8525db2c1928