### PR TITLE
feat: modern error dialog UI

### DIFF
--- a/src/app/error_handler.py
+++ b/src/app/error_handler.py
@@ -77,6 +77,25 @@ def _show_error_dialog(message: str, details: str) -> None:
         return
 
     try:  # pragma: no cover - UI logic not exercised in tests
+        try:
+            import customtkinter as ctk
+            from src.components.modern_error_dialog import ModernErrorDialog
+
+            root = tk._default_root
+            created_root = False
+            if root is None:
+                root = ctk.CTk()
+                root.withdraw()
+                created_root = True
+
+            dialog = ModernErrorDialog(root, message, details, _get_log_file())
+            root.wait_window(dialog)
+            if created_root:
+                root.destroy()
+            return
+        except Exception:
+            pass
+
         root = tk._default_root
         created_root = False
         if root is None:

--- a/src/components/__init__.py
+++ b/src/components/__init__.py
@@ -9,6 +9,10 @@ from .tooltip import Tooltip
 from .charts import LineChart
 from .gauge import Gauge
 from .bar_chart import BarChart
+try:  # pragma: no cover - optional component
+    from .modern_error_dialog import ModernErrorDialog
+except Exception:  # pragma: no cover - missing GUI deps
+    ModernErrorDialog = None  # type: ignore
 
 __all__ = [
     "Sidebar",
@@ -20,4 +24,5 @@ __all__ = [
     "LineChart",
     "Gauge",
     "BarChart",
+    "ModernErrorDialog",
 ]

--- a/src/components/modern_error_dialog.py
+++ b/src/components/modern_error_dialog.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import webbrowser
+from pathlib import Path
+
+import customtkinter as ctk
+
+
+class ModernErrorDialog(ctk.CTkToplevel):
+    """Modern error dialog using CustomTkinter widgets."""
+
+    def __init__(self, master: ctk.CTkBaseClass, message: str, details: str, log_file: Path | None = None):
+        super().__init__(master)
+        self.title("Unexpected Error")
+        self.resizable(True, True)
+
+        ctk.CTkLabel(self, text=message, wraplength=480, justify="left").pack(padx=20, pady=(20, 10))
+
+        self._details = ctk.CTkTextbox(self, width=480, height=200)
+        self._details.insert("1.0", details)
+        self._details.configure(state="disabled")
+        self._details.pack_forget()
+
+        btn_row = ctk.CTkFrame(self)
+        btn_row.pack(pady=(0, 20))
+
+        self._toggle_btn = ctk.CTkButton(btn_row, text="Show details", command=self._toggle)
+        self._toggle_btn.pack(side="left", padx=5)
+
+        if log_file is not None:
+            ctk.CTkButton(
+                btn_row,
+                text="Open Log",
+                command=lambda: webbrowser.open(log_file.as_uri()),
+            ).pack(side="left", padx=5)
+
+        ctk.CTkButton(btn_row, text="Copy", command=self._copy).pack(side="left", padx=5)
+        ctk.CTkButton(btn_row, text="Close", command=self.destroy).pack(side="left", padx=5)
+
+        self.grab_set()
+        self.focus_force()
+
+    def _toggle(self) -> None:
+        if self._details.winfo_manager():
+            self._details.pack_forget()
+            self._toggle_btn.configure(text="Show details")
+        else:
+            self._details.pack(fill="both", expand=True, padx=20, pady=(0, 10))
+            self._toggle_btn.configure(text="Hide details")
+
+    def _copy(self) -> None:
+        self.clipboard_clear()
+        self.clipboard_append(self._details.get("1.0", "end").strip())


### PR DESCRIPTION
## Summary
- introduce `ModernErrorDialog` based on CustomTkinter
- wire error handler to show modern dialog with copy and log features
- expose new dialog from components package

## Testing
- `pytest -q` *(fails: terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b5709f088325803c53d9aa2efd9d