### PR TITLE
Show total problem count

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -823,6 +823,7 @@ def collect_problems(
             matches.extend(res)
 
     matches.sort()
+    total_files = len({f for f, _, _ in matches})
 
     # Record all problem lines in the run summary for later display.
     for f, n, t in matches:
@@ -840,10 +841,12 @@ def collect_problems(
             for f, n, t in matches:
                 table.add_row(f, str(n), t)
             console.print(Panel(table, title=f"Problems ({len(matches)})", box=box.ROUNDED))
+            console.print(f"[bold]Total problems: {len(matches)} across {total_files} files[/]")
         else:
             for f, n, t in matches:
                 log(f"{f}:{n}: {t}")
-            log(f"Found {len(matches)} problem lines.")
+        if not RICH_AVAILABLE:
+            log(f"Total problems: {len(matches)} across {total_files} files")
 
 
 def _build_install_plan(req_path: Path, dev: bool, upgrade: bool) -> list[tuple[str, list[str], bool]]:


### PR DESCRIPTION
## Summary
- Show total problem count and affected file count after problem scan output

## Testing
- `python - <<'PY'
from setup import collect_problems
collect_problems()
PY`
- `pytest` *(fails: terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68a8149320748325bd6256f7ee5f04b9