### PR TITLE
feat: enhance error reporting

### DIFF
--- a/src/app/error_handler.py
+++ b/src/app/error_handler.py
@@ -8,6 +8,7 @@ import threading
 import traceback
 import warnings
 import webbrowser
+from datetime import datetime
 from pathlib import Path
 from typing import Type
 
@@ -160,20 +161,29 @@ def handle_exception(exc: Type[BaseException], value: BaseException, tb) -> None
     """Log *value* with traceback and show a friendly error dialog.
 
     This function is used for ``sys.excepthook`` and Tk's
-    ``report_callback_exception`` so any uncaught exceptions are routed here.
-    """
-    logger.error("Unhandled exception", exc_info=(exc, value, tb))
+    ``report_callback_exception`` so any uncaught exceptions are routed here."""
+
+    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    if tb is not None:
+        last = traceback.extract_tb(tb)[-1]
+        location = f"{last.filename}:{last.lineno} in {last.name}"
+    else:  # pragma: no cover - extremely rare
+        location = "unknown location"
+
+    if isinstance(value, IOError):
+        base_msg = f"An I/O error occurred: {value}"
+    elif isinstance(value, ValueError):
+        base_msg = f"Invalid value: {value}"
+    else:
+        base_msg = str(value)
+
+    msg = f"{timestamp} | {exc.__name__} at {location}: {base_msg}"
+
+    logger.error(msg, exc_info=(exc, value, tb))
 
     tb_str = "".join(traceback.format_exception(exc, value, tb))
     context = _collect_context()
-    _record(RECENT_ERRORS, f"{exc.__name__}:{value}\n{context}\n{tb_str}")
-
-    if isinstance(value, IOError):
-        msg = f"An I/O error occurred: {value}"
-    elif isinstance(value, ValueError):
-        msg = f"Invalid value: {value}"
-    else:
-        msg = str(value)
+    _record(RECENT_ERRORS, f"{msg}\n{context}\n{tb_str}")
 
     _show_error_dialog(msg, tb_str)
 
@@ -193,7 +203,8 @@ def install(window=None) -> None:
     sys.unraisablehook = _unraisable_hook
 
     def _showwarning(message, category, filename, lineno, file=None, line=None):
-        text = f"{filename}:{lineno}:{category.__name__}:{message}"
+        ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        text = f"{ts} | {filename}:{lineno}:{category.__name__}:{message}"
         logger.warning(text)
         _record(RECENT_WARNINGS, text)
 


### PR DESCRIPTION
## Summary
- include timestamp, file, and function info in the global error handler
- record warning details with timestamp for better diagnostics

## Testing
- `pytest -q` *(fails: terminated early)*
- `pytest tests/test_error_handler.py tests/test_security_error_logging.py -q`
- `flake8 src/app/error_handler.py`


------
https://chatgpt.com/codex/tasks/task_e_68a808a2478c83259097f7a2730384cb