### PR TITLE
Improve error logging details

### DIFF
--- a/tests/test_error_handler.py
+++ b/tests/test_error_handler.py
@@ -1,4 +1,5 @@
 import os
+import re
 import sys
 import threading
 import warnings
@@ -32,6 +33,9 @@ def test_warning_and_unraisable_capture(tmp_path, monkeypatch):
 
     warnings.warn("be careful", UserWarning)
     assert any("be careful" in w for w in eh.RECENT_WARNINGS)
+    warning_entry = eh.RECENT_WARNINGS[-1]
+    assert "test_error_handler.py" in warning_entry
+    assert re.search(r"\d{4}-\d{2}-\d{2}", warning_entry)
 
     info = SimpleNamespace(
         exc_type=RuntimeError,
@@ -42,6 +46,8 @@ def test_warning_and_unraisable_capture(tmp_path, monkeypatch):
     )
     sys.unraisablehook(info)
     assert any("boom" in e for e in eh.RECENT_ERRORS)
+    error_entry = eh.RECENT_ERRORS[-1]
+    assert re.search(r"\d{4}-\d{2}-\d{2}", error_entry)
 
 
 def test_handle_exception_uses_dialog(monkeypatch):


### PR DESCRIPTION
## Summary
- enrich error handler to log filename, line number, and timestamp for exceptions and warnings
- tighten error-handler tests to check recorded metadata

## Testing
- `pytest tests/test_error_handler.py -q`
- `pytest -q` *(fails: Terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68a8065317f48325995a0a497d2f2517