### PR TITLE
Ensure click overlay hover uses current window

### DIFF
--- a/src/views/click_overlay.py
+++ b/src/views/click_overlay.py
@@ -1216,7 +1216,10 @@ class ClickOverlay(tk.Toplevel):
             self._track_async(info)
         elif info.pid is None:
             self._last_info = None
-        return self._hover.stable_info(self._velocity)
+        stable = self._hover.stable_info(self._velocity)
+        if stable is None and info.pid not in (self._own_pid, None):
+            stable = info
+        return stable
 
     def _next_delay(self) -> int:
         """Return the delay in milliseconds until the next update."""

--- a/tests/test_click_overlay.py
+++ b/tests/test_click_overlay.py
@@ -2848,5 +2848,24 @@ def test_update_rect_handles_missing_last_cursor() -> None:
     assert d._buffer["cursor"] == (5, 7)
 
 
+def test_update_hover_tracker_returns_info_when_unstable() -> None:
+    os.environ["COOLBOX_LIGHTWEIGHT"] = "1"
+    from src.views import click_overlay
+
+    overlay = click_overlay.ClickOverlay.__new__(click_overlay.ClickOverlay, None)
+    overlay._hover = click_overlay.HoverTracker()
+    overlay._own_pid = 999
+    overlay._last_info = None
+    overlay._track_async = Mock()
+    overlay._velocity = 0.0
+
+    info = click_overlay.WindowInfo(123, (0, 0, 10, 10), "win")
+
+    with patch.object(overlay._hover, "stable_info", return_value=None):
+        result = click_overlay.ClickOverlay._update_hover_tracker(overlay, info)
+
+    assert result == info
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- fix hover tracking so click overlay reports the window under the cursor when no stable target exists
- add regression test for hover tracker fallback

## Testing
- `pytest tests/test_click_overlay.py::test_update_hover_tracker_returns_info_when_unstable tests/test_kill_by_click.py::test_kill_by_click_selects_and_kills_pid -q`

------
https://chatgpt.com/codex/tasks/task_e_68a5c425501c832589d4386634b7bb59