### PR TITLE
Run tools on main thread when needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- **Fix:** Retry tools on the UI thread when background execution raises
+  "main thread is not in main loop" so dialogs launch reliably.
+- **Fix:** Force Quit dialog executes on the UI thread, avoiding "main thread is
+  not in main loop" warnings.
+
 ## 1.3.76 - 2025-08-08
 
 - **Fix:** Ensure Kill by Click overlay closes when no process is selected to prevent UI lockups.

--- a/src/app/error_handler.py
+++ b/src/app/error_handler.py
@@ -217,9 +217,10 @@ def _native_error_dialog(title: str, body: str) -> None:
             ctypes.windll.user32.MessageBoxW(None, body, title, MB_OK | MB_SYSTEMMODAL | MB_TOPMOST | MB_ICONERROR)  # type: ignore[attr-defined]
             return
         if sys.platform == "darwin":
+            safe_body = body[:900].replace('"', '\\"')
             subprocess.run(
-                ["osascript", "-e", f'display alert "{title}" message "{body[:900].replace("\"","\\\"")}" as critical'],
-                check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+                ["osascript", "-e", f'display alert "{title}" message "{safe_body}" as critical'],
+                check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
             )
             return
         for cmd in (["zenity", "--error", "--no-wrap", "--title", title, "--text", body[:2000]],

--- a/src/utils/thread_manager.py
+++ b/src/utils/thread_manager.py
@@ -50,15 +50,23 @@ class ThreadManager:
             t.join(timeout=1)
 
     def post_exception(self, window, exc: BaseException) -> None:
-        """Report *exc* on the Tk main thread using ``window.after``.
+        """Report *exc* via the window's ``report_callback_exception`` hook.
 
-        The window's ``report_callback_exception`` hook is invoked so all
-        dialogs and logging are handled by the global error handler.
-        If the window no longer exists or cannot schedule the callback,
-        fall back to invoking the handler directly so errors are still
-        surfaced.
+        If called from a background thread the exception is marshalled to the
+        Tk main loop using ``window.after``.  When already on the main thread we
+        invoke the handler directly so errors are surfaced immediately.  Any
+        failure to schedule the callback falls back to a direct invocation to
+        ensure the error handler still sees the exception.
         """
         tb = exc.__traceback__
+        if threading.current_thread() is threading.main_thread():
+            try:
+                window.report_callback_exception(type(exc), exc, tb)
+            except Exception:
+                logging.getLogger(__name__).debug(
+                    "failed to report exception", exc_info=True
+                )
+            return
         try:
             window.after(
                 0,
@@ -81,14 +89,33 @@ class ThreadManager:
         *,
         window,
         status_bar: Any | None = None,
+        use_thread: bool = True,
     ) -> None:
-        """Execute *func* in a daemon thread and surface exceptions.
+        """Execute *func* and surface exceptions.
+
+        Parameters
+        ----------
+        name:
+            Friendly name for logging.
+        func:
+            Callable to execute.
+        window:
+            Tk root window for scheduling callbacks.
+        status_bar:
+            Optional status bar for user facing messages.
+        use_thread:
+            When ``True`` (the default) ``func`` runs in a background daemon
+            thread.  If ``False`` the callable is executed on the Tk main
+            thread via ``window.after`` which is required for any function that
+            performs GUI operations.  When running in a background thread and a
+            ``RuntimeError`` indicates the Tk main loop is required, the
+            manager automatically retries on the main thread.
 
         Any raised exception is logged with a full traceback and reported via
         ``status_bar`` and the application's global error handler.  Successful
-        completion also emits a log and optional status message.  All UI interactions are
-        marshalled back to the Tk main thread via ``window.after`` so failures
-        never crash the Home view.
+        completion also emits a log and optional status message.  All UI
+        interactions are marshalled back to the Tk main thread via
+        ``window.after`` so failures never crash the Home view.
         """
 
         import traceback
@@ -102,6 +129,25 @@ class ThreadManager:
                 try:
                     func()
                 except Exception as exc:  # pragma: no cover - best effort
+                    if (
+                        use_thread
+                        and isinstance(exc, RuntimeError)
+                        and "main thread is not in main loop" in str(exc)
+                    ):
+                        self.log_queue.put(
+                            f"WARNING:{name} requires Tk main loop; retrying on main thread"
+                        )
+                        window.after(
+                            0,
+                            lambda: self.run_tool(
+                                name,
+                                func,
+                                window=window,
+                                status_bar=status_bar,
+                                use_thread=False,
+                            ),
+                        )
+                        return
                     msg = f"{name} failed: {exc}"
                     self.log_queue.put(f"ERROR:{msg}")
                     for line in traceback.format_exc().splitlines():
@@ -147,7 +193,10 @@ class ThreadManager:
             duration = time.time() - start
             self.log_queue.put(f"INFO:{name} finished in {duration:.2f}s")
 
-        threading.Thread(target=runner, name=f"tool-{name}", daemon=True).start()
+        if use_thread:
+            threading.Thread(target=runner, name=f"tool-{name}", daemon=True).start()
+        else:
+            window.after(0, runner)
 
     def _logger_loop(self) -> None:
         while not self.shutdown.is_set():

--- a/src/views/tools_view.py
+++ b/src/views/tools_view.py
@@ -140,35 +140,54 @@ class ToolsView(BaseView):
         )
 
         tools = [
-            ("System Info", "View system information", self._system_info),
-            ("Process Manager", "Manage running processes", self._process_manager),
-            ("Force Quit", "Forcefully terminate a process", self._force_quit),
-            ("Disk Cleanup", "Clean temporary files", self._disk_cleanup),
+            ("System Info", "View system information", self._system_info, True),
+            (
+                "Process Manager",
+                "Manage running processes",
+                self._process_manager,
+                True,
+            ),
+            (
+                "Force Quit",
+                "Forcefully terminate a process",
+                self._force_quit,
+                False,
+            ),
+            ("Disk Cleanup", "Clean temporary files", self._disk_cleanup, True),
             (
                 "Screenshot",
                 "Capture screen to an image file",
                 self._screenshot_tool,
+                True,
             ),
-            ("Registry Editor", "Edit system registry (Windows)", self._registry_editor),
+            (
+                "Registry Editor",
+                "Edit system registry (Windows)",
+                self._registry_editor,
+                True,
+            ),
             (
                 "Launch VM Debug",
                 "Run CoolBox in a VM and wait for debugger",
                 self._launch_vm_debug,
+                True,
             ),
             (
                 "Executable Inspector",
                 "Inspect an executable file",
                 self._exe_inspector,
+                True,
             ),
             (
                 "Security Center",
                 "Toggle Firewall and Defender",
                 self._security_center,
+                True,
             ),
         ]
 
