### PR TITLE
Fix click-and-kill overlay cursor tracking

### DIFF
--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -1171,6 +1171,13 @@ class ClickOverlay(tk.Toplevel):
             )
             thr_ms, thr_px = self._move_thresholds()
             if dt * 1000.0 < thr_ms and dist < thr_px:
+                # Even when skipping heavy work, keep cursor data fresh so the
+                # crosshair doesn't appear frozen when the pointer moves
+                self._last_move_time = now
+                self._last_move_pos = (_e.x_root, _e.y_root)
+                with self._state_lock:
+                    self._cursor_x = _e.x_root
+                    self._cursor_y = _e.y_root
                 return
             self._last_move_time = now
             self._last_move_pos = (_e.x_root, _e.y_root)
@@ -1190,6 +1197,11 @@ class ClickOverlay(tk.Toplevel):
             dist = math.hypot(mx - self._last_move_pos[0], my - self._last_move_pos[1])
             thr_ms, thr_px = self._move_thresholds()
             if dt * 1000.0 < thr_ms and dist < thr_px:
+                self._last_move_time = now
+                self._last_move_pos = (mx, my)
+                with self._state_lock:
+                    self._cursor_x = mx
+                    self._cursor_y = my
                 return
             self._last_move_time = now
             self._last_move_pos = (mx, my)


### PR DESCRIPTION
## Summary
- prevent click overlay crosshair from freezing when pointer movement is below refresh thresholds

## Testing
- `pytest tests/test_click_overlay.py -k cursor -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4b76d03c8832580b7272c79aaba62