### PR TITLE
Show total problem count in problem scanner

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -839,11 +839,17 @@ def collect_problems(
             table.add_column("Text")
             for f, n, t in matches:
                 table.add_row(f, str(n), t)
-            console.print(Panel(table, title=f"Problems ({len(matches)})", box=box.ROUNDED))
+            panel = Panel(
+                table,
+                title="Problems",
+                subtitle=f"Total problems: {len(matches)}",
+                box=box.ROUNDED,
+            )
+            console.print(panel)
         else:
             for f, n, t in matches:
                 log(f"{f}:{n}: {t}")
-            log(f"Found {len(matches)} problem lines.")
+            log(f"Total problems: {len(matches)}")
 
 
 def _build_install_plan(req_path: Path, dev: bool, upgrade: bool) -> list[tuple[str, list[str], bool]]:

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -122,3 +122,19 @@ def test_config_file_overrides(monkeypatch, tmp_path):
     import importlib
     importlib.reload(setup)
     assert setup.CONFIG.no_anim is True
+
+
+def test_collect_problems_reports_total(monkeypatch, tmp_path):
+    (tmp_path / "sample.py").write_text("# TODO: fix\n")
+    monkeypatch.setattr(setup, "ROOT_DIR", tmp_path)
+    monkeypatch.setattr(setup, "RICH_AVAILABLE", True)
+    from io import StringIO
+    from rich.console import Console
+
+    buf = StringIO()
+    cap_console = Console(file=buf, force_terminal=True, color_system=None, width=80)
+    monkeypatch.setattr(setup, "console", cap_console)
+    setup.SUMMARY.warnings.clear()
+    setup.collect_problems()
+    output = buf.getvalue()
+    assert "Total problems: 1" in output


### PR DESCRIPTION
## Summary
- Display total problem count at bottom of `collect_problems` output via panel subtitle for clearer visibility.
- Log total problem count when Rich isn't available.
- Add regression test ensuring the problem scanner reports total count.

## Testing
- ⚠️ `pytest -q` *(terminated early)*
- ✅ `pytest tests/test_setup.py::test_collect_problems_reports_total -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8149320748325bd6256f7ee5f04b9