### PR TITLE
feat: show total problems summary

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -500,6 +500,10 @@ class RunSummary:
         for e in self.errors:
             table.add_row("[red]Error[/]", e)
         console.print(Panel(table, title="Summary", box=box.ROUNDED))
+        total = len(self.warnings) + len(self.errors)
+        console.print(
+            f"[bold]Total problems: {total} (Warnings: {len(self.warnings)}, Errors: {len(self.errors)})[/]"
+        )
 
 
 SUMMARY = RunSummary()


### PR DESCRIPTION
## Summary
- display total problems after warnings and errors in run summary

## Testing
- `pytest -q` *(fails: terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68a8166d4b1c83258c2e6abdf2b47ef2