### PR TITLE
Ensure System Info dialog runs on main thread

### DIFF
--- a/src/views/tools_view.py
+++ b/src/views/tools_view.py
@@ -528,8 +528,11 @@ class ToolsView(BaseView):
     def _system_info(self):
         """Open the enhanced System Info dialog."""
         from .system_info_dialog import SystemInfoDialog
-
-        SystemInfoDialog(self.app)
+        # ``ThreadManager.run_tool`` executes tool functions in a background thread
+        # to keep the UI responsive.  Creating Tkinter widgets from a worker thread
+        # raises ``RuntimeError: main thread is not in main loop``.  Schedule the
+        # dialog creation on the Tk main thread instead so it runs safely.
+        self.app.window.after(0, lambda: SystemInfoDialog(self.app))
 
     def _process_manager(self):
         """Display a simple cross-platform process manager."""


### PR DESCRIPTION
## Summary
- schedule System Info dialog creation via `after` so it's executed on Tk main thread

## Testing
- `pytest` *(fails: SyntaxError in src/app/error_handler.py: f-string expression part cannot include a backslash)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b81fed748325b9b353212dcaec2c