### PR TITLE
Requery click overlay when cursor moves off target

### DIFF
--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -1535,6 +1535,19 @@ class ClickOverlay(tk.Toplevel):
             if self._query_future is None:
                 self._query_window_async(self._update_rect)
             info = self._last_info or self._active_window or WindowInfo(None)
+        px = int(self._cursor_x)
+        py = int(self._cursor_y)
+        if (
+            info.pid not in (self._own_pid, None)
+            and info.rect
+            and not (
+                info.rect[0] <= px < info.rect[0] + info.rect[2]
+                and info.rect[1] <= py < info.rect[1] + info.rect[3]
+            )
+        ):
+            if self._query_future is None:
+                self._query_window_async(self._update_rect)
+            info = self._last_info or WindowInfo(None)
         self.pid = info.pid
         self.title_text = info.title
 
@@ -1543,8 +1556,6 @@ class ClickOverlay(tk.Toplevel):
         self._last_sent_info = stable
         self._handle_hover(stable_changed, stable)
 
-        px = int(self._cursor_x)
-        py = int(self._cursor_y)
         sw = self._screen_w
         sh = self._screen_h
         last = self._buffer.get("cursor")

--- a/tests/test_click_overlay.py
+++ b/tests/test_click_overlay.py
@@ -2848,5 +2848,68 @@ def test_update_rect_handles_missing_last_cursor() -> None:
     assert d._buffer["cursor"] == (5, 7)
 
 
+def test_update_rect_requeries_on_mismatch() -> None:
+    os.environ["COOLBOX_LIGHTWEIGHT"] = "1"
+    from src.views import click_overlay
+
+    class Dummy:
+        def __init__(self) -> None:
+            self._cursor_x = 50
+            self._cursor_y = 50
+            self._screen_w = 100
+            self._screen_h = 100
+            self.show_crosshair = False
+            self.show_label = False
+            self.hline = self.vline = self.rect = self.label = None
+            self._buffer = {
+                "cursor": (0, 0),
+                "rect": (0, 0, 10, 10),
+                "label_text": "",
+                "label_pos": (0, 0),
+                "pid": None,
+                "hline": (0, 0, 0, 0),
+                "vline": (0, 0, 0, 0),
+                "screen": (100, 100),
+            }
+            self._min_move_px = 0
+            self._last_info = None
+            self._active_window = click_overlay.WindowInfo(None)
+            self._query_future = None
+            self._own_pid = None
+            self.pid = None
+            self.title_text = ""
+            self._queried = False
+            self._update_rect = lambda info=None: None
+            self._last_sent_info = None
+            self.icon_item = None
+
+        def _draw_crosshair(self, updates, px, py, sw, sh, cursor_changed):
+            pass
+
+        def _update_label(self, info, updates):
+            return self._buffer["rect"], "", False, False
+
+        def _calc_label_pos(self, px, py, sw, sh):
+            return (0, 0)
+
+        def _apply_updates(self, updates):
+            pass
+
+        def _handle_hover(self, _hc, _info=None):
+            pass
+
+        def _update_hover_tracker(self, info):
+            return info
+
+        def _query_window_async(self, cb):
+            self._queried = True
+
+    d = Dummy()
+    info = click_overlay.WindowInfo(123, (0, 0, 10, 10), "win")
+    click_overlay.ClickOverlay._update_rect(d, info)
+    assert d._queried
+    assert d.pid is None
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- ensure click overlay re-queries window when cursor leaves previously sampled area
- add regression test for overlay re-query behavior

## Testing
- `pytest tests/test_click_overlay.py::test_update_rect_requeries_on_mismatch -q`
- `pytest` *(fails: terminated)*
- `flake8 src/views/click_overlay.py tests/test_click_overlay.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5c425501c832589d4386634b7bb59