### PR TITLE
Enhance project problem scanning and summary

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -786,13 +786,22 @@ def clean_pyc() -> None:
 def collect_problems(
     output: Path | None = None, markers: Sequence[str] | None = None
 ) -> None:
-    """Scan project files for common problem markers.
+    """Scan project files for common problem markers and record them.
 
-    By default this searches for TODO, FIXME, BUG and WARNING comments, but a
-    custom list of *markers* can be provided.
+    The scan walks the project directory and looks for comment markers such as
+    ``TODO`` or ``FIXME`` as well as calls to ``warnings.warn``.  Matches are
+    added to the run :class:`RunSummary` so they are displayed in the final
+    summary.  A custom list of ``markers`` may be provided to override the
+    defaults.
     """
 
-    markers = [m.strip() for m in (markers or ["TODO", "FIXME", "BUG", "WARNING"])]
+    markers = [
+        m.strip()
+        for m in (
+            markers
+            or ["TODO", "FIXME", "BUG", "WARNING", "warnings.warn"]
+        )
+    ]
     pattern = "|".join(re.escape(m) for m in markers)
     problem_re = re.compile(f"({pattern})", re.IGNORECASE)
     ignore_dirs = {".git", ".venv", "venv", "__pycache__"}
@@ -822,22 +831,25 @@ def collect_problems(
 
     matches.sort()
 
+    if matches:
+        for f, n, t in matches:
+            SUMMARY.add_warning(f"{f}:{n}: {t}")
+    else:
+        log("No problem markers found.")
+
     if output:
         output.write_text("\n".join(f"{f}:{n}: {t}" for f, n, t in matches))
         log(f"Wrote {len(matches)} problem lines to {output}")
+    elif RICH_AVAILABLE:
+        table = Table(box=box.SIMPLE_HEAVY)
+        table.add_column("File", overflow="fold")
+        table.add_column("Line", justify="right")
+        table.add_column("Text")
+        for f, n, t in matches:
+            table.add_row(f, str(n), t)
+        console.print(Panel(table, title=f"Problems ({len(matches)})", box=box.ROUNDED))
     else:
-        if RICH_AVAILABLE:
-            table = Table(box=box.SIMPLE_HEAVY)
-            table.add_column("File", overflow="fold")
-            table.add_column("Line", justify="right")
-            table.add_column("Text")
-            for f, n, t in matches:
-                table.add_row(f, str(n), t)
-            console.print(Panel(table, title=f"Problems ({len(matches)})", box=box.ROUNDED))
-        else:
-            for f, n, t in matches:
-                log(f"{f}:{n}: {t}")
-            log(f"Found {len(matches)} problem lines.")
+        log(f"Found {len(matches)} problem lines.")
 
 
 def _build_install_plan(req_path: Path, dev: bool, upgrade: bool) -> list[tuple[str, list[str], bool]]:

--- a/tests/test_collect_problems_summary.py
+++ b/tests/test_collect_problems_summary.py
@@ -1,0 +1,15 @@
+import setup
+from pathlib import Path
+
+
+def test_collect_problems_records_in_summary():
+    test_file = setup.ROOT_DIR / "temp_problem.txt"
+    test_file.write_text("FOOBAR_MARKER\n")
+    try:
+        setup.SUMMARY.warnings.clear()
+        setup.collect_problems(markers=["FOOBAR_MARKER"])
+        assert any("temp_problem.txt:1" in w for w in setup.SUMMARY.warnings)
+    finally:
+        if test_file.exists():
+            test_file.unlink()
+        setup.SUMMARY.warnings.clear()


### PR DESCRIPTION
## Summary
- extend `collect_problems` to scan for `warnings.warn` calls and record issues in run summary
- add test ensuring problem scan results populate summary

## Testing
- `pytest tests/test_collect_problems_summary.py -q`
- `pytest` *(fails: Terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68a811d920248325beed1834ecf7d19c