### PR TITLE
Fix Security Center dialog root and admin relaunch

### DIFF
--- a/scripts/security_center.py
+++ b/scripts/security_center.py
@@ -13,12 +13,12 @@ from src.utils import security  # noqa: E402
 
 def main() -> None:
     if not security.is_admin():
-        security.relaunch_security_center()
-        return
+        security.relaunch_security_center(sys.argv[1:])
+        sys.exit(0)
 
     app = CoolBoxApp()
     app.window.withdraw()
-    SecurityDialog(app)
+    SecurityDialog(app.window)
     app.window.mainloop()
 
 

--- a/scripts/security_center_hidden.py
+++ b/scripts/security_center_hidden.py
@@ -19,7 +19,7 @@ from src.views.security_dialog import SecurityDialog  # noqa: E402
 from src.utils import security  # noqa: E402
 
 if not security.is_admin():
-    security.relaunch_security_center()
+    security.relaunch_security_center(sys.argv[1:])
     sys.exit(0)
 
 
@@ -46,7 +46,7 @@ silence_stdio()
 def main() -> None:
     app = CoolBoxApp()
     app.window.withdraw()
-    SecurityDialog(app)
+    SecurityDialog(app.window)
     app.window.mainloop()
 
 


### PR DESCRIPTION
## Summary
- Use the application's Tk root when opening SecurityDialog to avoid attribute errors
- Pass through CLI arguments when relaunching Security Center with admin rights

## Testing
- `python -m flake8 scripts/security_center_hidden.py scripts/security_center.py`
- `pytest tests/test_security.py`
- `pytest tests/test_security_error_logging.py tests/test_security_service_errors.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4fbd47f8c8325aa02c1222f810996