### PR TITLE
Fix tooltip DPI tracking and allow Force Quit error stubbing

### DIFF
--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -14,6 +14,7 @@ from typing import Dict, Optional, TYPE_CHECKING
 from pathlib import Path
 import sys
 import logging
+from tkinter import messagebox
 
 from ..config import Config
 from ..components.toolbar import Toolbar
@@ -204,8 +205,6 @@ class CoolBoxApp:
 
     def open_force_quit(self) -> None:
         """Launch the Force Quit dialog or focus the existing one."""
-        from tkinter import messagebox
-
         try:
             from ..views.force_quit_dialog import ForceQuitDialog
         except Exception as exc:  # pragma: no cover - runtime import error


### PR DESCRIPTION
## Summary
- ensure tooltip windows are registered and deregistered with CustomTkinter's scaling tracker to avoid KeyError
- move messagebox import to module level so tests can stub Force Quit errors

## Testing
- `flake8 src/components/tooltip.py`
- `flake8 src/app/__init__.py`
- `pytest tests/test_force_quit_error.py -q`
- `pytest -q` *(fails: Terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68a4969cc934832596c61996ca9eec4c