### PR TITLE
Fix hover callback and selection stability

### DIFF
--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -751,6 +751,7 @@ class ClickOverlay(tk.Toplevel):
         self.pid: int | None = None
         self.title_text: str | None = None
         self._last_info: WindowInfo | None = None
+        self._last_sent_info: WindowInfo | None = None
         self._cached_info: WindowInfo | None = None
         self._screen_w = self.winfo_screenwidth()
         self._screen_h = self.winfo_screenheight()
@@ -1201,14 +1202,14 @@ class ClickOverlay(tk.Toplevel):
                 self._cursor_x = fx
                 self._cursor_y = fy
                 self._velocity = math.hypot(vx, vy)
-        _ = self._update_hover_tracker()
         if self.update_state is UpdateState.IDLE:
             self.update_state = UpdateState.PENDING
             self.after_idle(self._process_update)
 
-    def _update_hover_tracker(self) -> WindowInfo | None:
+    def _update_hover_tracker(self, info: WindowInfo | None = None) -> WindowInfo | None:
         """Update hover statistics and return a stable guess if available."""
-        info = self._query_window()
+        if info is None:
+            info = self._query_window()
         self._hover.update(info, self._own_pid)
         if info.pid not in (self._own_pid, None):
             self._last_info = info
@@ -1537,6 +1538,11 @@ class ClickOverlay(tk.Toplevel):
         self.pid = info.pid
         self.title_text = info.title
 
+        stable = self._update_hover_tracker(info)
+        stable_changed = stable != self._last_sent_info
+        self._last_sent_info = stable
+        self._handle_hover(stable_changed, stable)
+
         px = int(self._cursor_x)
         py = int(self._cursor_y)
         sw = self._screen_w
@@ -1569,7 +1575,6 @@ class ClickOverlay(tk.Toplevel):
         if "label_pos" in updates:
             self._buffer["label_pos"] = updates["label_pos"]
         self._buffer["pid"] = info.pid
-        self._handle_hover(hover_changed)
 
     def _draw_crosshair(
         self,
@@ -1627,13 +1632,16 @@ class ClickOverlay(tk.Toplevel):
         hover_changed = text_changed or info.pid != self._buffer["pid"]
         return rect, text, window_changed, hover_changed
 
-    def _handle_hover(self, hover_changed: bool) -> None:
+    def _handle_hover(self, hover_changed: bool, info: WindowInfo | None) -> None:
         """Invoke the hover callback when the target window changes."""
-        if hover_changed and self.on_hover is not None:
-            try:
-                self.on_hover(self.pid, self.title_text)
-            except Exception:
-                pass
+        if not hover_changed or self.on_hover is None:
+            return
+        pid = None if info is None else info.pid
+        title = None if info is None else getattr(info, "title", None)
+        try:
+            self.on_hover(pid, title)
+        except Exception:
+            pass
 
     def _stable_info(self) -> WindowInfo | None:
         """Return a best guess based solely on recent hover history."""

--- a/src/views/force_quit_dialog.py
+++ b/src/views/force_quit_dialog.py
@@ -1873,7 +1873,14 @@ class ForceQuitDialog(BaseDialog):
         """Highlight ``pid`` in the process list while the overlay is active."""
         if not hasattr(self, "tree"):
             return
-        if pid is None or not self.tree.exists(str(pid)):
+        if pid is None:
+            if time.monotonic() - getattr(self, "_last_hover_ts", 0) < 0.12:
+                return  # ignore brief dropouts
+            self.tree.selection_remove(self.tree.selection())
+            self._set_hover_row(None)
+            return
+        self._last_hover_ts = time.monotonic()
+        if not self.tree.exists(str(pid)):
             self.tree.selection_remove(self.tree.selection())
             self._set_hover_row(None)
             return

--- a/tests/test_click_overlay.py
+++ b/tests/test_click_overlay.py
@@ -2739,6 +2739,8 @@ def test_update_rect_skips_small_move_no_window_change() -> None:
             }
             self._applied = False
             self._min_move_px = 2
+            self._last_sent_info = None
+            self._last_sent_info = None
 
         def _draw_crosshair(self, updates: dict[str, tuple[int, ...] | str], px: int, py: int, sw: int, sh: int, cursor_changed: bool) -> None:
             pass
@@ -2752,8 +2754,11 @@ def test_update_rect_skips_small_move_no_window_change() -> None:
         def _apply_updates(self, updates: dict[str, tuple[int, ...] | str]) -> None:
             self._applied = True
 
-        def _handle_hover(self, _hc: bool) -> None:  # pragma: no cover - dummy
+        def _handle_hover(self, _hc: bool, _info=None) -> None:  # pragma: no cover - dummy
             pass
+
+        def _update_hover_tracker(self, info):
+            return info
 
     d = Dummy()
     d._cursor_x = 1
@@ -2787,6 +2792,7 @@ def test_update_rect_handles_missing_last_cursor() -> None:
             }
             self._applied = False
             self._min_move_px = 2
+            self._last_sent_info = None
 
         def _draw_crosshair(
             self,
@@ -2810,8 +2816,11 @@ def test_update_rect_handles_missing_last_cursor() -> None:
         def _apply_updates(self, updates: dict[str, tuple[int, ...] | str]) -> None:
             self._applied = True
 
-        def _handle_hover(self, _hc: bool) -> None:  # pragma: no cover - dummy
+        def _handle_hover(self, _hc: bool, _info=None) -> None:  # pragma: no cover - dummy
             pass
+
+        def _update_hover_tracker(self, info):
+            return info
 
     d = Dummy()
     click_overlay.ClickOverlay._update_rect(


### PR DESCRIPTION
## Summary
- forward stable WindowInfo to click overlay hover callback
- retain last stable window and avoid flicker when overlay reports None
- ignore brief hover dropouts before clearing Force Quit selection

## Testing
- `pytest tests/test_hover_tracker.py tests/test_force_quit_highlight.py tests/test_click_overlay.py::TestClickOverlay::test_on_hover_callback_invoked tests/test_click_overlay.py::TestClickOverlay::test_on_hover_not_called_when_window_unchanged tests/test_click_overlay.py::test_update_rect_skips_small_move_no_window_change tests/test_click_overlay.py::test_update_rect_handles_missing_last_cursor`


------
https://chatgpt.com/codex/tasks/task_e_68a5b67ca8a88325895ebf7be0673e98