### PR TITLE
feat: add error trap for setup script

### DIFF
--- a/scripts/setup_dev_env.sh
+++ b/scripts/setup_dev_env.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
+
+trap 'echo "Error on line $LINENO: $BASH_COMMAND" >&2' ERR
 python3 -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- improve setup script by failing explicitly on errors

## Testing
- `pytest` *(fails: Terminated)*
- `pytest tests/test_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8338471a483259c7e928eeec9c138