### PR TITLE
Log modern error dialog failures in error handler

### DIFF
--- a/src/app/error_handler.py
+++ b/src/app/error_handler.py
@@ -94,8 +94,16 @@ def _show_error_dialog(message: str, details: str) -> None:
             if created_root:
                 root.destroy()
             return
-        except Exception:
-            pass
+        except Exception as exc:
+            # Provide visibility into why the fancy dialog failed so callers
+            # aren't left wondering what went wrong.  This is intentionally
+            # light-touch: we log the issue and continue with a simpler
+            # fallback dialog rather than raising another exception.
+            logger.warning("Modern error dialog unavailable: %s", exc, exc_info=True)
+            _record(
+                RECENT_ERRORS,
+                f"{datetime.now().isoformat()}:ModernErrorDialog:{exc}\n{traceback.format_exc()}",
+            )
 
         root = tk._default_root
         created_root = False

--- a/tests/test_error_handler.py
+++ b/tests/test_error_handler.py
@@ -3,6 +3,7 @@ import sys
 import threading
 import warnings
 from types import SimpleNamespace
+import logging
 
 import pytest
 
@@ -120,4 +121,72 @@ def test_error_dialog_creates_root_when_default_destroyed(monkeypatch):
 
     assert created["called"]
     assert new_root.destroyed
+
+
+def test_modern_dialog_failure_logs(monkeypatch, caplog):
+    """If the modern dialog fails, a warning should be logged and recorded."""
+
+    # Ensure a clean slate for recorded errors
+    eh.RECENT_ERRORS.clear()
+
+    class DeadRoot:
+        def winfo_exists(self):
+            return False
+
+        def wait_window(self, _):
+            pass
+
+    dead_root = DeadRoot()
+
+    class DummyRoot:
+        def withdraw(self):
+            pass
+
+        def wait_window(self, _):
+            pass
+
+        def destroy(self):
+            pass
+
+        def winfo_exists(self):
+            return True
+
+    new_root = DummyRoot()
+
+    def bad_ctk():
+        raise RuntimeError("boom")
+
+    ctk_mod = SimpleNamespace(CTk=bad_ctk)
+    monkeypatch.setitem(sys.modules, "customtkinter", ctk_mod)
+    monkeypatch.setitem(
+        sys.modules,
+        "src.components.modern_error_dialog",
+        SimpleNamespace(ModernErrorDialog=lambda *a, **k: None),
+    )
+
+    tk_mod = SimpleNamespace(_default_root=dead_root, Tk=lambda: new_root, Toplevel=lambda *a, **k: new_root)
+    monkeypatch.setattr(eh, "tk", tk_mod, raising=False)
+
+    class DummyWidget:
+        def pack(self, *a, **k):
+            pass
+
+        def insert(self, *a, **k):
+            pass
+
+        def configure(self, *a, **k):
+            pass
+
+        def pack_forget(self, *a, **k):
+            pass
+
+    monkeypatch.setattr(eh, "ttk", SimpleNamespace(Label=lambda *a, **k: DummyWidget(), Button=lambda *a, **k: DummyWidget()))
+    monkeypatch.setattr(eh, "scrolledtext", SimpleNamespace(ScrolledText=lambda *a, **k: DummyWidget()))
+    monkeypatch.setattr(eh, "_get_log_file", lambda: None)
+
+    caplog.set_level(logging.WARNING)
+    eh._show_error_dialog("oops", "details")
+
+    assert any("modern error dialog unavailable" in rec.message.lower() for rec in caplog.records)
+    assert any("ModernErrorDialog" in e for e in eh.RECENT_ERRORS)
 


### PR DESCRIPTION
## Summary
- log and record why the Modern error dialog fails and fall back gracefully
- cover fallback logging in a new unit test

## Testing
- `pytest tests/test_error_handler.py tests/test_security_error_logging.py -q`
- `pytest` *(fails: Terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68a84ea648448325872dbdf32297726f