### PR TITLE
feat: relaunch security center with admin rights

### DIFF
--- a/scripts/security_center.py
+++ b/scripts/security_center.py
@@ -8,9 +8,12 @@ sys.path.insert(0, str(ROOT))
 
 from src.app import CoolBoxApp  # noqa: E402
 from src.views.security_dialog import SecurityDialog  # noqa: E402
+from src.utils.security import ensure_admin  # noqa: E402
 
 
 def main() -> None:
+    if not ensure_admin():
+        return
     app = CoolBoxApp()
     app.window.withdraw()
     SecurityDialog(app)

--- a/scripts/security_center_hidden.py
+++ b/scripts/security_center_hidden.py
@@ -16,6 +16,7 @@ from src.utils.win_console import (  # noqa: E402
 )
 from src.app import CoolBoxApp  # noqa: E402
 from src.views.security_dialog import SecurityDialog  # noqa: E402
+from src.utils.security import ensure_admin  # noqa: E402
 
 
 # Hide the terminal ASAP before creating any Tk windows.
@@ -39,6 +40,8 @@ silence_stdio()
 
 
 def main() -> None:
+    if not ensure_admin():
+        return
     app = CoolBoxApp()
     app.window.withdraw()
     SecurityDialog(app)

--- a/src/utils/security.py
+++ b/src/utils/security.py
@@ -50,8 +50,37 @@ def is_admin() -> bool:
 
 
 def ensure_admin() -> bool:
-    """Return True if running with administrative privileges."""
-    return is_admin()
+    """Ensure the current process has administrative privileges.
+
+    If already running as admin, returns ``True``. On Windows, when not
+    elevated, this spawns a new copy of the current Python executable with
+    the same arguments using the ``runas`` verb and then exits the original
+    process. Environment variable ``COOLBOX_ADMIN_RELAUNCHED`` prevents
+    infinite respawn loops. Returns ``False`` when a relaunch was attempted
+    or not possible.
+    """
+
+    if is_admin():
+        return True
+
+    if not _IS_WINDOWS:
+        return False
+
+    if os.environ.get("COOLBOX_ADMIN_RELAUNCHED") == "1":
+        return False
+
+    try:
+        import shlex
+
+        os.environ["COOLBOX_ADMIN_RELAUNCHED"] = "1"
+        params = " ".join(shlex.quote(a) for a in sys.argv)
+        ctypes.windll.shell32.ShellExecuteW(
+            None, "runas", sys.executable, params, None, 1
+        )
+    except Exception:
+        return False
+    sys.exit(0)
+    return False
 
 
 # ------------------------------ Run helpers --------------------------------

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -82,3 +82,29 @@ def test_ensure_admin(monkeypatch):
     monkeypatch.setattr(security, "is_admin", lambda: True)
     assert security.ensure_admin() is True
 
+
+def test_ensure_admin_relaunch(monkeypatch):
+    monkeypatch.setattr(security, "_IS_WINDOWS", True)
+    monkeypatch.setattr(security, "is_admin", lambda: False)
+
+    called: dict[str, str] = {}
+
+    class DummyShell32:
+        def ShellExecuteW(self, hwnd, op, file, params, directory, show):
+            called.update(op=op, file=file, params=params)
+            return 42
+
+    monkeypatch.setattr(
+        security,
+        "ctypes",
+        SimpleNamespace(windll=SimpleNamespace(shell32=DummyShell32())),
+    )
+    exits: list[int] = []
+    monkeypatch.setattr(security.sys, "exit", lambda code=0: exits.append(code))
+    monkeypatch.delenv("COOLBOX_ADMIN_RELAUNCHED", raising=False)
+
+    assert security.ensure_admin() is False
+    assert called["op"] == "runas"
+    assert exits == [0]
+    assert os.environ.get("COOLBOX_ADMIN_RELAUNCHED") == "1"
+


### PR DESCRIPTION
## Summary
- ensure admin rights by relaunching current process with UAC if needed
- security center scripts now check for admin and relaunch when required
- add regression test for ensure_admin relaunch behavior

## Testing
- `pytest tests/test_security.py -q`
- `pytest -q` *(fails: Terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f8055468832591c458b7ce56ca1f