### PR TITLE
feat: relaunch security center with admin rights

### DIFF
--- a/scripts/security_center.py
+++ b/scripts/security_center.py
@@ -8,9 +8,14 @@ sys.path.insert(0, str(ROOT))
 
 from src.app import CoolBoxApp  # noqa: E402
 from src.views.security_dialog import SecurityDialog  # noqa: E402
+from src.utils import security  # noqa: E402
 
 
 def main() -> None:
+    if not security.is_admin():
+        security.relaunch_security_center()
+        return
+
     app = CoolBoxApp()
     app.window.withdraw()
     SecurityDialog(app)

--- a/scripts/security_center_hidden.py
+++ b/scripts/security_center_hidden.py
@@ -16,6 +16,11 @@ from src.utils.win_console import (  # noqa: E402
 )
 from src.app import CoolBoxApp  # noqa: E402
 from src.views.security_dialog import SecurityDialog  # noqa: E402
+from src.utils import security  # noqa: E402
+
+if not security.is_admin():
+    security.relaunch_security_center()
+    sys.exit(0)
 
 
 # Hide the terminal ASAP before creating any Tk windows.

--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -230,6 +230,15 @@ class CoolBoxApp:
         """Open the Security Center dialog."""
         from ..views.security_dialog import SecurityDialog
         import tkinter as tk
+        from src.utils import security
+
+        if not security.is_admin():
+            if security.relaunch_security_center():
+                return
+            messagebox.showwarning(
+                "Security Center", "Administrator rights required."
+            )
+            return
 
         if (
             self.security_center_window is not None

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -128,6 +128,7 @@ from .security import (
     is_admin,
     ensure_admin,
     get_defender_status,
+    relaunch_security_center,
 )
 from .thread_manager import ThreadManager
 from .gpu import benchmark_gpu_usage
@@ -243,6 +244,7 @@ __all__ = [
     "is_admin",
     "ensure_admin",
     "get_defender_status",
+    "relaunch_security_center",
     "ScoringEngine",
     "Tuning",
     "tuning",

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -162,6 +162,20 @@ class TestCoolBoxApp(unittest.TestCase):
         app.destroy()
 
     @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_open_security_center_relaunches_when_not_admin(self) -> None:
+        app = CoolBoxApp()
+        flag = {"called": False}
+        with patch("src.utils.security.is_admin", lambda: False), \
+             patch(
+                 "src.utils.security.relaunch_security_center",
+                 lambda: flag.__setitem__("called", True) or True,
+             ):
+            app.open_security_center()
+        self.assertTrue(flag["called"])  # relaunch attempted
+        self.assertIsNone(app.security_center_window)
+        app.destroy()
+
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
     def test_security_center_singleton(self) -> None:
         app = CoolBoxApp()
         patches = [


### PR DESCRIPTION
## Summary
- relaunch Security Center in elevated mode when opened without admin rights
- update app to spawn elevated dialog and notify if elevation fails
- add regression test for relaunch logic

## Testing
- `python -m py_compile scripts/security_center.py scripts/security_center_hidden.py src/app/__init__.py src/utils/security.py src/utils/__init__.py tests/test_app.py`
- `pytest` *(failed: terminated early in environment)*
- `pytest tests/test_app.py::TestCoolBoxApp::test_open_security_center_relaunches_when_not_admin -q` *(skipped: No display available)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f8055468832591c458b7ce56ca1f