### PR TITLE
Run tools on main thread when needed

### DIFF
--- a/src/app/error_handler.py
+++ b/src/app/error_handler.py
@@ -217,8 +217,9 @@ def _native_error_dialog(title: str, body: str) -> None:
             ctypes.windll.user32.MessageBoxW(None, body, title, MB_OK | MB_SYSTEMMODAL | MB_TOPMOST | MB_ICONERROR)  # type: ignore[attr-defined]
             return
         if sys.platform == "darwin":
+            escaped = body[:900].replace('"', '\\"')
             subprocess.run(
-                ["osascript", "-e", f'display alert "{title}" message "{body[:900].replace("\"","\\\"")}" as critical'],
+                ["osascript", "-e", f'display alert "{title}" message "{escaped}" as critical'],
                 check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
             )
             return
@@ -320,7 +321,10 @@ def _ensure_hidden_root(persistent: bool) -> TkRoot | None:
     global _persistent_root
     if tk is None:
         return None
-    r = _current_root()
+    try:
+        r = _current_root()
+    except Exception:
+        r = None
     if _root_alive(r):
         return r
     try:
@@ -331,7 +335,8 @@ def _ensure_hidden_root(persistent: bool) -> TkRoot | None:
             r = tk.Tk()  # type: ignore[call-arg]
         r.withdraw()
         setattr(r, "_cbx_err_persistent", bool(persistent))
-        _persistent_root = r
+        if persistent:
+            _persistent_root = r
         try:
             tk._default_root = r  # type: ignore[attr-defined]
         except Exception:
@@ -357,18 +362,42 @@ def _show_error_dialog(message: str, details: str) -> None:
         logger.error("Unhandled exception: %s\n%s\nUI diagnostics: %s", message, details, diag)
         return
 
-    if not _should_popup(f"E:{message.splitlines()[0][:200]}"):
-        logger.error("Suppressed popup: %s\n%s", message, details)
-        return
-
-    root = _current_root()
-    if not _root_alive(root):
-        root = _ensure_hidden_root(persistent=_want_persistent_root)
-    if not _root_alive(root):
-        title = "Unexpected Error"; body = f"{message}\n\n{details[:2000]}"
-        _native_error_dialog(title, body); _spawn_popup_subprocess(title, body); return
-
+    root_error: BaseException | None = None
     try:
+        root = _current_root()
+    except Exception as exc:
+        root = None
+        root_error = exc
+    temp_root = False
+    if not _root_alive(root):
+        try:
+            root = _ensure_hidden_root(persistent=False)
+        except Exception as exc:
+            root_error = exc if root_error is None else root_error
+            root = None
+        temp_root = _root_alive(root)
+    try:
+        if not _root_alive(root):
+            if root_error is not None:
+                try:
+                    tb = "".join(
+                        traceback.format_exception(
+                            type(root_error), root_error, root_error.__traceback__
+                        )
+                    )
+                    _record(
+                        RECENT_ERRORS,
+                        f"{datetime.now().isoformat()}:DialogError:show_error_dialog:{root_error}\n{tb}",
+                    )
+                except Exception:
+                    logger.debug("Failed to record dialog error", exc_info=True)
+            title = "Unexpected Error"; body = f"{message}\n\n{details[:2000]}"
+            _native_error_dialog(title, body); _spawn_popup_subprocess(title, body); return
+
+        if not _should_popup(f"E:{message.splitlines()[0][:200]}"):
+            logger.error("Suppressed popup: %s\n%s", message, details)
+            return
+
         # Prefer modern dialog
         try:
             import customtkinter as ctk  # type: ignore
@@ -413,6 +442,12 @@ def _show_error_dialog(message: str, details: str) -> None:
             logger.debug("Failed to record dialog error", exc_info=True)
         title = "Unexpected Error"; body = f"{message}\n\n{details[:2000]}"
         _native_error_dialog(title, body); _spawn_popup_subprocess(title, body)
+    finally:
+        if temp_root and _root_alive(root):
+            try:
+                root.destroy()
+            except Exception:
+                pass
 
 # -------------------------------------------------------------------------------------------------
 # exception handling
