### PR TITLE
Run tools on main thread when needed

### DIFF
--- a/src/app/error_handler.py
+++ b/src/app/error_handler.py
@@ -217,9 +217,10 @@ def _native_error_dialog(title: str, body: str) -> None:
             ctypes.windll.user32.MessageBoxW(None, body, title, MB_OK | MB_SYSTEMMODAL | MB_TOPMOST | MB_ICONERROR)  # type: ignore[attr-defined]
             return
         if sys.platform == "darwin":
+            escaped = body[:900].replace('"', '\\"')
             subprocess.run(
-                ["osascript", "-e", f'display alert "{title}" message "{body[:900].replace("\"","\\\"")}" as critical'],
-                check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+                ["osascript", "-e", f'display alert "{title}" message "{escaped}" as critical'],
+                check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
             )
             return
         for cmd in (["zenity", "--error", "--no-wrap", "--title", title, "--text", body[:2000]],

--- a/src/views/tools_view.py
+++ b/src/views/tools_view.py
@@ -255,13 +255,21 @@ class ToolsView(BaseView):
         )
 
     def _safe_launch(self, name: str, func: callable) -> None:
-        """Run *func* in a background thread and surface errors gracefully."""
+        """Execute *func* and surface errors gracefully.
+
+        Many tool callbacks create Tk dialogs or interact with other GUI
+        elements.  Those operations must run on the Tk main thread, so we
+        explicitly disable background threading and marshal execution through
+        ``window.after``.  The thread manager still handles logging and error
+        reporting for consistent behaviour.
+        """
 
         self.app.thread_manager.run_tool(
             name,
             func,
             window=self.app.window,
             status_bar=self.app.status_bar,
+            use_thread=False,
         )
 
     # Tool implementations


### PR DESCRIPTION
## Summary
- allow ThreadManager.run_tool to execute callbacks on main thread
- launch ToolsView actions without background thread to avoid Tk errors
- invoke Tk error handler directly when already on main thread
- escape AppleScript command to avoid f-string syntax error on macOS

## Testing
- `pytest -q` *(terminates after multiple failures)*
- `pytest tests/test_error_handler.py -q` *(fails: recent warnings not recorded, dialog root not destroyed, dialog failure not recorded, CLI option error)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b81fed748325b9b353212dcaec2c