### PR TITLE
Fix warning hook overridden by logging.captureWarnings

### DIFF
--- a/src/app/error_handler.py
+++ b/src/app/error_handler.py
@@ -264,8 +264,13 @@ def install(window=None) -> None:
         logger.warning(text)
         _record(RECENT_WARNINGS, text)
 
-    warnings.showwarning = _showwarning
+    # ``logging.captureWarnings(True)`` installs its own ``warnings.showwarning``
+    # handler.  If called *after* assigning our custom hook it would overwrite
+    # it, preventing warnings from being recorded.  Capture warnings first and
+    # then restore our hook so warnings are both logged and stored in
+    # ``RECENT_WARNINGS``.
     logging.captureWarnings(True)
+    warnings.showwarning = _showwarning
 
     if window is not None:
         window.report_callback_exception = handle_exception


### PR DESCRIPTION
## Summary
- Ensure error handler keeps its custom warning hook by invoking `logging.captureWarnings` before setting `warnings.showwarning`
- Record warnings properly so dialogs/logs trigger again

## Testing
- `pytest tests/test_error_handler.py::test_warning_and_unraisable_capture -q`
- `pytest tests/test_error_handler.py::test_handle_exception_uses_dialog -q`
- `pytest tests/test_tool_error_handling.py::TestToolErrorHandling::test_safe_launch_logs_warnings -q` *(skipped: No display available)*
- `pytest -q` *(terminated: environment limitation)*

------
https://chatgpt.com/codex/tasks/task_e_68a855d58818832585fb9d5948f525b4