### PR TITLE
Handle problem scan for binaries and fix spinner column

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -296,6 +296,7 @@ class RainbowSpinnerColumn(ProgressColumn):
     """Spinner that cycles through a rainbow of colors."""
 
     def __init__(self, frames: str = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏", colors: Sequence[str] | None = None):
+        super().__init__()
         self.frames = frames
         self.colors = list(colors or RAINBOW_COLORS)
         self._index = 0
@@ -792,21 +793,38 @@ def collect_problems(
 ) -> None:
     """Scan project files for common problem markers.
 
-    By default this searches for ``TODO``, ``FIXME``, ``BUG`` and ``WARNING``
+    By default this searches for ``TODO``, ``FIXME`` and ``BUG``
     comments across the repository.  All matches are appended to the global
     ``SUMMARY`` so they are displayed in the final run report.  A custom list of
     *markers* can be provided via ``markers``.
     """
 
-    markers = [m.strip() for m in (markers or ["TODO", "FIXME", "BUG", "WARNING"])]
+    markers = [m.strip() for m in (markers or ["TODO", "FIXME", "BUG"])]
     pattern = "|".join(re.escape(m) for m in markers)
     problem_re = re.compile(f"({pattern})", re.IGNORECASE)
     ignore_dirs = {".git", ".venv", "venv", "__pycache__"}
 
+    def _is_text_file(path: Path) -> bool:
+        try:
+            with path.open("rb") as fh:
+                chunk = fh.read(1024)
+            if b"\0" in chunk:
+                return False
+            chunk.decode("utf-8")
+            return True
+        except Exception:
+            return False
+
+    current_file = Path(__file__).resolve()
     files = [
         p
         for p in ROOT_DIR.rglob("*")
-        if p.is_file() and not any(part in ignore_dirs for part in p.parts)
+        if (
+            p.is_file()
+            and p.resolve() != current_file
+            and not any(part in ignore_dirs for part in p.parts)
+            and _is_text_file(p)
+        )
     ]
 
     def _scan(path: Path) -> list[tuple[str, int, str]]:
@@ -1005,7 +1023,7 @@ def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
         "--markers",
         type=str,
         default=None,
-        help="Comma separated markers (default: TODO,FIXME,BUG,WARNING)",
+        help="Comma separated markers (default: TODO,FIXME,BUG)",
     )
 
     p_test = sub.add_parser("test", help="Run pytest")


### PR DESCRIPTION
## Summary
- skip binary assets when scanning for TODO/FIXME markers and drop WARNING from defaults
- initialize RainbowSpinnerColumn correctly to avoid missing _table_column error
- update CLI help to reflect new marker defaults

## Testing
- `python setup.py problems`
- `pytest -q` *(fails: Terminated)*
- `pytest tests/test_rainbow.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a831cceb008325a6d941af0f705a7f