### PR TITLE
Fix hover selection callback to use stable window info

### DIFF
--- a/src/utils/hover_tracker.py
+++ b/src/utils/hover_tracker.py
@@ -18,6 +18,7 @@ class HoverTracker:
         self._current_streak: int = 0
         self._hover_start = time.monotonic()
         self._last_pid: int | None = None
+        self._last_emitted: WindowInfo | None = None
 
     # Public accessors -------------------------------------------------
     @property
@@ -91,11 +92,14 @@ class HoverTracker:
         pid, count = max(self._pid_stability.items(), key=lambda i: i[1])
         threshold = tuning.stability_threshold + int(velocity * tuning.vel_stab_scale)
         if count < threshold:
-            return None
+            return self._last_emitted or None
         for info in reversed(self._info_history):
             if info.pid == pid:
+                self._last_emitted = info
                 return info
-        return WindowInfo(pid)
+        chosen = WindowInfo(pid)
+        self._last_emitted = chosen
+        return chosen
 
     def reset(self) -> None:
         """Clear all runtime state."""
@@ -107,3 +111,4 @@ class HoverTracker:
         self._current_streak = 0
         self._hover_start = time.monotonic()
         self._last_pid = None
+        self._last_emitted = None

--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -752,6 +752,7 @@ class ClickOverlay(tk.Toplevel):
         self.title_text: str | None = None
         self._last_info: WindowInfo | None = None
         self._cached_info: WindowInfo | None = None
+        self._last_sent_info: WindowInfo | None = None
         self._screen_w = self.winfo_screenwidth()
         self._screen_h = self.winfo_screenheight()
         try:
@@ -1201,7 +1202,10 @@ class ClickOverlay(tk.Toplevel):
                 self._cursor_x = fx
                 self._cursor_y = fy
                 self._velocity = math.hypot(vx, vy)
-        _ = self._update_hover_tracker()
+        info = self._update_hover_tracker()
+        hover_changed = info != self._last_sent_info
+        self._last_sent_info = info
+        self._handle_hover(hover_changed, info)
         if self.update_state is UpdateState.IDLE:
             self.update_state = UpdateState.PENDING
             self.after_idle(self._process_update)
@@ -1569,7 +1573,6 @@ class ClickOverlay(tk.Toplevel):
         if "label_pos" in updates:
             self._buffer["label_pos"] = updates["label_pos"]
         self._buffer["pid"] = info.pid
-        self._handle_hover(hover_changed)
 
     def _draw_crosshair(
         self,
@@ -1627,13 +1630,16 @@ class ClickOverlay(tk.Toplevel):
         hover_changed = text_changed or info.pid != self._buffer["pid"]
         return rect, text, window_changed, hover_changed
 
-    def _handle_hover(self, hover_changed: bool) -> None:
+    def _handle_hover(self, hover_changed: bool, info: WindowInfo | None) -> None:
         """Invoke the hover callback when the target window changes."""
-        if hover_changed and self.on_hover is not None:
-            try:
-                self.on_hover(self.pid, self.title_text)
-            except Exception:
-                pass
+        if not hover_changed or self.on_hover is None:
+            return
+        pid = None if info is None else info.pid
+        title = None if info is None else getattr(info, "title", None)
+        try:
+            self.on_hover(pid, title)
+        except Exception:
+            pass
 
     def _stable_info(self) -> WindowInfo | None:
         """Return a best guess based solely on recent hover history."""
@@ -1768,6 +1774,7 @@ class ClickOverlay(tk.Toplevel):
         self._last_info = None
         with self._state_lock:
             self._cached_info = None
+        self._last_sent_info = None
         self._hover.reset()
         self._path_history.clear()
         self._point_cache.clear()

--- a/src/views/force_quit_dialog.py
+++ b/src/views/force_quit_dialog.py
@@ -1873,7 +1873,14 @@ class ForceQuitDialog(BaseDialog):
         """Highlight ``pid`` in the process list while the overlay is active."""
         if not hasattr(self, "tree"):
             return
-        if pid is None or not self.tree.exists(str(pid)):
+        if pid is None:
+            if time.monotonic() - getattr(self, "_last_hover_ts", 0) < 0.12:
+                return
+            self.tree.selection_remove(self.tree.selection())
+            self._set_hover_row(None)
+            return
+        self._last_hover_ts = time.monotonic()
+        if not self.tree.exists(str(pid)):
             self.tree.selection_remove(self.tree.selection())
             self._set_hover_row(None)
             return

--- a/tests/test_click_overlay.py
+++ b/tests/test_click_overlay.py
@@ -2752,7 +2752,7 @@ def test_update_rect_skips_small_move_no_window_change() -> None:
         def _apply_updates(self, updates: dict[str, tuple[int, ...] | str]) -> None:
             self._applied = True
 
-        def _handle_hover(self, _hc: bool) -> None:  # pragma: no cover - dummy
+        def _handle_hover(self, _hc: bool, _info=None) -> None:  # pragma: no cover - dummy
             pass
 
     d = Dummy()
@@ -2810,7 +2810,7 @@ def test_update_rect_handles_missing_last_cursor() -> None:
         def _apply_updates(self, updates: dict[str, tuple[int, ...] | str]) -> None:
             self._applied = True
 
-        def _handle_hover(self, _hc: bool) -> None:  # pragma: no cover - dummy
+        def _handle_hover(self, _hc: bool, _info=None) -> None:  # pragma: no cover - dummy
             pass
 
     d = Dummy()


### PR DESCRIPTION
## Summary
- forward stable WindowInfo to Force Quit overlay hover callback
- persist last stable window to avoid transient deselection
- add hover grace period before clearing selection

## Testing
- `pytest tests/test_hover_tracker.py`
- `pytest tests/test_click_overlay.py::TestClickOverlay::test_queue_update_records_coordinates` (skipped: No display available)
- `pytest tests/test_force_quit_highlight.py`
- `pytest` *(fails: terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b67ca8a88325895ebf7be0673e98