### PR TITLE
Enable force quit actions earlier

### DIFF
--- a/src/views/force_quit_dialog.py
+++ b/src/views/force_quit_dialog.py
@@ -969,7 +969,20 @@ class ForceQuitDialog(BaseDialog):
             self._snapshot_changed = True
 
     def _update_kill_actions(self) -> None:
-        if self._actions_enabled or self._enum_progress < 1.0:
+        """Enable kill actions once process data is available.
+
+        Previously the dialog waited for the initial process enumeration to
+        fully complete (``_enum_progress`` reaching ``1.0``) before enabling the
+        various kill buttons.  On systems with a large number of processes this
+        could take a noticeable amount of time, leaving the actions appearing
+        unresponsive.  Instead we now enable the buttons as soon as *any*
+        process data has been loaded.  The old behaviour is still respected if
+        enumeration completes with an empty snapshot.
+        """
+
+        if self._actions_enabled:
+            return
+        if self._enum_progress < 1.0 and not self.process_snapshot:
             return
         self.kill_selected_btn.configure(state=tk.NORMAL)
         for btn in self._action_buttons:

--- a/tests/test_force_quit_actions.py
+++ b/tests/test_force_quit_actions.py
@@ -14,6 +14,7 @@ class Dummy:
 
 def test_kill_actions_enable_once() -> None:
     dialog = SimpleNamespace(
+        process_snapshot={},
         _enum_progress=0.0,
         _actions_enabled=False,
         kill_selected_btn=Dummy(),
@@ -23,7 +24,7 @@ def test_kill_actions_enable_once() -> None:
     ForceQuitDialog._update_kill_actions(dialog)
     assert dialog.kill_selected_btn.state == tk.DISABLED
 
-    dialog._enum_progress = 1.0
+    dialog.process_snapshot[1] = object()
     ForceQuitDialog._update_kill_actions(dialog)
     assert dialog.kill_selected_btn.state == tk.NORMAL
 


### PR DESCRIPTION
## Summary
- enable Force Quit kill buttons as soon as processes load instead of waiting for full enumeration
- update tests for new action enabling behavior

## Testing
- `pytest tests/test_force_quit_actions.py::test_kill_actions_enable_once -q`
- `pytest tests/test_force_quit.py tests/test_force_quit_interval.py tests/test_force_quit_fps.py tests/test_force_quit_cache.py tests/test_force_quit_debounce.py tests/test_force_quit_error.py -q` (warnings: PytestUnhandledThreadExceptionWarning)


------
https://chatgpt.com/codex/tasks/task_e_68a4ad1030b08325b214a9f1035eb0d5