-        for name, desc, func in tools:
-            self._create_tool_item(body, name, desc, func)
+        for name, desc, func, threaded in tools:
+            self._create_tool_item(body, name, desc, func, use_thread=threaded)
 
     def _create_text_tools(self):
         """Create text manipulation tools"""
@@ -208,7 +227,15 @@ class ToolsView(BaseView):
         for name, desc, func in tools:
             self._create_tool_item(body, name, desc, func)
 
-    def _create_tool_item(self, parent, name: str, description: str, command):
+    def _create_tool_item(
+        self,
+        parent,
+        name: str,
+        description: str,
+        command,
+        *,
+        use_thread: bool = True,
+    ) -> None:
         """Create a tool item"""
         # Tool frame
         tool_frame = ctk.CTkFrame(parent)
@@ -234,7 +261,9 @@ class ToolsView(BaseView):
         button = self.grid_button(
             tool_frame,
             "Launch",
-            lambda cmd=command, name=name: self._safe_launch(name, cmd),
+            lambda cmd=command, name=name, ut=use_thread: self._safe_launch(
+                name, cmd, use_thread=ut
+            ),
             0,
             column=1,
             columnspan=1,
@@ -254,14 +283,22 @@ class ToolsView(BaseView):
             )
         )
 
-    def _safe_launch(self, name: str, func: callable) -> None:
-        """Run *func* in a background thread and surface errors gracefully."""
+    def _safe_launch(
+        self, name: str, func: callable, *, use_thread: bool = True
+    ) -> None:
+        """Execute *func* in the thread manager with error handling.
+
+        Tools run in a background thread by default.  If a callback requires
+        Tk's main loop (for example when creating dialogs) the thread manager
+        automatically retries the command on the UI thread.
+        """
 
         self.app.thread_manager.run_tool(
             name,
             func,
             window=self.app.window,
             status_bar=self.app.status_bar,
+            use_thread=use_thread,
         )
 
     # Tool implementations


### PR DESCRIPTION
## Summary
- Retry tool callbacks on the UI thread when background execution raises "main thread is not in main loop"
- Launch tools via ThreadManager with automatic main-thread fallback
- Document main-thread retry behavior in changelog
- Force Quit dialog runs on the UI thread to avoid main-loop warnings

## Testing
- `python -m py_compile src/utils/thread_manager.py src/views/tools_view.py src/app/error_handler.py`
- `pytest -q` *(terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b81fed748325b9b353212dcaec2c