### PR TITLE
Prevent setup hang from RainbowBorder thread

### DIFF
--- a/src/utils/rainbow.py
+++ b/src/utils/rainbow.py
@@ -157,7 +157,10 @@ class RainbowBorder:
     def stop(self) -> None:
         self._stop.set()
         if self._thread is not None:
-            self._thread.join()
+            # Joining without a timeout can hang the main thread if the
+            # animation thread misbehaves.  Use a small timeout so setup
+            # never gets stuck waiting for the rainbow border to finish.
+            self._thread.join(timeout=1.0)
             self._thread = None
             self._clear()
             with _console_lock_ctx(self.console):


### PR DESCRIPTION
## Summary
- avoid blocking when stopping the RainbowBorder animation by joining with a timeout

## Testing
- `pytest tests/test_rainbow.py tests/test_setup.py tests/test_auto_setup.py`
- `pytest` *(fails: Terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68a834f4a84083258e7c3b6922c566dd