### PR TITLE
Fix Security Center dialogs to use Tk master and elevate

### DIFF
--- a/scripts/security_center.py
+++ b/scripts/security_center.py
@@ -9,16 +9,19 @@ sys.path.insert(0, str(ROOT))
 from src.app import CoolBoxApp  # noqa: E402
 from src.views.security_dialog import SecurityDialog  # noqa: E402
 from src.utils import security  # noqa: E402
+import tkinter as tk
 
 
 def main() -> None:
     if not security.is_admin():
-        security.relaunch_security_center()
+        security.relaunch_security_center(sys.argv[1:])
         return
 
     app = CoolBoxApp()
     app.window.withdraw()
-    SecurityDialog(app)
+    top = tk.Toplevel(app.window)
+    SecurityDialog(top)
+    top.protocol("WM_DELETE_WINDOW", app.window.destroy)
     app.window.mainloop()
 
 

--- a/scripts/security_center_hidden.py
+++ b/scripts/security_center_hidden.py
@@ -17,9 +17,10 @@ from src.utils.win_console import (  # noqa: E402
 from src.app import CoolBoxApp  # noqa: E402
 from src.views.security_dialog import SecurityDialog  # noqa: E402
 from src.utils import security  # noqa: E402
+import tkinter as tk
 
 if not security.is_admin():
-    security.relaunch_security_center()
+    security.relaunch_security_center(sys.argv[1:])
     sys.exit(0)
 
 
@@ -46,7 +47,9 @@ silence_stdio()
 def main() -> None:
     app = CoolBoxApp()
     app.window.withdraw()
-    SecurityDialog(app)
+    top = tk.Toplevel(app.window)
+    SecurityDialog(top)
+    top.protocol("WM_DELETE_WINDOW", app.window.destroy)
     app.window.mainloop()
 
 


### PR DESCRIPTION
## Summary
- Ensure security center scripts relaunch with admin rights and pass CLI args
- Create a Tkinter `Toplevel` for SecurityDialog and close app cleanly

## Testing
- `pytest` *(fails: command terminated in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68a4fbd47f8c8325aa02c1222f810996