### PR TITLE
Bind window to PhotoImage when setting icon

### DIFF
--- a/src/app/icon.py
+++ b/src/app/icon.py
@@ -36,7 +36,7 @@ def set_app_icon(window):
     temp_icon: str | None = None
     try:
         image = Image.open(icon_path)
-        photo = ImageTk.PhotoImage(image)
+        photo = ImageTk.PhotoImage(image, master=window)
         window.iconphoto(True, photo)
 
         if sys.platform.startswith("win"):


### PR DESCRIPTION
## Summary
- Fix window icon setup by creating the ImageTk.PhotoImage with the target window as master

## Testing
- `pytest` *(fails: SyntaxError in error_handler.py during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b524f5048325869842801dc9fda2