### PR TITLE
Fix SecurityDialog initialization in security center scripts

### DIFF
--- a/scripts/security_center.py
+++ b/scripts/security_center.py
@@ -18,7 +18,8 @@ def main() -> None:
 
     app = CoolBoxApp()
     app.window.withdraw()
-    SecurityDialog(app)
+    # Pass the underlying Tk window to SecurityDialog
+    SecurityDialog(app.window)
     app.window.mainloop()
 
 

--- a/scripts/security_center_hidden.py
+++ b/scripts/security_center_hidden.py
@@ -46,7 +46,8 @@ silence_stdio()
 def main() -> None:
     app = CoolBoxApp()
     app.window.withdraw()
-    SecurityDialog(app)
+    # SecurityDialog expects a Tkinter window, not the CoolBoxApp wrapper
+    SecurityDialog(app.window)
     app.window.mainloop()
 
 


### PR DESCRIPTION
## Summary
- Pass the underlying Tk window to `SecurityDialog` when launching the Security Center
- Keep elevation logic so the dialog relaunches with administrator rights if needed

## Testing
- `pytest tests/test_app.py::TestCoolBoxApp::test_open_security_center_method tests/test_app.py::TestCoolBoxApp::test_open_security_center_relaunches_when_not_admin -q`
- `pytest` *(fails: terminated early; see logs)*

------
https://chatgpt.com/codex/tasks/task_e_68a4fbd47f8c8325aa02c1222f810996