### PR TITLE
Fix force quit threading and icon handling

### DIFF
--- a/src/app/icon.py
+++ b/src/app/icon.py
@@ -36,7 +36,7 @@ def set_app_icon(window):
     temp_icon: str | None = None
     try:
         image = Image.open(icon_path)
-        photo = ImageTk.PhotoImage(image)
+        photo = ImageTk.PhotoImage(image, master=window)
         window.iconphoto(True, photo)
 
         if sys.platform.startswith("win"):

--- a/src/views/tools_view.py
+++ b/src/views/tools_view.py
@@ -603,7 +603,12 @@ class ToolsView(BaseView):
 
     def _force_quit(self) -> None:
         """Open the advanced Force Quit dialog."""
-        self.app.open_force_quit()
+        # ForceQuitDialog requires interacting with Tk, which must occur on
+        # the main thread.  The tools view launches commands in background
+        # threads via ``ThreadManager``, so schedule the dialog creation back
+        # onto the Tk event loop to avoid ``RuntimeError: main thread is not
+        # in main loop`` when the tool is launched asynchronously.
+        self.app.window.after(0, self.app.open_force_quit)
 
     def _disk_cleanup(self):
         """Remove temporary files in the system temp directory."""


### PR DESCRIPTION
## Summary
- ensure Tk PhotoImage icon is attached to the window to avoid iconphoto errors
- run Force Quit dialog on the Tk main thread
- improve error handler: safer macOS dialog quoting, resilient reinstall, temporary root cleanup, CLI simulation option

## Testing
- `pytest tests/test_error_handler.py::test_warning_and_unraisable_capture -q`
- `pytest tests/test_error_handler.py::test_error_dialog_creates_root_when_default_destroyed -q`
- `pytest tests/test_error_handler.py::test_cli_simulate_handler_failure -q`
- `pytest -x -q` *(fails: Terminated)*


------
https://chatgpt.com/codex/tasks/task_e_68a8b19fc0d88325b3a79d767df164c3