### PR TITLE
Ensure error dialogs run on main thread

### DIFF
--- a/src/app/error_handler.py
+++ b/src/app/error_handler.py
@@ -210,7 +210,15 @@ def install(window=None) -> None:
     """Install global hooks so all warnings and errors are logged."""
 
     def _thread_hook(args):
-        handle_exception(args.exc_type, args.exc_value, args.exc_traceback)
+        if window is not None and hasattr(window, "after"):
+            window.after(
+                0,
+                lambda: handle_exception(
+                    args.exc_type, args.exc_value, args.exc_traceback
+                ),
+            )
+        else:
+            handle_exception(args.exc_type, args.exc_value, args.exc_traceback)
 
     def _unraisable_hook(args):
         exc = args.exc_type or type(args.exc_value)


### PR DESCRIPTION
## Summary
- fix error dialog hook to dispatch thread exceptions via the Tk window's `after`
- test that thread errors are scheduled on the main thread

## Testing
- `pytest tests/test_error_handler.py -q`
- `pytest tests/test_security_error_logging.py -q`
- `pytest -q` *(fails: Terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68a84ac57e248325b16b9d9d44011c79