### PR TITLE
Ensure tools run on Tk main thread

### DIFF
--- a/src/app/error_handler.py
+++ b/src/app/error_handler.py
@@ -217,8 +217,9 @@ def _native_error_dialog(title: str, body: str) -> None:
             ctypes.windll.user32.MessageBoxW(None, body, title, MB_OK | MB_SYSTEMMODAL | MB_TOPMOST | MB_ICONERROR)  # type: ignore[attr-defined]
             return
         if sys.platform == "darwin":
+            safe_body = body[:900].replace("\"", "\\\"")
             subprocess.run(
-                ["osascript", "-e", f'display alert "{title}" message "{body[:900].replace("\"","\\\"")}" as critical'],
+                ["osascript", "-e", f'display alert "{title}" message "{safe_body}" as critical'],
                 check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
             )
             return

--- a/src/utils/thread_manager.py
+++ b/src/utils/thread_manager.py
@@ -81,14 +81,18 @@ class ThreadManager:
         *,
         window,
         status_bar: Any | None = None,
+        use_thread: bool = True,
     ) -> None:
-        """Execute *func* in a daemon thread and surface exceptions.
+        """Execute *func* and surface exceptions.
 
-        Any raised exception is logged with a full traceback and reported via
-        ``status_bar`` and the application's global error handler.  Successful
-        completion also emits a log and optional status message.  All UI interactions are
-        marshalled back to the Tk main thread via ``window.after`` so failures
-        never crash the Home view.
+        If *use_thread* is ``True`` (the default) the function is executed in a
+        background daemon thread. When ``False`` the function is scheduled on
+        the Tk main loop using ``window.after`` so it can safely interact with
+        the UI. Any raised exception is logged with a full traceback and
+        reported via ``status_bar`` and the application's global error handler.
+        Successful completion also emits a log and optional status message.
+        All UI interactions are marshalled back to the Tk main thread via
+        ``window.after`` so failures never crash the Home view.
         """
 
         import traceback
@@ -147,7 +151,13 @@ class ThreadManager:
             duration = time.time() - start
             self.log_queue.put(f"INFO:{name} finished in {duration:.2f}s")
 
-        threading.Thread(target=runner, name=f"tool-{name}", daemon=True).start()
+        if use_thread:
+            threading.Thread(target=runner, name=f"tool-{name}", daemon=True).start()
+        else:
+            try:
+                window.after(0, runner)
+            except Exception:  # pragma: no cover - best effort
+                runner()
 
     def _logger_loop(self) -> None:
         while not self.shutdown.is_set():

--- a/src/views/tools_view.py
+++ b/src/views/tools_view.py
@@ -254,14 +254,20 @@ class ToolsView(BaseView):
             )
         )
 
-    def _safe_launch(self, name: str, func: callable) -> None:
-        """Run *func* in a background thread and surface errors gracefully."""
+    def _safe_launch(self, name: str, func: callable, *, use_thread: bool = False) -> None:
+        """Execute *func* and surface errors via the thread manager.
+
+        By default the function is scheduled on the Tk main loop to avoid
+        cross-thread UI errors.  Pass ``use_thread=True`` for long-running tasks
+        that can safely execute in a background thread.
+        """
 
         self.app.thread_manager.run_tool(
             name,
             func,
             window=self.app.window,
             status_bar=self.app.status_bar,
+            use_thread=use_thread,
         )
 
     # Tool implementations


### PR DESCRIPTION
## Summary
- Allow ThreadManager.run_tool to schedule work on the Tk main loop or a background thread
- Launch tools on the main thread by default to avoid "main thread is not in main loop" errors
- Fix macOS error dialog quoting in error_handler

## Testing
- `pytest tests/test_thread_manager.py::test_thread_manager_threads_and_communication -q`
- `pytest tests/test_tool_error_handling.py::TestToolErrorHandling::test_safe_launch_logs_errors -q` *(skipped: No display available)*
- `pytest tests/test_tool_error_handling.py::TestToolErrorHandling::test_safe_launch_logs_warnings -q` *(skipped: No display available)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b81fed748325b9b353212dcaec2c