### PR TITLE
Log modern error dialog failures

### DIFF
--- a/src/app/error_handler.py
+++ b/src/app/error_handler.py
@@ -94,8 +94,22 @@ def _show_error_dialog(message: str, details: str) -> None:
             if created_root:
                 root.destroy()
             return
-        except Exception:
-            pass
+        except Exception as dialog_error:
+            logger.exception("Failed to show modern error dialog")
+            try:
+                tb = "".join(
+                    traceback.format_exception(
+                        type(dialog_error), dialog_error, dialog_error.__traceback__
+                    )
+                )
+                _record(
+                    RECENT_ERRORS,
+                    f"{datetime.now().isoformat()}:DialogError:ModernErrorDialog:{dialog_error}\\n{tb}",
+                )
+            except Exception:  # pragma: no cover - best effort
+                logger.debug(
+                    "Failed to record modern dialog error", exc_info=True
+                )
 
         root = tk._default_root
         created_root = False


### PR DESCRIPTION
## Summary
- log and record failures when the modern error dialog cannot be displayed
- add regression test covering modern dialog failure logging

## Testing
- `pytest -q` *(failed: process terminated)*
- `pytest tests/test_error_handler.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a850b17b8483259f17733c6a7fd5de