### PR TITLE
Improve Windows Defender toggle reliability

### DIFF
--- a/src/views/security_dialog.py
+++ b/src/views/security_dialog.py
@@ -227,16 +227,23 @@ class SecurityDialog(BaseDialog):
         ok_fw = set_firewall_enabled(self.firewall_var.get())
 
         if platform.system() == "Windows":
-            ok_def = set_defender_enabled(self.defender_var.get())
+            ok_def, err_def = set_defender_enabled(self.defender_var.get())
         else:
-            ok_def = True
+            ok_def, err_def = True, None
             self.defender_sw.configure(state="disabled")
 
         if ok_fw and ok_def:
             messagebox.showinfo("Security Center", "Settings applied successfully")
         else:
+            parts = []
+            if not ok_fw:
+                parts.append("Firewall")
+            if not ok_def:
+                parts.append("Defender")
+            detail = f"\n{err_def}" if err_def else ""
             messagebox.showwarning(
-                "Security Center", "Failed to apply some settings"
+                "Security Center",
+                f"Failed to apply: {', '.join(parts)}{detail}",
             )
 
     def destroy(self) -> None:  # type: ignore[override]


### PR DESCRIPTION
## Summary
- handle tamper protection and report errors when toggling Windows Defender
- show which security settings failed to apply

## Testing
- `flake8 src/utils/security.py src/views/security_dialog.py`
- `pytest -q` *(terminated)*
- `pytest tests/test_error_handler.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4bd0fc7d083259c219df13ec5e9c0