### PR TITLE
Fix click-to-kill window selection

### DIFF
--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -23,7 +23,6 @@ import psutil
 from PIL import Image, ImageTk
 from src.utils.window_utils import (
     get_active_window,
-    get_window_at,
     get_window_under_cursor,
     list_windows_at,
     make_window_clickthrough,
@@ -1649,7 +1648,8 @@ class ClickOverlay(tk.Toplevel):
 
     def _confirm_window(self) -> WindowInfo:
         """Re-query the click location after the overlay closes."""
-        info = get_window_at(int(self._click_x), int(self._click_y))
+        wins = list_windows_at(int(self._click_x), int(self._click_y))
+        info = wins[0] if wins else WindowInfo(None)
         self.engine.tracker.add(info, self._initial_active_pid)
         return info
 

--- a/tests/test_click_overlay.py
+++ b/tests/test_click_overlay.py
@@ -2123,6 +2123,31 @@ class TestClickOverlay(unittest.TestCase):
         root.destroy()
 
     @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
+    def test_confirm_prefers_front_window(self) -> None:
+        root = tk.Tk()
+        with patch("src.views.click_overlay.is_supported", return_value=False):
+            overlay = ClickOverlay(root)
+
+        overlay._click_x = 5
+        overlay._click_y = 5
+        front = WindowInfo(1, (0, 0, 10, 10), "front")
+        back = WindowInfo(2, (0, 0, 10, 10), "back")
+
+        with (
+            patch.object(overlay, "_query_window_at", return_value=front),
+            patch("src.views.click_overlay.list_windows_at", return_value=[front, back]),
+            patch("src.views.click_overlay.get_window_at", return_value=back, create=True),
+            patch("src.utils.scoring_engine.tuning.confirm_weight", 5.0),
+        ):
+            overlay.close = lambda _e=None: None
+            overlay._on_click()
+
+        self.assertEqual(overlay.pid, 1)
+
+        overlay.destroy()
+        root.destroy()
+
+    @unittest.skipIf(os.environ.get("DISPLAY") is None, "No display available")
     def test_gaze_duration_tracks_hover(self) -> None:
         root = tk.Tk()
         with patch("src.views.click_overlay.is_supported", return_value=False):

--- a/tests/test_window_utils.py
+++ b/tests/test_window_utils.py
@@ -187,6 +187,17 @@ class TestWindowUtils(unittest.TestCase):
             self.assertIsInstance(info, WindowInfo)
             self.assertTrue(hasattr(info, "handle"))
 
+    def test_list_windows_at_ignores_misreported_front(self):
+        from src.utils import window_utils as wu
+
+        front = WindowInfo(1, (0, 0, 10, 10), "front", 1)
+        back = WindowInfo(2, (0, 0, 10, 10), "back", 2)
+        with (
+            mock.patch.object(wu, "_fallback_list_windows_at", return_value=[front, back]),
+            mock.patch.object(wu, "get_window_at", return_value=back),
+        ):
+            self.assertEqual(wu.list_windows_at(0, 0), [front, back])
+
     def test_list_windows_fast_path(self):
         from src.utils import window_utils as wu
 


### PR DESCRIPTION
## Summary
- ensure window enumeration is used before WindowFromPoint so click-to-kill targets the frontmost window
- confirm click selection using stacked windows
- add regression tests for window ordering and selection

## Testing
- `pytest >/tmp/unit.log && tail -n 20 /tmp/unit.log` *(fails: process terminated)*
- `pytest tests/test_window_utils.py::TestWindowUtils::test_list_windows_at_ignores_misreported_front tests/test_click_overlay.py::TestClickOverlay::test_confirm_prefers_front_window -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5bd5297ec8325935c61db7fc896f6