### PR TITLE
Initialize RainbowSpinnerColumn to avoid AttributeError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -296,6 +296,12 @@ class RainbowSpinnerColumn(ProgressColumn):
     """Spinner that cycles through a rainbow of colors."""
 
     def __init__(self, frames: str = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏", colors: Sequence[str] | None = None):
+        # Ensure ProgressColumn is initialised so Rich can access internal
+        # attributes such as ``_table_column``. Rich 14+ requires custom
+        # progress columns to call ``super().__init__`` to set these up
+        # correctly, otherwise an ``AttributeError`` is raised during
+        # rendering.
+        super().__init__()
         self.frames = frames
         self.colors = list(colors or RAINBOW_COLORS)
         self._index = 0


### PR DESCRIPTION
## Summary
- fix custom RainbowSpinnerColumn to call `ProgressColumn` constructor

## Testing
- `pytest` *(fails: terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68a83be87300832583b22e225cf13b9e