### PR TITLE
Ensure tooltip cleans up scaling tracker entries

### DIFF
--- a/src/components/tooltip.py
+++ b/src/components/tooltip.py
@@ -40,9 +40,13 @@ class Tooltip(ctk.CTkToplevel):
 
     def _on_destroy(self, _event=None) -> None:
         """Remove tooltip from CustomTkinter's scaling tracker."""
-        scaling_tracker.ScalingTracker.remove_window(self._set_scaling, self)
-        scaling_tracker.ScalingTracker.window_widgets_dict.pop(self, None)
-        scaling_tracker.ScalingTracker.window_dpi_scaling_dict.pop(self, None)
+        tracker = scaling_tracker.ScalingTracker
+        # Clean up any lingering registry entries first so the scaling
+        # tracker doesn't attempt to access a missing window and raise a
+        # ``KeyError`` during its periodic DPI check.
+        tracker.window_widgets_dict.pop(self, None)
+        tracker.window_dpi_scaling_dict.pop(self, None)
+        tracker.remove_window(self._set_scaling, self)
 
     def destroy(self) -> None:  # type: ignore[override]
         """Destroy tooltip and deregister from scaling tracker."""

--- a/tests/test_tooltip_scaling_tracker.py
+++ b/tests/test_tooltip_scaling_tracker.py
@@ -16,3 +16,18 @@ def test_tooltip_registers_with_scaling_tracker() -> None:
     root.update_idletasks()
     assert tip not in scaling_tracker.ScalingTracker.window_dpi_scaling_dict
     root.destroy()
+
+
+@pytest.mark.skipif(os.environ.get("DISPLAY") is None, reason="No display available")
+def test_tooltip_cleans_up_when_parent_destroyed() -> None:
+    root = ctk.CTk()
+    tip = Tooltip(root, "bye")
+    root.update_idletasks()
+    assert tip in scaling_tracker.ScalingTracker.window_dpi_scaling_dict
+    root.destroy()
+    # process pending events, ignoring errors if the root is already gone
+    try:
+        root.update()
+    except Exception:
+        pass
+    assert tip not in scaling_tracker.ScalingTracker.window_dpi_scaling_dict


### PR DESCRIPTION
## Summary
- Prevent KeyError by cleaning up tooltip from CustomTkinter's scaling tracker before destruction
- Add regression test covering parent window destruction

## Testing
- `pytest -q` *(terminated: Terminated)*
- `pytest tests/test_tooltip_scaling_tracker.py::test_tooltip_cleans_up_when_parent_destroyed -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8528f4b5483258d85472b31bef964