### PR TITLE
Fix RainbowSpinnerColumn initialization

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -296,9 +296,11 @@ class RainbowSpinnerColumn(ProgressColumn):
     """Spinner that cycles through a rainbow of colors."""
 
     def __init__(self, frames: str = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏", colors: Sequence[str] | None = None):
+        """Initialize the spinner and prepare ProgressColumn internals."""
         self.frames = frames
         self.colors = list(colors or RAINBOW_COLORS)
         self._index = 0
+        self._table_column = None  # ProgressColumn normally sets this in __init__
 
     def render(self, task):  # type: ignore[override]
         char = self.frames[self._index % len(self.frames)]

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -122,3 +122,16 @@ def test_config_file_overrides(monkeypatch, tmp_path):
     import importlib
     importlib.reload(setup)
     assert setup.CONFIG.no_anim is True
+
+
+def test_progress_spinner():
+    """Ensure the progress helper constructs without errors."""
+    with setup._progress() as prog:
+        task = prog.add_task("demo", total=1)
+        prog.advance(task)
+
+
+def test_rainbow_spinner_column_init():
+    col = setup.RainbowSpinnerColumn()
+    assert hasattr(col, "_table_column")
+    assert col._table_column is None


### PR DESCRIPTION
## Summary
- initialize RainbowSpinnerColumn without calling ProgressColumn.__init__ and set `_table_column` manually
- add unit test ensuring `_table_column` attribute exists and progress spinner works

## Testing
- `pytest tests/test_setup.py::test_progress_spinner -q`
- `pytest tests/test_setup.py::test_rainbow_spinner_column_init -q`
- `pytest tests/test_setup.py -q` *(fails: Offline mode: skipping pip install pkg)*


------
https://chatgpt.com/codex/tasks/task_e_68a83de019f883258dc188f553783b0e