### PR TITLE
Handle Force Quit thread safety and icon initialization

### DIFF
--- a/src/app/icon.py
+++ b/src/app/icon.py
@@ -36,7 +36,7 @@ def set_app_icon(window):
     temp_icon: str | None = None
     try:
         image = Image.open(icon_path)
-        photo = ImageTk.PhotoImage(image)
+        photo = ImageTk.PhotoImage(image, master=window)
         window.iconphoto(True, photo)
 
         if sys.platform.startswith("win"):

--- a/src/views/tools_view.py
+++ b/src/views/tools_view.py
@@ -603,7 +603,11 @@ class ToolsView(BaseView):
 
     def _force_quit(self) -> None:
         """Open the advanced Force Quit dialog."""
-        self.app.open_force_quit()
+        # The Force Quit dialog manipulates Tk widgets and must run on the
+        # main thread.  ``_force_quit`` is launched in a background thread via
+        # ``ThreadManager.run_tool`` so schedule the actual dialog creation on
+        # the Tk event loop.
+        self.app.window.after(0, self.app.open_force_quit)
 
     def _disk_cleanup(self):
         """Remove temporary files in the system temp directory."""


### PR DESCRIPTION
## Summary
- avoid `pyimage1` icon errors by tying icon image to the application window
- ensure Force Quit dialog runs on the Tk main thread

## Testing
- `pytest` *(fails: SyntaxError in src/app/error_handler.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b19fc0d88325b3a79d767df164c3