### PR TITLE
Run tools on main thread when needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- **Fix:** Retry tools on the UI thread when background execution raises
+  "main thread is not in main loop" so dialogs launch reliably.
+- **Fix:** Always create the Force Quit dialog on the main Tk loop to avoid
+  "main thread is not in main loop" warnings.
+
 ## 1.3.76 - 2025-08-08
 
 - **Fix:** Ensure Kill by Click overlay closes when no process is selected to prevent UI lockups.

--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -14,6 +14,7 @@ from typing import Dict, Optional, TYPE_CHECKING
 from pathlib import Path
 import sys
 import logging
+import threading
 from tkinter import messagebox
 
 from ..config import Config
@@ -205,6 +206,10 @@ class CoolBoxApp:
 
     def open_force_quit(self) -> None:
         """Launch the Force Quit dialog or focus the existing one."""
+        if threading.current_thread() is not threading.main_thread():
+            self.window.after(0, self.open_force_quit)
+            return
+
         try:
             from ..views.force_quit_dialog import ForceQuitDialog
         except Exception as exc:  # pragma: no cover - runtime import error

--- a/src/app/error_handler.py
+++ b/src/app/error_handler.py
@@ -217,9 +217,10 @@ def _native_error_dialog(title: str, body: str) -> None:
             ctypes.windll.user32.MessageBoxW(None, body, title, MB_OK | MB_SYSTEMMODAL | MB_TOPMOST | MB_ICONERROR)  # type: ignore[attr-defined]
             return
         if sys.platform == "darwin":
+            safe_body = body[:900].replace('"', '\\"')
             subprocess.run(
-                ["osascript", "-e", f'display alert "{title}" message "{body[:900].replace("\"","\\\"")}" as critical'],
-                check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+                ["osascript", "-e", f'display alert "{title}" message "{safe_body}" as critical'],
+                check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
             )
             return
         for cmd in (["zenity", "--error", "--no-wrap", "--title", title, "--text", body[:2000]],

--- a/src/utils/thread_manager.py
+++ b/src/utils/thread_manager.py
@@ -50,15 +50,23 @@ class ThreadManager:
             t.join(timeout=1)
 
     def post_exception(self, window, exc: BaseException) -> None:
-        """Report *exc* on the Tk main thread using ``window.after``.
+        """Report *exc* via the window's ``report_callback_exception`` hook.
 
-        The window's ``report_callback_exception`` hook is invoked so all
-        dialogs and logging are handled by the global error handler.
-        If the window no longer exists or cannot schedule the callback,
-        fall back to invoking the handler directly so errors are still
-        surfaced.
+        If called from a background thread the exception is marshalled to the
+        Tk main loop using ``window.after``.  When already on the main thread we
+        invoke the handler directly so errors are surfaced immediately.  Any
+        failure to schedule the callback falls back to a direct invocation to
+        ensure the error handler still sees the exception.
         """
         tb = exc.__traceback__
+        if threading.current_thread() is threading.main_thread():
+            try:
+                window.report_callback_exception(type(exc), exc, tb)
+            except Exception:
+                logging.getLogger(__name__).debug(
+                    "failed to report exception", exc_info=True
+                )
+            return
         try:
             window.after(
                 0,
@@ -81,14 +89,33 @@ class ThreadManager:
         *,
         window,
         status_bar: Any | None = None,
+        use_thread: bool = True,
     ) -> None:
-        """Execute *func* in a daemon thread and surface exceptions.
+        """Execute *func* and surface exceptions.
+
+        Parameters
+        ----------
+        name:
+            Friendly name for logging.
+        func:
+            Callable to execute.
+        window:
+            Tk root window for scheduling callbacks.
+        status_bar:
+            Optional status bar for user facing messages.
+        use_thread:
+            When ``True`` (the default) ``func`` runs in a background daemon
+            thread.  If ``False`` the callable is executed on the Tk main
+            thread via ``window.after`` which is required for any function that
+            performs GUI operations.  When running in a background thread and a
+            ``RuntimeError`` indicates the Tk main loop is required, the
+            manager automatically retries on the main thread.
 
         Any raised exception is logged with a full traceback and reported via
         ``status_bar`` and the application's global error handler.  Successful
-        completion also emits a log and optional status message.  All UI interactions are
-        marshalled back to the Tk main thread via ``window.after`` so failures
-        never crash the Home view.
+        completion also emits a log and optional status message.  All UI
+        interactions are marshalled back to the Tk main thread via
+        ``window.after`` so failures never crash the Home view.
         """
 
         import traceback
@@ -102,6 +129,25 @@ class ThreadManager:
                 try:
                     func()
                 except Exception as exc:  # pragma: no cover - best effort
+                    if (
+                        use_thread
+                        and isinstance(exc, RuntimeError)
+                        and "main thread is not in main loop" in str(exc)
+                    ):
+                        self.log_queue.put(
+                            f"WARNING:{name} requires Tk main loop; retrying on main thread"
+                        )
+                        window.after(
+                            0,
+                            lambda: self.run_tool(
+                                name,
+                                func,
+                                window=window,
+                                status_bar=status_bar,
+                                use_thread=False,
+                            ),
+                        )
+                        return
                     msg = f"{name} failed: {exc}"
                     self.log_queue.put(f"ERROR:{msg}")
                     for line in traceback.format_exc().splitlines():
@@ -147,7 +193,10 @@ class ThreadManager:
             duration = time.time() - start
             self.log_queue.put(f"INFO:{name} finished in {duration:.2f}s")
 
-        threading.Thread(target=runner, name=f"tool-{name}", daemon=True).start()
+        if use_thread:
+            threading.Thread(target=runner, name=f"tool-{name}", daemon=True).start()
+        else:
+            window.after(0, runner)
 
     def _logger_loop(self) -> None:
         while not self.shutdown.is_set():

--- a/src/views/tools_view.py
+++ b/src/views/tools_view.py
@@ -255,7 +255,12 @@ class ToolsView(BaseView):
         )
 
     def _safe_launch(self, name: str, func: callable) -> None:
-        """Run *func* in a background thread and surface errors gracefully."""
+        """Execute *func* in the thread manager with error handling.
+
+        Tools run in a background thread by default.  If a callback requires
+        Tk's main loop (for example when creating dialogs) the thread manager
+        automatically retries the command on the UI thread.
+        """
 
         self.app.thread_manager.run_tool(
             name,


### PR DESCRIPTION
## Summary
- Retry tool callbacks on the UI thread when background execution hits "main thread is not in main loop"
- Launch tools via ThreadManager with automatic main-thread fallback
- Create Force Quit dialog from the Tk main loop to avoid "main thread is not in main loop" warnings

## Testing
- `python -m py_compile src/app/__init__.py src/app/error_handler.py src/utils/thread_manager.py src/views/tools_view.py`
- `pytest -q` *(terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b81fed748325b9b353212dcaec2c