### PR TITLE
Fix Defender toggle refresh in Security Center

### DIFF
--- a/src/views/security_dialog.py
+++ b/src/views/security_dialog.py
@@ -222,6 +222,7 @@ class SecurityDialog(BaseDialog):
 
     def _apply(self) -> None:
         if not ensure_admin():
+            self._refresh()
             return
 
         ok_fw = set_firewall_enabled(self.firewall_var.get())
@@ -245,6 +246,7 @@ class SecurityDialog(BaseDialog):
                 "Security Center",
                 f"Failed to apply: {', '.join(parts)}{detail}",
             )
+        self._refresh()
 
     def destroy(self) -> None:  # type: ignore[override]
         if self._scan_check is not None:


### PR DESCRIPTION
## Summary
- Refresh Security Center toggles after applying firewall/Defender changes
- Update Defender test for new run_command_ex API

## Testing
- `pytest tests/test_security.py::test_set_defender_enabled -q`
- `pytest tests/test_security.py -q`
- `pytest -q` *(fails: Terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c2b0a33883259401e926089e2bed