### PR TITLE
Ensure tooltip scaling tracker cleanup

### DIFF
--- a/src/components/tooltip.py
+++ b/src/components/tooltip.py
@@ -35,5 +35,6 @@ class Tooltip(ctk.CTkToplevel):
     def destroy(self) -> None:  # type: ignore[override]
         """Destroy tooltip and deregister from scaling tracker."""
         scaling_tracker.ScalingTracker.remove_window(self._set_scaling, self)
+        scaling_tracker.ScalingTracker.window_widgets_dict.pop(self, None)
         scaling_tracker.ScalingTracker.window_dpi_scaling_dict.pop(self, None)
         super().destroy()

--- a/tests/test_tooltip_scaling_tracker.py
+++ b/tests/test_tooltip_scaling_tracker.py
@@ -1,0 +1,18 @@
+import os
+import pytest
+import customtkinter as ctk
+from customtkinter.windows.widgets.scaling import scaling_tracker
+
+from src.components.tooltip import Tooltip
+
+
+@pytest.mark.skipif(os.environ.get("DISPLAY") is None, reason="No display available")
+def test_tooltip_registers_with_scaling_tracker() -> None:
+    root = ctk.CTk()
+    tip = Tooltip(root, "hello")
+    root.update_idletasks()
+    assert tip in scaling_tracker.ScalingTracker.window_dpi_scaling_dict
+    tip.destroy()
+    root.update_idletasks()
+    assert tip not in scaling_tracker.ScalingTracker.window_dpi_scaling_dict
+    root.destroy()


### PR DESCRIPTION
## Summary
- Ensure tooltips fully deregister from CustomTkinter's scaling tracker by removing stale dictionary entries.
- Add regression test verifying tooltip registration and cleanup.

## Testing
- `pytest tests/test_tooltip_scaling_tracker.py -q` (skipped: No display available)

------
https://chatgpt.com/codex/tasks/task_e_68a4b1bcdbc88325a3fd86ba2dc4dd4b