### PR TITLE
Fix RainbowSpinnerColumn initialization

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -295,7 +295,23 @@ def NeonPulseBorder(**kwargs):
 class RainbowSpinnerColumn(ProgressColumn):
     """Spinner that cycles through a rainbow of colors."""
 
-    def __init__(self, frames: str = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏", colors: Sequence[str] | None = None):
+    def __init__(
+        self,
+        frames: str = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏",
+        colors: Sequence[str] | None = None,
+    ):
+        """Initialize spinner without invoking ``ProgressColumn.__init__``.
+
+        ``ProgressColumn`` does some setup in ``__init__`` which isn't safe to
+        call in our environment.  We replicate the minimal attributes it
+        expects so the progress helper can operate without errors.
+        """
+        # Copied from ``ProgressColumn.__init__`` but done manually to avoid
+        # executing the base class constructor.
+        self._table_column = None
+        self._renderable_cache: dict = {}
+        self._update_time = None
+
         self.frames = frames
         self.colors = list(colors or RAINBOW_COLORS)
         self._index = 0

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -122,3 +122,16 @@ def test_config_file_overrides(monkeypatch, tmp_path):
     import importlib
     importlib.reload(setup)
     assert setup.CONFIG.no_anim is True
+
+
+def test_progress_spinner():
+    """Ensure the progress helper constructs without errors."""
+    with setup._progress() as prog:
+        task = prog.add_task("demo", total=1)
+        prog.advance(task)
+
+
+def test_rainbow_spinner_initializes_attrs():
+    col = setup.RainbowSpinnerColumn()
+    assert hasattr(col, "_table_column")
+    assert hasattr(col, "_renderable_cache")


### PR DESCRIPTION
## Summary
- avoid calling ProgressColumn.__init__ and manually set expected attributes
- add tests ensuring RainbowSpinnerColumn sets internal state

## Testing
- `pytest tests/test_setup.py::test_rainbow_spinner_initializes_attrs -q`
- `pytest tests/test_setup.py::test_progress_spinner -q`
- `pytest tests/test_setup.py -q` *(fails: Offline mode: skipping /root/.pyenv/versions/3.11.12/bin/python3.11 -m pip install pkg)*

------
https://chatgpt.com/codex/tasks/task_e_68a83de019f883258dc188f553783b0e