### PR TITLE
Run tools on main thread when needed

### DIFF
--- a/src/app/error_handler.py
+++ b/src/app/error_handler.py
@@ -217,8 +217,9 @@ def _native_error_dialog(title: str, body: str) -> None:
             ctypes.windll.user32.MessageBoxW(None, body, title, MB_OK | MB_SYSTEMMODAL | MB_TOPMOST | MB_ICONERROR)  # type: ignore[attr-defined]
             return
         if sys.platform == "darwin":
+            safe_body = body[:900].replace('"', '\\"')
             subprocess.run(
-                ["osascript", "-e", f'display alert "{title}" message "{body[:900].replace("\"","\\\"")}" as critical'],
+                ["osascript", "-e", f'display alert "{title}" message "{safe_body}" as critical'],
                 check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
             )
             return

--- a/src/utils/thread_manager.py
+++ b/src/utils/thread_manager.py
@@ -60,12 +60,15 @@ class ThreadManager:
         """
         tb = exc.__traceback__
         try:
-            window.after(
-                0,
-                lambda exc=exc, tb=tb: window.report_callback_exception(
-                    type(exc), exc, tb
-                ),
-            )
+            if threading.current_thread() is threading.main_thread():
+                window.report_callback_exception(type(exc), exc, tb)
+            else:  # schedule on main thread
+                window.after(
+                    0,
+                    lambda exc=exc, tb=tb: window.report_callback_exception(
+                        type(exc), exc, tb
+                    ),
+                )
         except Exception:  # pragma: no cover - best effort
             try:
                 window.report_callback_exception(type(exc), exc, tb)
@@ -81,14 +84,31 @@ class ThreadManager:
         *,
         window,
         status_bar: Any | None = None,
+        use_thread: bool = True,
     ) -> None:
-        """Execute *func* in a daemon thread and surface exceptions.
+        """Execute *func* and surface exceptions.
+
+        Parameters
+        ----------
+        name:
+            Friendly name for logging.
+        func:
+            Callable to execute.
+        window:
+            Tk root window for scheduling callbacks.
+        status_bar:
+            Optional status bar for user facing messages.
+        use_thread:
+            When ``True`` (the default) ``func`` runs in a background daemon
+            thread.  If ``False`` the callable is executed on the Tk main
+            thread via ``window.after`` which is required for any function that
+            performs GUI operations.
 
         Any raised exception is logged with a full traceback and reported via
         ``status_bar`` and the application's global error handler.  Successful
-        completion also emits a log and optional status message.  All UI interactions are
-        marshalled back to the Tk main thread via ``window.after`` so failures
-        never crash the Home view.
+        completion also emits a log and optional status message.  All UI
+        interactions are marshalled back to the Tk main thread via
+        ``window.after`` so failures never crash the Home view.
         """
 
         import traceback
@@ -147,7 +167,10 @@ class ThreadManager:
             duration = time.time() - start
             self.log_queue.put(f"INFO:{name} finished in {duration:.2f}s")
 
-        threading.Thread(target=runner, name=f"tool-{name}", daemon=True).start()
+        if use_thread:
+            threading.Thread(target=runner, name=f"tool-{name}", daemon=True).start()
+        else:
+            window.after(0, runner)
 
     def _logger_loop(self) -> None:
         while not self.shutdown.is_set():

--- a/src/views/tools_view.py
+++ b/src/views/tools_view.py
@@ -255,13 +255,21 @@ class ToolsView(BaseView):
         )
 
     def _safe_launch(self, name: str, func: callable) -> None:
-        """Run *func* in a background thread and surface errors gracefully."""
+        """Execute *func* and surface errors gracefully.
+
+        Many tool callbacks create Tk dialogs or interact with other GUI
+        elements.  Those operations must run on the Tk main thread, so we
+        explicitly disable background threading and marshal execution through
+        ``window.after``.  The thread manager still handles logging and error
+        reporting for consistent behaviour.
+        """
 
         self.app.thread_manager.run_tool(
             name,
             func,
             window=self.app.window,
             status_bar=self.app.status_bar,
+            use_thread=False,
         )
 
     # Tool implementations


### PR DESCRIPTION
## Summary
- allow `ThreadManager.run_tool` to execute callbacks on main thread
- launch `ToolsView` actions without background thread to avoid Tk errors
- report exceptions immediately on main thread and fix macOS fallback f-string

## Testing
- `pytest -q` *(fails: process terminated after partial progress)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b81fed748325b9b353212dcaec2c