@@ -630,9 +665,16 @@ def install(window: TkRoot | None = None, *, warn_popups: Optional[bool] = None,
         _want_persistent_root = bool(ensure_root)
 
         if _installed:
+            # Re-apply hooks so external configuration (e.g. logging.captureWarnings)
+            # does not permanently stomp our warnings handler.
+            _apply_hooks()
             if tk is not None and window is not None:
-                try: window.report_callback_exception = handle_exception  # type: ignore[attr-defined]
-                except Exception: logger.debug("Failed to hook report_callback_exception", exc_info=True)
+                try:
+                    window.report_callback_exception = handle_exception  # type: ignore[attr-defined]
+                except Exception:
+                    logger.debug(
+                        "Failed to hook report_callback_exception", exc_info=True
+                    )
                 _start_ui_pump(window)
             return
 
@@ -733,6 +775,11 @@ def _cli(argv: list[str] | None = None) -> int:
     parser.add_argument("--force-dialog", action="store_true", help="Show a forced dialog now")
     parser.add_argument("--diagnose-ui", action="store_true", help="Include GUI diagnostics")
     parser.add_argument("--ensure-root", action="store_true", help="Create hidden root if none exists")
+    parser.add_argument(
+        "--simulate-handler-failure",
+        action="store_true",
+        help="Trigger a failure inside the error handler",
+    )
     parser.add_argument("--uninstall", action="store_true", help="Uninstall before exiting")
     args = parser.parse_args(argv)
 
@@ -740,6 +787,12 @@ def _cli(argv: list[str] | None = None) -> int:
 
     if args.force_dialog:
         force_test_dialog("CLI forced dialog")
+
+    if args.simulate_handler_failure:
+        def _fail(exc, value, tb):  # pragma: no cover - testing path
+            raise RuntimeError("simulated failure")
+
+        globals()["handle_exception"] = _fail  # type: ignore[assignment]
 
     if args.trigger_error:
         with error_boundary():

--- a/src/utils/thread_manager.py
+++ b/src/utils/thread_manager.py
@@ -50,29 +50,33 @@ class ThreadManager:
             t.join(timeout=1)
 
     def post_exception(self, window, exc: BaseException) -> None:
-        """Report *exc* on the Tk main thread using ``window.after``.
+        """Report *exc* via ``window.report_callback_exception``.
 
-        The window's ``report_callback_exception`` hook is invoked so all
-        dialogs and logging are handled by the global error handler.
-        If the window no longer exists or cannot schedule the callback,
-        fall back to invoking the handler directly so errors are still
-        surfaced.
+        When called from a background thread the exception is marshalled
+        onto the Tk main loop using ``window.after``.  If already on the
+        main thread (such as when ``run_tool`` executes synchronously) the
+        handler is invoked immediately so tests that do not drive the Tk
+        event loop still surface failures.  Any scheduling or reporting
+        errors fall back to a best-effort direct invocation and emit a debug
+        log if that too fails.
         """
         tb = exc.__traceback__
-        try:
-            window.after(
-                0,
-                lambda exc=exc, tb=tb: window.report_callback_exception(
-                    type(exc), exc, tb
-                ),
-            )
-        except Exception:  # pragma: no cover - best effort
+
+        def _report() -> None:
             try:
                 window.report_callback_exception(type(exc), exc, tb)
             except Exception:
                 logging.getLogger(__name__).debug(
                     "failed to report exception", exc_info=True
                 )
+
+        if threading.current_thread() is threading.main_thread():
+            _report()
+            return
+        try:
+            window.after(0, _report)
+        except Exception:  # pragma: no cover - best effort
+            _report()
 
     def run_tool(
         self,
@@ -81,14 +85,31 @@ class ThreadManager:
         *,
         window,
         status_bar: Any | None = None,
+        use_thread: bool = True,
     ) -> None:
-        """Execute *func* in a daemon thread and surface exceptions.
+        """Execute *func* and surface exceptions.
+
+        Parameters
+        ----------
+        name:
+            Friendly name for logging.
+        func:
+            Callable to execute.
+        window:
+            Tk root window for scheduling callbacks.
+        status_bar:
+            Optional status bar for user facing messages.
+        use_thread:
+            When ``True`` (the default) ``func`` runs in a background daemon
+            thread.  If ``False`` the callable is executed on the Tk main
+            thread via ``window.after`` which is required for any function that
+            performs GUI operations.
 
         Any raised exception is logged with a full traceback and reported via
         ``status_bar`` and the application's global error handler.  Successful
-        completion also emits a log and optional status message.  All UI interactions are
-        marshalled back to the Tk main thread via ``window.after`` so failures
-        never crash the Home view.
+        completion also emits a log and optional status message.  All UI
+        interactions are marshalled back to the Tk main thread via
+        ``window.after`` so failures never crash the Home view.
         """
 
         import traceback
@@ -147,7 +168,10 @@ class ThreadManager:
             duration = time.time() - start
             self.log_queue.put(f"INFO:{name} finished in {duration:.2f}s")
 
-        threading.Thread(target=runner, name=f"tool-{name}", daemon=True).start()
+        if use_thread:
+            threading.Thread(target=runner, name=f"tool-{name}", daemon=True).start()
+        else:
+            window.after(0, runner)
 
     def _logger_loop(self) -> None:
         while not self.shutdown.is_set():

--- a/src/views/tools_view.py
+++ b/src/views/tools_view.py
@@ -255,13 +255,21 @@ class ToolsView(BaseView):
         )
 
     def _safe_launch(self, name: str, func: callable) -> None:
-        """Run *func* in a background thread and surface errors gracefully."""
+        """Execute *func* and surface errors gracefully.
+
+        Many tool callbacks create Tk dialogs or interact with other GUI
+        elements.  Those operations must run on the Tk main thread, so we
+        explicitly disable background threading and marshal execution through
+        ``window.after``.  The thread manager still handles logging and error
+        reporting for consistent behaviour.
+        """
 
         self.app.thread_manager.run_tool(
             name,
             func,
             window=self.app.window,
             status_bar=self.app.status_bar,
+            use_thread=False,
         )
 
     # Tool implementations


### PR DESCRIPTION
## Summary
- allow ThreadManager.run_tool to execute callbacks on main thread
- launch ToolsView actions without background thread to avoid Tk errors
- fix error handler escaping and ensure dialogs still record failures
- reapply warning hooks and add CLI flag to simulate handler failure

## Testing
- `pytest tests/test_error_handler.py tests/test_security_error_logging.py -q`
- `pytest -q` *(terminated at ~38%)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b81fed748325b9b353212dcaec2c