### PR TITLE
Fix RainbowSpinnerColumn initialization

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -296,6 +296,8 @@ class RainbowSpinnerColumn(ProgressColumn):
     """Spinner that cycles through a rainbow of colors."""
 
     def __init__(self, frames: str = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏", colors: Sequence[str] | None = None):
+        """Initialize the spinner and ensure base class setup runs."""
+        super().__init__()
         self.frames = frames
         self.colors = list(colors or RAINBOW_COLORS)
         self._index = 0

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -122,3 +122,10 @@ def test_config_file_overrides(monkeypatch, tmp_path):
     import importlib
     importlib.reload(setup)
     assert setup.CONFIG.no_anim is True
+
+
+def test_progress_spinner():
+    """Ensure the progress helper constructs without errors."""
+    with setup._progress() as prog:
+        task = prog.add_task("demo", total=1)
+        prog.advance(task)


### PR DESCRIPTION
## Summary
- initialize custom progress column with superclass constructor to avoid missing attribute
- add regression test verifying progress spinner works

## Testing
- `pytest tests/test_setup.py::test_progress_spinner -q`
- `pytest tests/test_setup.py` *(fails: Offline mode: skipping pip install pkg)*

------
https://chatgpt.com/codex/tasks/task_e_68a83de019f883258dc188f553783b0e