### PR TITLE
Run Force Quit dialog on main thread

### DIFF
--- a/src/views/tools_view.py
+++ b/src/views/tools_view.py
@@ -603,7 +603,12 @@ class ToolsView(BaseView):
 
     def _force_quit(self) -> None:
         """Open the advanced Force Quit dialog."""
-        self.app.open_force_quit()
+        # _force_quit is invoked from a background thread via
+        # ``ThreadManager.run_tool``.  Creating Tk dialogs from a non-main
+        # thread raises ``RuntimeError: main thread is not in main loop``.  Use
+        # ``after`` to marshal the call back onto the Tk main thread so the
+        # dialog can be created safely.
+        self.app.window.after(0, self.app.open_force_quit)
 
     def _disk_cleanup(self):
         """Remove temporary files in the system temp directory."""


### PR DESCRIPTION
## Summary
- schedule Force Quit dialog creation on Tk main loop

## Testing
- `pytest` *(fails: SyntaxError: f-string expression part cannot include a backslash)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b64644bc832590409a2c5e1de9a3