### PR TITLE
Ensure Force Quit dialog opens on main thread

### DIFF
--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -14,6 +14,7 @@ from typing import Dict, Optional, TYPE_CHECKING
 from pathlib import Path
 import sys
 import logging
+import threading
 from tkinter import messagebox
 
 from ..config import Config
@@ -205,6 +206,9 @@ class CoolBoxApp:
 
     def open_force_quit(self) -> None:
         """Launch the Force Quit dialog or focus the existing one."""
+        if threading.current_thread() is not threading.main_thread():
+            self.window.after(0, self.open_force_quit)
+            return
         try:
             from ..views.force_quit_dialog import ForceQuitDialog
         except Exception as exc:  # pragma: no cover - runtime import error

--- a/src/app/error_handler.py
+++ b/src/app/error_handler.py
@@ -217,8 +217,10 @@ def _native_error_dialog(title: str, body: str) -> None:
             ctypes.windll.user32.MessageBoxW(None, body, title, MB_OK | MB_SYSTEMMODAL | MB_TOPMOST | MB_ICONERROR)  # type: ignore[attr-defined]
             return
         if sys.platform == "darwin":
+            safe_body = body[:900].replace('"', '\\"')
+            script = f'display alert "{title}" message "{safe_body}" as critical'
             subprocess.run(
-                ["osascript", "-e", f'display alert "{title}" message "{body[:900].replace("\"","\\\"")}" as critical'],
+                ["osascript", "-e", script],
                 check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
             )
             return


### PR DESCRIPTION
## Summary
- marshal Force Quit dialog creation to the Tk main thread to avoid thread errors
- escape macOS native error dialog script to fix f-string parsing

## Testing
- `pytest tests/test_force_quit_error.py -q`
- `pytest -q` *(fails: terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b64644bc832590409a2c5e1de9a3