### PR TITLE
feat: enrich error details

### DIFF
--- a/src/app/error_handler.py
+++ b/src/app/error_handler.py
@@ -193,7 +193,17 @@ def handle_exception(exc: Type[BaseException], value: BaseException, tb) -> None
         desc = str(value)
 
     msg = f"{desc} (at {location} on {timestamp})"
-    _show_error_dialog(msg, tb_str)
+    details_lines = [
+        f"Exception: {exc.__name__}",
+        f"Message: {value}",
+        f"Location: {location}",
+        f"Time: {timestamp}",
+        f"Context: {context}",
+        "Traceback:",
+        tb_str,
+    ]
+    formatted_details = "\n".join(details_lines)
+    _show_error_dialog(msg, formatted_details)
 
 
 def install(window=None) -> None:

--- a/tests/test_error_handler.py
+++ b/tests/test_error_handler.py
@@ -62,4 +62,6 @@ def test_handle_exception_uses_dialog(monkeypatch):
 
     assert "kaboom" in called["msg"]
     assert "RuntimeError" in called["details"]
+    assert "Location:" in called["details"]
+    assert "Traceback:" in called["details"]
 


### PR DESCRIPTION
## Summary
- expand error handler details with exception, location, context, and traceback
- verify dialog formatting to include location and traceback

## Testing
- `pytest tests/test_error_handler.py tests/test_security_error_logging.py`


------
https://chatgpt.com/codex/tasks/task_e_68a80ae72fd08325a5c03a336525fdfe