### PR TITLE
Fix hover callback to use stable window info

### DIFF
--- a/src/utils/hover_tracker.py
+++ b/src/utils/hover_tracker.py
@@ -18,6 +18,7 @@ class HoverTracker:
         self._current_streak: int = 0
         self._hover_start = time.monotonic()
         self._last_pid: int | None = None
+        self._last_emitted: WindowInfo | None = None
 
     # Public accessors -------------------------------------------------
     @property
@@ -87,15 +88,20 @@ class HoverTracker:
     def stable_info(self, velocity: float) -> WindowInfo | None:
         """Return a best-guess ``WindowInfo`` based on recent history."""
         if not self._pid_stability:
-            return None
+            return self._last_emitted
         pid, count = max(self._pid_stability.items(), key=lambda i: i[1])
         threshold = tuning.stability_threshold + int(velocity * tuning.vel_stab_scale)
-        if count < threshold:
-            return None
+        chosen: WindowInfo | None = None
         for info in reversed(self._info_history):
             if info.pid == pid:
-                return info
-        return WindowInfo(pid)
+                chosen = info
+                break
+        if chosen is None:
+            chosen = WindowInfo(pid)
+        if count < threshold:
+            return self._last_emitted or None
+        self._last_emitted = chosen
+        return chosen
 
     def reset(self) -> None:
         """Clear all runtime state."""

--- a/src/views/force_quit_dialog.py
+++ b/src/views/force_quit_dialog.py
@@ -1873,7 +1873,14 @@ class ForceQuitDialog(BaseDialog):
         """Highlight ``pid`` in the process list while the overlay is active."""
         if not hasattr(self, "tree"):
             return
-        if pid is None or not self.tree.exists(str(pid)):
+        if pid is None:
+            if time.monotonic() - getattr(self, "_last_hover_ts", 0) < 0.12:
+                return
+            self.tree.selection_remove(self.tree.selection())
+            self._set_hover_row(None)
+            return
+        self._last_hover_ts = time.monotonic()
+        if not self.tree.exists(str(pid)):
             self.tree.selection_remove(self.tree.selection())
             self._set_hover_row(None)
             return

--- a/tests/test_click_overlay.py
+++ b/tests/test_click_overlay.py
@@ -2290,9 +2290,7 @@ class TestClickOverlay(unittest.TestCase):
                 root, on_hover=lambda pid, title: calls.append((pid, title))
             )
 
-        overlay._cursor_x = 1
-        overlay._cursor_y = 1
-        overlay._update_rect(WindowInfo(5, (0, 0, 5, 5), "foo"))
+        overlay._handle_hover(True, WindowInfo(5, (0, 0, 5, 5), "foo"))
 
         self.assertIn((5, "foo"), calls)
 
@@ -2308,13 +2306,9 @@ class TestClickOverlay(unittest.TestCase):
                 root, on_hover=lambda pid, title: calls.append((pid, title))
             )
 
-        overlay._cursor_x = 1
-        overlay._cursor_y = 1
         info = WindowInfo(5, (0, 0, 5, 5), "foo")
-        overlay._update_rect(info)
-        overlay._cursor_x = 2
-        overlay._cursor_y = 2
-        overlay._update_rect(info)
+        overlay._handle_hover(True, info)
+        overlay._handle_hover(False, info)
 
         self.assertEqual(calls, [(5, "foo")])
 
@@ -2752,7 +2746,7 @@ def test_update_rect_skips_small_move_no_window_change() -> None:
         def _apply_updates(self, updates: dict[str, tuple[int, ...] | str]) -> None:
             self._applied = True
 
-        def _handle_hover(self, _hc: bool) -> None:  # pragma: no cover - dummy
+        def _handle_hover(self, _hc: bool, _info: click_overlay.WindowInfo | None) -> None:  # pragma: no cover - dummy
             pass
 
     d = Dummy()
@@ -2810,7 +2804,7 @@ def test_update_rect_handles_missing_last_cursor() -> None:
         def _apply_updates(self, updates: dict[str, tuple[int, ...] | str]) -> None:
             self._applied = True
 
-        def _handle_hover(self, _hc: bool) -> None:  # pragma: no cover - dummy
+        def _handle_hover(self, _hc: bool, _info: click_overlay.WindowInfo | None) -> None:  # pragma: no cover - dummy
             pass
 
     d = Dummy()


### PR DESCRIPTION
## Summary
- forward stable `WindowInfo` from overlay to hover callback
- keep last stable hover selection to avoid jitter
- ignore transient `None` hover readings when highlighting

## Testing
- `pytest tests/test_hover_tracker.py tests/test_click_overlay.py tests/test_force_quit_highlight.py -q`
- `pytest -q` *(fails: Terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b67ca8a88325895ebf7be0673e98