### PR TITLE
feat: harden error handler

### DIFF
--- a/src/app/error_handler.py
+++ b/src/app/error_handler.py
@@ -111,6 +111,31 @@ def _get_log_file() -> Path | None:
     return None
 
 
+def _fail_safe(name: str, func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+    """Execute ``func`` and ensure any failure is reported and recorded.
+
+    ``name`` is a human readable label used for logging.  If ``func`` raises an
+    exception we log the error, append a ``HandlerError`` entry to
+    ``RECENT_ERRORS`` and print a concise message to ``stderr`` so automated
+    tools or a user running headless still sees that something went wrong.
+    """
+
+    try:
+        return func(*args, **kwargs)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.exception("%s failed", name)
+        try:
+            tb = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+            _record(RECENT_ERRORS, f"{datetime.now().isoformat()}:HandlerError:{name}:{exc}\n{tb}")
+        except Exception:
+            logger.debug("Failed to record handler error", exc_info=True)
+        try:
+            sys.stderr.write(f"[CoolBox error handler] {name} failed: {exc}\n")
+        except Exception:
+            pass
+        return None
+
+
 # -------------------------------------------------------------------------------------------------
 # UI pump
 # -------------------------------------------------------------------------------------------------
@@ -264,40 +289,43 @@ def _show_error_dialog(message: str, details: str) -> None:
 # Exception handling
 # -------------------------------------------------------------------------------------------------
 def handle_exception(exc: Type[BaseException], value: BaseException, tb) -> None:
-    timestamp = datetime.now().isoformat()
-    if tb is not None:
-        last = traceback.extract_tb(tb)[-1]
-        location = f"{last.filename}:{last.lineno}"
-    else:
-        location = "unknown location"
+    def _impl() -> None:
+        timestamp = datetime.now().isoformat()
+        if tb is not None:
+            last = traceback.extract_tb(tb)[-1]
+            location = f"{last.filename}:{last.lineno}"
+        else:
+            location = "unknown location"
 
-    logger.error(
-        "Unhandled exception %s at %s on %s", exc.__name__, location, timestamp,
-        exc_info=(exc, value, tb),
-    )
+        logger.error(
+            "Unhandled exception %s at %s on %s", exc.__name__, location, timestamp,
+            exc_info=(exc, value, tb),
+        )
 
-    tb_str = "".join(traceback.format_exception(exc, value, tb))
-    context = _collect_context()
-    _record(RECENT_ERRORS, f"{timestamp}:{exc.__name__}:{location}:{value}\n{context}\n{tb_str}")
+        tb_str = "".join(traceback.format_exception(exc, value, tb))
+        context = _collect_context()
+        _record(RECENT_ERRORS, f"{timestamp}:{exc.__name__}:{location}:{value}\n{context}\n{tb_str}")
 
-    if isinstance(value, OSError):
-        desc = f"I/O error: {value}"
-    elif isinstance(value, ValueError):
-        desc = f"Invalid value: {value}"
-    else:
-        desc = str(value)
+        if isinstance(value, OSError):
+            desc = f"I/O error: {value}"
+        elif isinstance(value, ValueError):
+            desc = f"Invalid value: {value}"
+        else:
+            desc = str(value)
 
-    msg = f"{desc} (at {location} on {timestamp})"
-    details = "\n".join([
-        f"Exception: {exc.__name__}",
-        f"Message: {value}",
-        f"Location: {location}",
-        f"Time: {timestamp}",
-        f"Context: {context}",
-        "Traceback:",
-        tb_str,
-    ])
-    _show_error_dialog(msg, details)
+        msg = f"{desc} (at {location} on {timestamp})"
+        details = "\n".join([
+            f"Exception: {exc.__name__}",
+            f"Message: {value}",
+            f"Location: {location}",
+            f"Time: {timestamp}",
+            f"Context: {context}",
+            "Traceback:",
+            tb_str,
+        ])
+        _fail_safe("show_error_dialog", _show_error_dialog, msg, details)
+
+    _fail_safe("handle_exception", _impl)
 
 
 # -------------------------------------------------------------------------------------------------

--- a/tests/test_error_handler.py
+++ b/tests/test_error_handler.py
@@ -178,3 +178,21 @@ def test_cli_trigger_error_invokes_handler():
     assert "test error from trigger_test_error" in proc.stderr
     data = json.loads(proc.stdout.strip().splitlines()[-1])
     assert data["installed"] is True
+
+
+def test_internal_failure_is_reported(monkeypatch):
+    """If ``handle_exception`` itself fails, the error is recorded and reported."""
+
+    eh.RECENT_ERRORS.clear()
+
+    def boom():
+        raise RuntimeError("inner boom")
+
+    monkeypatch.setattr(eh, "_collect_context", boom)
+
+    try:
+        raise RuntimeError("outer")
+    except RuntimeError as exc:
+        eh.handle_exception(RuntimeError, exc, None)
+
+    assert any("HandlerError" in e and "inner boom" in e for e in eh.RECENT_ERRORS)


### PR DESCRIPTION
## Summary
- add fail-safe helper to report internal error handler failures
- wrap exception handling and error dialog with new fail-safe
- test that handler records failures even if internal logic breaks

## Testing
- `pytest tests/test_error_handler.py -q`
- `python -m src.app.error_handler --trigger-error --uninstall 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68a89ccfb42083258ab487b94ddcd748