### PR TITLE
Ensure error handler UI pump starts only after scheduling

### DIFF
--- a/src/app/error_handler.py
+++ b/src/app/error_handler.py
@@ -115,7 +115,6 @@ def _start_ui_pump(root: TkRoot) -> None:
     global _PUMP_STARTED, _root_ref
     if _PUMP_STARTED:
         return
-    _PUMP_STARTED = True
     _root_ref = weakref.ref(root)
 
     def _poll() -> None:
@@ -143,6 +142,8 @@ def _start_ui_pump(root: TkRoot) -> None:
         root.after(200, _poll)
     except Exception:
         logger.debug("Failed to start UI pump", exc_info=True)
+    else:
+        _PUMP_STARTED = True
 
 
 def _enqueue_ui(kind: str, message: str, details: str) -> None:


### PR DESCRIPTION
## Summary
- Avoid marking the error handler's UI pump as started when scheduling fails
- Prevent losing queued error dialogs when `root.after` raises

## Testing
- ⚠️ `pytest` (terminated: process killed)
- ✅ `pytest tests/test_error_handler.py -q`
- ✅ `pytest tests/test_force_quit_error.py tests/test_security_error_logging.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8618c3ca483258a182d6c6a28c45d