### PR TITLE
Explain firewall and Defender failures

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -4,6 +4,7 @@ import os
 import unittest
 import customtkinter as ctk
 from unittest.mock import patch
+from types import SimpleNamespace
 
 from src.app import CoolBoxApp
 
@@ -145,7 +146,13 @@ class TestCoolBoxApp(unittest.TestCase):
         patches = [
             patch("src.views.security_dialog.is_firewall_enabled", lambda: True),
             patch("src.views.security_dialog.is_defender_supported", lambda: True),
-            patch("src.views.security_dialog.read_current_states", lambda: (True, True)),
+            patch(
+                "src.views.security_dialog.read_current_statuses",
+                lambda: (
+                    SimpleNamespace(domain=True, private=True, public=True, error=None),
+                    SimpleNamespace(realtime=True, error=None),
+                ),
+            ),
             patch("src.utils.security.is_admin", lambda: True),
         ]
         for p in patches:
@@ -165,7 +172,13 @@ class TestCoolBoxApp(unittest.TestCase):
         patches = [
             patch("src.views.security_dialog.is_firewall_enabled", lambda: True),
             patch("src.views.security_dialog.is_defender_supported", lambda: True),
-            patch("src.views.security_dialog.read_current_states", lambda: (True, True)),
+            patch(
+                "src.views.security_dialog.read_current_statuses",
+                lambda: (
+                    SimpleNamespace(domain=True, private=True, public=True, error=None),
+                    SimpleNamespace(realtime=True, error=None),
+                ),
+            ),
             patch("src.utils.security.is_admin", lambda: True),
         ]
         for p in patches:

--- a/tests/test_security_error_logging.py
+++ b/tests/test_security_error_logging.py
@@ -1,0 +1,61 @@
+import subprocess
+
+import src.utils.firewall as firewall
+import src.utils.defender as defender
+from src.utils.security import run_command_background
+from src.app import error_handler as eh
+
+
+def _boom_run(*args, **kwargs):  # pragma: no cover - helper to force errors
+    raise FileNotFoundError("nope")
+
+
+def test_firewall_run_ex_records(monkeypatch):
+    monkeypatch.setattr(subprocess, "run", _boom_run)
+    eh.RECENT_ERRORS.clear()
+    out, rc = firewall._run_ex(["foo"])
+    assert rc == -1 and "FileNotFoundError" in out
+    assert any("FileNotFoundError" in e for e in eh.RECENT_ERRORS)
+
+
+def test_defender_run_ex_records(monkeypatch):
+    monkeypatch.setattr(subprocess, "run", _boom_run)
+    eh.RECENT_ERRORS.clear()
+    out, rc = defender._run_ex(["foo"])
+    assert rc == -1 and "FileNotFoundError" in out
+    assert any("FileNotFoundError" in e for e in eh.RECENT_ERRORS)
+
+
+def test_run_command_background_records(monkeypatch):
+    def boom_popen(*args, **kwargs):  # pragma: no cover - helper
+        raise OSError("fail")
+
+    monkeypatch.setattr(subprocess, "Popen", boom_popen)
+    eh.RECENT_ERRORS.clear()
+    ok, proc = run_command_background(["foo"])
+    assert ok is False and proc is None
+    assert any("OSError" in e for e in eh.RECENT_ERRORS)
+
+
+def test_run_ex_exit_code_message(monkeypatch):
+    class CP:
+        stdout = ""
+        stderr = ""
+        returncode = 7
+
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: CP())
+    out, rc = firewall._run_ex(["foo", "bar"])
+    assert rc == 7 and "exited with code 7" in out and "foo bar" in out
+
+
+def test_ps_exit_code_message(monkeypatch):
+    class CP:
+        stdout = ""
+        stderr = ""
+        returncode = 3
+
+    monkeypatch.setattr(defender.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: CP())
+    out, rc = defender._ps("Get-Thing")
+    assert rc == 3 and "exited with code 3" in out
+

--- a/tests/test_security_service_errors.py
+++ b/tests/test_security_service_errors.py
@@ -1,0 +1,26 @@
+import platform
+
+from src.utils import firewall, defender
+
+
+def test_firewall_service_error(monkeypatch):
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    monkeypatch.setattr(firewall, "ensure_admin", lambda: True)
+    monkeypatch.setattr(
+        firewall, "_services_ok", lambda: (False, "BFE not running")
+    )
+    ok, err = firewall.set_firewall_enabled(True)
+    assert ok is False and "BFE not running" in err
+
+
+def test_defender_service_error(monkeypatch):
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    monkeypatch.setattr(defender, "ensure_admin", lambda: True)
+    monkeypatch.setattr(defender, "is_defender_supported", lambda: True)
+    monkeypatch.setattr(
+        defender, "_defender_services_ok", lambda: (False, "WinDefend not running")
+    )
+    monkeypatch.setattr(defender, "_third_party_av_present", lambda: False)
+    ok, err = defender.set_defender_enabled(True)
+    assert ok is False and "WinDefend not running" in err
+


### PR DESCRIPTION
## Summary
- Surface command timeouts, missing binaries, and exit codes when firewall or Defender helpers fail
- Security Center reads detailed firewall/Defender status objects and warns users with any reported errors
- Regression tests cover exit-code diagnostics and updated Security Center helpers

## Testing
- `pytest tests/test_security.py tests/test_security_error_logging.py tests/test_security_service_errors.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4d0a954c88325a25f370c975be4da