### PR TITLE
Fix RainbowSpinnerColumn initialization

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -296,6 +296,11 @@ class RainbowSpinnerColumn(ProgressColumn):
     """Spinner that cycles through a rainbow of colors."""
 
     def __init__(self, frames: str = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏", colors: Sequence[str] | None = None):
+        """Initialize spinner without relying on ProgressColumn.__init__."""
+        # Manually set attributes normally configured by ProgressColumn.__init__
+        self._table_column = None
+        self._renderable_cache = {}
+        self._update_time = None
         self.frames = frames
         self.colors = list(colors or RAINBOW_COLORS)
         self._index = 0

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -122,3 +122,10 @@ def test_config_file_overrides(monkeypatch, tmp_path):
     import importlib
     importlib.reload(setup)
     assert setup.CONFIG.no_anim is True
+
+
+def test_progress_spinner():
+    """Ensure the progress helper constructs without errors."""
+    with setup._progress() as prog:
+        task = prog.add_task("demo", total=1)
+        prog.advance(task)


### PR DESCRIPTION
## Summary
- initialize RainbowSpinnerColumn attributes manually instead of invoking ProgressColumn.__init__

## Testing
- `pytest tests/test_setup.py::test_progress_spinner -q`
- `pytest tests/test_setup.py -q` *(fails: Offline mode: skipping /root/.pyenv/versions/3.11.12/bin/python3.11 -m pip install pkg)*

------
https://chatgpt.com/codex/tasks/task_e_68a83de019f883258dc188f553783b0e